### PR TITLE
Removed extra hover in translate-x

### DIFF
--- a/website/src/components/navbar/index.tsx
+++ b/website/src/components/navbar/index.tsx
@@ -114,7 +114,7 @@ export default function Navbar() {
 
             {/* Stargazer Avatars Container - Only show on non-mobile */}
             {!isMobile && (
-              <div className="absolute left-0 top-1/2 -translate-x-full -translate-y-1/2 flex items-center opacity-0 group-hover:opacity-100 group-hover:hover:translate-x-[-80%] transition-all duration-300 pointer-events-none">
+              <div className="absolute left-0 top-1/2 -translate-x-full -translate-y-1/2 flex items-center opacity-0 group-hover:opacity-100 group-hover:translate-x-[-80%] transition-all duration-300 pointer-events-none">
                 {/* Display only if not loading, no error, and stargazers exist */}
                 {!isLoadingStars &&
                   !starsError &&


### PR DESCRIPTION
This PR removes an unnecessary `hover` modifier from the `group-hover:translate-x-[-80%]` class. The `hover` was redundant as `group-hover` already triggers the effect when the parent group is hovered.