### PR TITLE
chore(core): use latest hono to avoid duplicate dependencies

### DIFF
--- a/.changeset/chore-core-dedupe.md
+++ b/.changeset/chore-core-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Use the latest Hono to avoid duplicate dependencies

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "^1.10.1",
     "@n8n/json-schema-to-zod": "^1.1.0",
     "@types/ws": "^8.18.1",
-    "hono": "^3.12.6",
+    "hono": "^4.7.7",
     "npm-check-updates": "^17.1.18",
     "uuid": "^9.0.1",
     "ws": "^8.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,10 +652,10 @@ importers:
         version: 1.0.1
       '@hono/node-server':
         specifier: ^1.14.0
-        version: 1.14.0(hono@3.12.12)
+        version: 1.14.0(hono@4.7.7)
       '@hono/node-ws':
         specifier: ^1.1.1
-        version: 1.1.1(@hono/node-server@1.14.0)(hono@3.12.12)
+        version: 1.1.1(@hono/node-server@1.14.0)(hono@4.7.7)
       '@libsql/client':
         specifier: ^0.15.0
         version: 0.15.0
@@ -669,8 +669,8 @@ importers:
         specifier: ^8.18.1
         version: 8.18.1
       hono:
-        specifier: ^3.12.6
-        version: 3.12.12
+        specifier: ^4.7.7
+        version: 4.7.7
       npm-check-updates:
         specifier: ^17.1.18
         version: 17.1.18
@@ -2417,24 +2417,24 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@hono/node-server@1.14.0(hono@3.12.12):
+  /@hono/node-server@1.14.0(hono@4.7.7):
     resolution: {integrity: sha512-YUCxJwgHRKSqjrdTk9e4VMGKN27MK5r4+MGPyZTgKH+IYbK+KtYbHeOcPGJ91KGGD6RIQiz2dAHxvjauNhOS8g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
     dependencies:
-      hono: 3.12.12
+      hono: 4.7.7
     dev: false
 
-  /@hono/node-ws@1.1.1(@hono/node-server@1.14.0)(hono@3.12.12):
+  /@hono/node-ws@1.1.1(@hono/node-server@1.14.0)(hono@4.7.7):
     resolution: {integrity: sha512-iFJrAw5GuBTstehBzLY2FyW5rRlXmO3Uwpijpm4Liv75owNP/UjZe3KExsLuEK4w+u+xhvHqOoQUyEKWUvyghw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       '@hono/node-server': ^1.11.1
       hono: ^4.6.0
     dependencies:
-      '@hono/node-server': 1.14.0(hono@3.12.12)
-      hono: 3.12.12
+      '@hono/node-server': 1.14.0(hono@4.7.7)
+      hono: 4.7.7
       ws: 8.18.1
     transitivePeerDependencies:
       - bufferutil
@@ -7230,9 +7230,9 @@ packages:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
     dev: true
 
-  /hono@3.12.12:
-    resolution: {integrity: sha512-5IAMJOXfpA5nT+K0MNjClchzz0IhBHs2Szl7WFAhrFOsbtQsYmNynFyJRg/a3IPsmCfxcrf8txUGiNShXpK5Rg==}
-    engines: {node: '>=16.0.0'}
+  /hono@4.7.7:
+    resolution: {integrity: sha512-2PCpQRbN87Crty8/L/7akZN3UyZIAopSoRxCwRbJgUuV1+MHNFHzYFxZTg4v/03cXUm+jce/qa2VSBZpKBm3Qw==}
+    engines: {node: '>=16.9.0'}
     dev: false
 
   /hosted-git-info@2.8.9:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Currently, there is a dependency on the latest `@hono/node-server`, `@hono/node-ws` and the old `hono@3`, the first two of which depend on the latest hono, resulting in an unnecessary increase in size.

## What is the new behavior?

Updating Hono to the latest version will no longer have two Hono installations.

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
