### PR TITLE
feat: integrate OpenAPI documentation and enhance API routes

### DIFF
--- a/.changeset/twelve-lies-fold.md
+++ b/.changeset/twelve-lies-fold.md
@@ -2,7 +2,7 @@
 "@voltagent/core": patch
 ---
 
-feat: Add OpenAPI (Swagger) Documentation for Core API - # 64
+feat: Add OpenAPI (Swagger) Documentation for Core API - #64
 
 - Integrated `@hono/zod-openapi` and `@hono/swagger-ui` to provide interactive API documentation.
 - Documented the following core endpoints with request/response schemas, parameters, and examples:

--- a/.changeset/twelve-lies-fold.md
+++ b/.changeset/twelve-lies-fold.md
@@ -1,0 +1,20 @@
+---
+"@voltagent/core": patch
+---
+
+feat: Add OpenAPI (Swagger) Documentation for Core API - # 64
+
+- Integrated `@hono/zod-openapi` and `@hono/swagger-ui` to provide interactive API documentation.
+- Documented the following core endpoints with request/response schemas, parameters, and examples:
+  - `GET /agents`: List all registered agents.
+  - `POST /agents/{id}/text`: Generate text response.
+  - `POST /agents/{id}/stream`: Stream text response (SSE).
+  - `POST /agents/{id}/object`: Generate object response (Note: Requires backend update to fully support JSON Schema input).
+  - `POST /agents/{id}/stream-object`: Stream object response (SSE) (Note: Requires backend update to fully support JSON Schema input).
+- Added `/doc` endpoint serving the OpenAPI 3.1 specification in JSON format.
+- Added `/ui` endpoint serving the interactive Swagger UI.
+- Improved API discoverability:
+  - Added links to Swagger UI and OpenAPI Spec on the root (`/`) endpoint.
+  - Added links to Swagger UI and OpenAPI Spec in the server startup console logs.
+- Refactored API schemas and route definitions into `api.routes.ts` for better organization.
+- Standardized generation options (like `userId`, `temperature`, `maxTokens`) in the API schema with descriptions, examples, and sensible defaults.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,9 +13,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
@@ -24,9 +22,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@dmitryrechkin/json-schema-to-zod": "^1.0.1",
     "@hono/node-server": "^1.14.0",
     "@hono/node-ws": "^1.1.1",
+    "@hono/swagger-ui": "^0.5.1",
+    "@hono/zod-openapi": "^0.19.6",
     "@libsql/client": "^0.15.0",
     "@modelcontextprotocol/sdk": "^1.10.1",
     "@n8n/json-schema-to-zod": "^1.1.0",

--- a/packages/core/src/server/api.routes.ts
+++ b/packages/core/src/server/api.routes.ts
@@ -1,0 +1,401 @@
+import { z } from "zod";
+import { createRoute } from "@hono/zod-openapi";
+import type { AgentStatus } from "../agent/types"; // Import AgentStatus if needed for schemas
+
+// --- Schemas ---
+
+// Common Parameter Schema
+export const ParamsSchema = z.object({
+  id: z.string().openapi({
+    param: { name: "id", in: "path" },
+    description: "The ID of the agent",
+    example: "my-agent-123",
+  }),
+});
+
+// Common Error Response Schema
+export const ErrorSchema = z.object({
+  success: z.literal(false),
+  error: z.string().openapi({ description: "Error message" }),
+});
+
+// SubAgent Response Schema (simplified)
+export const SubAgentResponseSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    status: z.string().openapi({ description: "Current status of the sub-agent" }), // Keeping string for now
+    model: z.string(),
+    tools: z.array(z.any()).optional(),
+    memory: z.any().optional(),
+  })
+  .passthrough();
+
+// Agent Response Schema (updated to use SubAgentResponseSchema)
+export const AgentResponseSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    status: z.string().openapi({ description: "Current status of the agent" }), // Reverted to z.string()
+    model: z.string(),
+    tools: z.array(z.any()), // Simplified tool representation
+    subAgents: z
+      .array(SubAgentResponseSchema)
+      .optional()
+      .openapi({ description: "List of sub-agents" }), // Use SubAgent schema
+    memory: z.any().optional(), // Simplified memory representation
+    // Add other fields from getFullState if necessary and want them documented
+  })
+  .passthrough();
+
+// Schema for common generation options passed in the request body
+export const GenerateOptionsSchema = z
+  .object({
+    userId: z.string().optional().openapi({ description: "Optional user ID for context tracking" }),
+    conversationId: z
+      .string()
+      .optional()
+      .openapi({ description: "Optional conversation ID for context tracking" }),
+    contextLimit: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(10)
+      .openapi({ description: "Optional limit for conversation history context" }),
+    temperature: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .default(0.7)
+      .openapi({ description: "Controls randomness (0-1)" }),
+    maxTokens: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(1024)
+      .openapi({ description: "Maximum tokens to generate" }),
+    topP: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .default(1.0)
+      .openapi({ description: "Controls diversity via nucleus sampling (0-1)" }),
+    frequencyPenalty: z
+      .number()
+      .min(0)
+      .max(2)
+      .optional()
+      .default(0.0)
+      .openapi({ description: "Penalizes repeated tokens (0-2)" }),
+    presencePenalty: z
+      .number()
+      .min(0)
+      .max(2)
+      .optional()
+      .default(0.0)
+      .openapi({ description: "Penalizes tokens based on presence (0-2)" }),
+    seed: z
+      .number()
+      .int()
+      .optional()
+      .openapi({ description: "Optional seed for reproducible results" }),
+    stopSequences: z
+      .array(z.string())
+      .optional()
+      .openapi({ description: "Stop sequences to end generation" }),
+    extraOptions: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .openapi({ description: "Provider-specific options" }),
+    // Add other relevant options from PublicGenerateOptions if known/needed for API exposure
+  })
+  .passthrough(); // Allow other provider-specific options not explicitly defined here
+
+// Text Generation Schemas
+export const TextRequestSchema = z.object({
+  input: z
+    .string()
+    .openapi({ description: "Input text for the agent", example: "Tell me a joke!" }),
+  options: GenerateOptionsSchema.optional().openapi({
+    description: "Optional generation parameters",
+  }), // Use GenerateOptionsSchema
+});
+
+export const TextResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.string().openapi({ description: "Generated text response" }), // Assuming simple text response for now
+});
+
+// Stream Text Schemas (Representing SSE content)
+export const StreamTextEventSchema = z.object({
+  text: z.string().optional(),
+  timestamp: z.string().datetime().optional(),
+  type: z.enum(["text", "completion", "error"]).optional(),
+  done: z.boolean().optional(),
+  error: z.string().optional(),
+});
+
+// Object Generation Schemas
+export const ObjectRequestSchema = z.object({
+  input: z
+    .string()
+    .openapi({ description: "Input text for the agent", example: "Tell me a joke!" }),
+  schema: z
+    .object({})
+    .passthrough()
+    .openapi({
+      description: "JSON schema describing the desired output object structure.",
+      example: {
+        type: "object",
+        properties: {
+          joke_setup: {
+            type: "string",
+            description: "The setup part of the joke",
+          },
+          punchline: {
+            type: "string",
+            description: "The punchline of the joke",
+          },
+          rating: {
+            type: "number",
+            description: "A rating of how funny the joke is from 1 to 5",
+          },
+        },
+        required: ["joke_setup", "punchline"],
+      },
+    }), // Expect a JSON Schema object
+  options: GenerateOptionsSchema.optional().openapi({
+    description: "Optional generation parameters",
+  }), // Use GenerateOptionsSchema
+});
+
+export const ObjectResponseSchema = z.object({
+  success: z.literal(true),
+  data: z.object({}).passthrough().openapi({ description: "Generated object response" }), // Using passthrough object
+});
+
+// Stream Object Schemas (Representing SSE content)
+// Assuming the stream delivers partial objects or final object based on implementation
+export const StreamObjectEventSchema = z.any().openapi({
+  description: "Streamed object parts or the final object, format depends on agent implementation.",
+});
+
+// --- Route Definitions ---
+
+// Get all agents route
+export const getAgentsRoute = createRoute({
+  method: "get",
+  path: "/agents",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            success: z.literal(true),
+            data: z
+              .array(AgentResponseSchema)
+              .openapi({ description: "List of registered agents" }),
+          }),
+        },
+      },
+      description: "List of all registered agents",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Failed to retrieve agents",
+    },
+  },
+  tags: ["Agent Management"],
+});
+
+// Generate text response
+export const textRoute = createRoute({
+  method: "post",
+  path: "/agents/{id}/text",
+  request: {
+    params: ParamsSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: TextRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: TextResponseSchema,
+        },
+      },
+      description: "Successful text generation",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Agent not found",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Failed to generate text",
+    },
+  },
+  tags: ["Agent Generation"], // Add tags for grouping in Swagger UI
+});
+
+// Stream text response
+export const streamRoute = createRoute({
+  method: "post",
+  path: "/agents/{id}/stream",
+  request: {
+    params: ParamsSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: TextRequestSchema, // Reusing TextRequestSchema
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        // SSE streams are tricky in OpenAPI. Describe the format.
+        "text/event-stream": {
+          schema: StreamTextEventSchema, // Schema for the *content* of an event
+        },
+      },
+      description: `Server-Sent Events stream. Each event is formatted as:\n\
+'data: {"text":"...", "timestamp":"...", "type":"text"}\n\n'\n
+or\n\
+'data: {"done":true, "timestamp":"...", "type":"completion"}\n\n'\n
+or\n\
+'data: {"error":"...", "timestamp":"...", "type":"error"}\n\n'`,
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Agent not found",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Failed to stream text",
+    },
+  },
+  tags: ["Agent Generation"],
+});
+
+// Generate object response
+export const objectRoute = createRoute({
+  method: "post",
+  path: "/agents/{id}/object",
+  request: {
+    params: ParamsSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: ObjectRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: ObjectResponseSchema,
+        },
+      },
+      description: "Successful object generation",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Agent not found",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Failed to generate object",
+    },
+  },
+  tags: ["Agent Generation"],
+});
+
+// Stream object response
+export const streamObjectRoute = createRoute({
+  method: "post",
+  path: "/agents/{id}/stream-object",
+  request: {
+    params: ParamsSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: ObjectRequestSchema, // Reuse ObjectRequestSchema
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        // Describe SSE format for object streaming
+        "text/event-stream": {
+          schema: StreamObjectEventSchema, // Schema for the *content* of an event
+        },
+      },
+      description: `Server-Sent Events stream for object generation.\n\
+Events might contain partial object updates or the final object.\n\
+The exact format (e.g., JSON patches, partial objects) depends on the agent's implementation.\n\
+Example event: 'data: {"partialUpdate": {...}}\n\n' or 'data: {"finalObject": {...}}\n\n'`,
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Agent not found",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description: "Failed to stream object",
+    },
+  },
+  tags: ["Agent Generation"],
+});

--- a/packages/core/src/server/api.ts
+++ b/packages/core/src/server/api.ts
@@ -2,18 +2,35 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { WebSocketServer } from "ws";
 import type { WebSocket } from "ws";
+import { z } from "zod";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { swaggerUI } from "@hono/swagger-ui";
 import type { AgentHistoryEntry } from "../agent/history";
 import { AgentEventEmitter } from "../events";
 import { AgentRegistry } from "./registry";
 import type { AgentResponse, ApiContext, ApiResponse } from "./types";
+import type { AgentStatus } from "../agent/types";
 import {
   checkForUpdates,
   updateAllPackages,
   updateSinglePackage,
   type PackageUpdateInfo,
 } from "../utils/update";
+import {
+  getAgentsRoute,
+  textRoute,
+  streamRoute,
+  objectRoute,
+  streamObjectRoute,
+  type ErrorSchema,
+  type TextResponseSchema,
+  type ObjectResponseSchema,
+  type AgentResponseSchema,
+  type TextRequestSchema,
+  type ObjectRequestSchema,
+} from "./api.routes";
 
-const app = new Hono();
+const app = new OpenAPIHono();
 
 // Nerdy landing page
 app.get("/", (c) => {
@@ -59,10 +76,9 @@ app.get("/", (c) => {
                 padding: 10px 15px;
                 border-radius: 4px;
                 transition: background-color 0.2s, color 0.2s;
-            }
+             }
             a:hover {
-                background-color: #64b5f6;
-                color: #2a2a2a;
+                text-decoration: underline; /* Add underline on hover */
             }
             .logo {
               font-size: 1.8em; /* Slightly smaller logo */
@@ -82,6 +98,11 @@ app.get("/", (c) => {
               <p style="margin-bottom: 15px;">If you find VoltAgent useful, please consider giving us a <a href="http://github.com/voltAgent/voltagent" target="_blank" style="border: none; padding: 0; font-weight: bold; color: #64b5f6;"> star on GitHub ⭐</a>!</p>
               <p>Need support or want to connect with the community? Join our <a href="https://s.voltagent.dev/discord" target="_blank" style="border: none; padding: 0; font-weight: bold; color: #64b5f6;">Discord server</a>.</p>
             </div>
+            <div style="margin-top: 30px; display: flex; flex-direction: row; justify-content: center; align-items: center; gap: 25px;">
+              <a href="/ui" target="_blank" style="border: none; padding: 0; font-weight: bold; color: #64b5f6;">Swagger UI</a>
+              <span style="color: #555555;">|</span> <!-- Optional separator -->
+              <a href="/doc" target="_blank" style="border: none; padding: 0; font-weight: bold; color: #64b5f6;">OpenAPI Spec</a>
+            </div>
         </div>
         <script>
             console.log("%c⚡ VoltAgent Activated ⚡ %c", "color: #64b5f6; font-size: 1.5em; font-weight: bold;", "color: #cccccc; font-size: 1em;");
@@ -96,35 +117,61 @@ app.use("/*", cors());
 // Store WebSocket connections for each agent
 const agentConnections = new Map<string, Set<WebSocket>>();
 
+// Enable CORS for all routes
+app.use(
+  "/*",
+  cors({
+    origin: "*",
+    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization"],
+    exposeHeaders: ["Content-Length", "X-Kuma-Revision"],
+    maxAge: 600,
+    credentials: true,
+  }),
+);
+
 // Get all agents
-app.get("/agents", (c: ApiContext) => {
+app.openapi(getAgentsRoute, (c) => {
   const registry = AgentRegistry.getInstance();
   const agents = registry.getAllAgents();
 
-  const response: ApiResponse<AgentResponse[]> = {
-    success: true,
-    data: agents.map((agent) => {
+  try {
+    const responseData = agents.map((agent) => {
       const fullState = agent.getFullState();
 
       // Ensure subAgents conform to the AgentResponse type
       return {
         ...fullState,
+        status: fullState.status as AgentStatus, // Cast status
         tools: agent.getToolsForApi(),
         subAgents:
           fullState.subAgents?.map((subAgent: any) => ({
             id: subAgent.id || "",
             name: subAgent.name || "",
             description: subAgent.description || "",
-            status: subAgent.status || "idle",
+            status: (subAgent.status as AgentStatus) || "idle", // Cast status
             model: subAgent.model || "",
             tools: subAgent.tools || [],
             memory: subAgent.memory,
           })) || [],
-      } as any;
-    }),
-  };
+      } as z.infer<typeof AgentResponseSchema>; // Assert type conformance
+    });
 
-  return c.json(response);
+    const response = {
+      success: true,
+      data: responseData,
+    } satisfies z.infer<
+      (typeof getAgentsRoute.responses)[200]["content"]["application/json"]["schema"]
+    >; // Use satisfies
+
+    return c.json(response);
+  } catch (error) {
+    console.error("Failed to get agents:", error);
+    return c.json(
+      { success: false, error: "Failed to retrieve agents" } satisfies z.infer<typeof ErrorSchema>,
+      500,
+    );
+  }
 });
 
 // Get agent by ID
@@ -145,7 +192,9 @@ app.get("/agents/:id", (c: ApiContext) => {
     success: true,
     data: {
       ...agent.getFullState(),
+      status: agent.getFullState().status as AgentStatus,
       tools: agent.getToolsForApi() as any,
+      subAgents: agent.getFullState().subAgents as any,
     },
   };
 
@@ -189,92 +238,68 @@ app.get("/agents/:id/history", async (c: ApiContext) => {
   return c.json(response);
 });
 
-// Enable CORS for all routes
-app.use(
-  "/*",
-  cors({
-    origin: "*",
-    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization"],
-    exposeHeaders: ["Content-Length", "X-Kuma-Revision"],
-    maxAge: 600,
-    credentials: true,
-  }),
-);
-
 // Generate text response
-app.post("/agents/:id/text", async (c: ApiContext) => {
-  const id = c.req.param("id");
+app.openapi(textRoute, async (c) => {
+  const { id } = c.req.valid("param") as { id: string };
   const registry = AgentRegistry.getInstance();
   const agent = registry.getAgent(id);
 
   if (!agent) {
-    const response: ApiResponse<null> = {
-      success: false,
-      error: "Agent not found",
-    };
-    return c.json(response, 404);
+    return c.json(
+      { success: false, error: "Agent not found" } satisfies z.infer<typeof ErrorSchema>,
+      404,
+    );
   }
 
   try {
-    const body = await c.req.json();
-    const { input, options = {} } = body;
+    const { input, options = {} } = c.req.valid("json") as z.infer<typeof TextRequestSchema>;
 
     const response = await agent.generateText(input, options);
-    return c.json({ success: true, data: response });
+    return c.json({ success: true, data: response } satisfies z.infer<typeof TextResponseSchema>);
   } catch (error) {
     return c.json(
       {
         success: false,
         error: error instanceof Error ? error.message : "Failed to generate text",
-      },
+      } satisfies z.infer<typeof ErrorSchema>,
       500,
     );
   }
 });
 
 // Stream text response
-app.post("/agents/:id/stream", async (c: ApiContext) => {
-  const id = c.req.param("id");
+app.openapi(streamRoute, async (c) => {
+  const { id } = c.req.valid("param") as { id: string };
   const registry = AgentRegistry.getInstance();
   const agent = registry.getAgent(id);
 
   if (!agent) {
-    const response: ApiResponse<null> = {
-      success: false,
-      error: "Agent not found",
-    };
-    return c.json(response, 404);
+    return c.json(
+      { success: false, error: "Agent not found" } satisfies z.infer<typeof ErrorSchema>,
+      404,
+    );
   }
 
   try {
-    const body = await c.req.json();
-    const { input, options = {} } = body;
+    const { input, options = {} } = c.req.valid("json") as z.infer<typeof TextRequestSchema>;
 
-    // Create a ReadableStream
     const stream = new ReadableStream({
       async start(controller) {
         try {
           const response = await agent.streamText(input, {
             ...options,
-            userId: "1",
           });
 
-          // Handle the stream
           for await (const chunk of response.textStream) {
-            // Format the chunk as SSE data with additional metadata
             const data = {
               text: chunk,
               timestamp: new Date().toISOString(),
               type: "text",
             };
             const sseMessage = `data: ${JSON.stringify(data)}\n\n`;
-
-            // Encode and send the message
             controller.enqueue(new TextEncoder().encode(sseMessage));
           }
 
-          // Send completion message
           const completionData = {
             done: true,
             timestamp: new Date().toISOString(),
@@ -282,25 +307,32 @@ app.post("/agents/:id/stream", async (c: ApiContext) => {
           };
           const completionMessage = `data: ${JSON.stringify(completionData)}\n\n`;
           controller.enqueue(new TextEncoder().encode(completionMessage));
-
-          // Close the stream
           controller.close();
         } catch (error) {
-          // Send error message
           const errorData = {
             error: error instanceof Error ? error.message : "Streaming failed",
             timestamp: new Date().toISOString(),
             type: "error",
           };
           const errorMessage = `data: ${JSON.stringify(errorData)}\n\n`;
-          controller.enqueue(new TextEncoder().encode(errorMessage));
-          controller.close();
+          try {
+            controller.enqueue(new TextEncoder().encode(errorMessage));
+          } catch (e) {
+            console.error("Failed to enqueue error message:", e);
+          }
+          try {
+            controller.close();
+          } catch (e) {
+            console.error("Failed to close controller after error:", e);
+          }
         }
+      },
+      cancel(reason) {
+        console.log("Stream cancelled:", reason);
       },
     });
 
-    // Return the stream with SSE headers
-    return new Response(stream, {
+    return c.body(stream, {
       headers: {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -311,72 +343,116 @@ app.post("/agents/:id/stream", async (c: ApiContext) => {
     return c.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : "Failed to stream text",
-      },
+        error: error instanceof Error ? error.message : "Failed to initiate text stream",
+      } satisfies z.infer<typeof ErrorSchema>,
       500,
     );
   }
 });
 
 // Generate object response
-app.post("/agents/:id/object", async (c: ApiContext) => {
-  const id = c.req.param("id");
+app.openapi(objectRoute, async (c) => {
+  const { id } = c.req.valid("param") as { id: string };
   const registry = AgentRegistry.getInstance();
   const agent = registry.getAgent(id);
 
   if (!agent) {
-    const response: ApiResponse<null> = {
-      success: false,
-      error: "Agent not found",
-    };
-    return c.json(response, 404);
+    return c.json(
+      { success: false, error: "Agent not found" } satisfies z.infer<typeof ErrorSchema>,
+      404,
+    );
   }
 
   try {
-    const body = await c.req.json();
-    const { input, schema, options = {} } = body;
+    const {
+      input,
+      schema,
+      options = {},
+    } = c.req.valid("json") as z.infer<typeof ObjectRequestSchema>;
 
     const response = await agent.generateObject(input, schema, options);
-    return c.json({ success: true, data: response });
+    return c.json({ success: true, data: response } satisfies z.infer<typeof ObjectResponseSchema>);
   } catch (error) {
     return c.json(
       {
         success: false,
         error: error instanceof Error ? error.message : "Failed to generate object",
-      },
+      } satisfies z.infer<typeof ErrorSchema>,
       500,
     );
   }
 });
 
 // Stream object response
-app.post("/agents/:id/stream-object", async (c: ApiContext) => {
-  const id = c.req.param("id");
+app.openapi(streamObjectRoute, async (c) => {
+  const { id } = c.req.valid("param") as { id: string };
   const registry = AgentRegistry.getInstance();
   const agent = registry.getAgent(id);
 
   if (!agent) {
-    const response: ApiResponse<null> = {
-      success: false,
-      error: "Agent not found",
-    };
-    return c.json(response, 404);
+    return c.json(
+      { success: false, error: "Agent not found" } satisfies z.infer<typeof ErrorSchema>,
+      404,
+    );
   }
 
   try {
-    const body = await c.req.json();
-    const { input, schema, options = {} } = body;
+    const {
+      input,
+      schema,
+      options = {},
+    } = c.req.valid("json") as z.infer<typeof ObjectRequestSchema>;
 
-    // Set up SSE headers
-    c.header("Content-Type", "text/event-stream");
-    c.header("Cache-Control", "no-cache");
-    c.header("Connection", "keep-alive");
+    const agentStream = await agent.streamObject(input, schema, options);
 
-    // Create a stream from the agent's streamObject method
-    const stream = await agent.streamObject(input, schema, options);
+    const sseStream = new ReadableStream({
+      async start(controller) {
+        const reader = agentStream.getReader();
+        const decoder = new TextDecoder();
 
-    // Return the stream
-    return new Response(stream, {
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+              const completionData = {
+                done: true,
+                type: "completion",
+                timestamp: new Date().toISOString(),
+              };
+              controller.enqueue(`data: ${JSON.stringify(completionData)}\n\n`);
+              break;
+            }
+            const chunkString = decoder.decode(value, { stream: true });
+            controller.enqueue(`data: ${chunkString}\n\n`);
+          }
+          controller.close();
+        } catch (error) {
+          const errorData = {
+            error: error instanceof Error ? error.message : "Object streaming failed",
+            type: "error",
+            timestamp: new Date().toISOString(),
+          };
+          try {
+            controller.enqueue(`data: ${JSON.stringify(errorData)}\n\n`);
+          } catch (e) {
+            console.error("Failed to enqueue error message:", e);
+          }
+          try {
+            controller.close();
+          } catch (e) {
+            console.error("Failed to close controller after error:", e);
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      },
+      cancel(reason) {
+        console.log("Object Stream cancelled:", reason);
+        agentStream.cancel(reason);
+      },
+    });
+
+    return c.body(sseStream, {
       headers: {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -387,74 +463,8 @@ app.post("/agents/:id/stream-object", async (c: ApiContext) => {
     return c.json(
       {
         success: false,
-        error: error instanceof Error ? error.message : "Failed to stream object",
-      },
-      500,
-    );
-  }
-});
-
-// Execute a tool directly
-app.post("/agents/:id/tools/:toolName/execute", async (c: ApiContext) => {
-  // Get agent ID and decode URI component to handle spaces and special characters
-  const encodedId = c.req.param("id");
-  const id = decodeURIComponent(encodedId);
-
-  // Get and decode tool name
-  const encodedToolName = c.req.param("toolName");
-  const toolName = decodeURIComponent(encodedToolName);
-
-  console.log(`[API] Execute tool request for agent: "${id}", tool: "${toolName}"`);
-
-  const registry = AgentRegistry.getInstance();
-  const agent = registry.getAgent(id);
-
-  if (!agent) {
-    console.log(`[API] Agent not found: "${id}"`);
-    const response: ApiResponse<null> = {
-      success: false,
-      error: `Agent not found: ${id}`,
-    };
-    return c.json(response, 404);
-  }
-
-  try {
-    const body = await c.req.json();
-    const { params = {} } = body;
-
-    // Find the tool in the agent's tools
-    const tools = agent.getTools();
-    const tool = tools.find((t) => t.name === toolName);
-
-    if (!tool) {
-      console.log(`[API] Tool not found: "${toolName}" for agent: "${id}"`);
-      return c.json(
-        {
-          success: false,
-          error: `Tool '${toolName}' not found for this agent`,
-        },
-        404,
-      );
-    }
-
-    console.log(`[API] Executing tool "${toolName}" with params:`, params);
-
-    // Execute the tool
-    const result = await tool.execute(params);
-
-    console.log(`[API] Tool "${toolName}" executed successfully`);
-    return c.json({
-      success: true,
-      data: { result },
-    });
-  } catch (error) {
-    console.error(`[API] Error executing tool "${toolName}":`, error);
-
-    return c.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Failed to execute tool",
-      },
+        error: error instanceof Error ? error.message : "Failed to initiate object stream",
+      } satisfies z.infer<typeof ErrorSchema>,
       500,
     );
   }
@@ -544,6 +554,24 @@ app.post("/updates/:packageName", async (c: ApiContext) => {
   }
 });
 
+// OpenAPI Documentation Endpoints
+
+// The OpenAPI specification endpoint
+app.doc("/doc", {
+  openapi: "3.1.0",
+  info: {
+    version: "1.0.0",
+    title: "VoltAgent Core API",
+    description: "API for managing and interacting with VoltAgents",
+  },
+  servers: [{ url: "http://localhost:3141", description: "Local development server" }],
+});
+
+// Swagger UI endpoint
+app.get("/ui", swaggerUI({ url: "/doc" }));
+
+console.log("API routes registered. OpenAPI spec available at /doc, UI at /ui");
+
 export { app as default };
 
 // Create WebSocket server
@@ -592,7 +620,7 @@ export const createWebSocketServer = () => {
     });
   });
 
-  wss.on("connection", (ws, req) => {
+  wss.on("connection", async (ws, req) => {
     // Extract agent ID from URL - new URL structure /ws/agents/:id
     const url = new URL(req.url || "", "ws://localhost");
     const pathParts = url.pathname.split("/");
@@ -647,8 +675,8 @@ export const createWebSocketServer = () => {
     // Get agent and send initial full state
     const agent = AgentRegistry.getInstance().getAgent(agentId);
     if (agent) {
-      // Get history
-      const history = agent.getHistory();
+      // Get history - needs await
+      const history = await agent.getHistory();
 
       if (history && history.length > 0) {
         // Send all history entries in one message
@@ -662,7 +690,7 @@ export const createWebSocketServer = () => {
 
         // Also check if there's an active history entry and send it individually
         const activeHistory = history.find(
-          (entry) => entry.status !== "completed" && entry.status !== "error",
+          (entry: AgentHistoryEntry) => entry.status !== "completed" && entry.status !== "error",
         );
 
         if (activeHistory) {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -79,7 +79,13 @@ const printServerStartup = (port: number, message: string) => {
   );
   console.log(divider);
   console.log(
-    `${colors.green}  ✓ ${colors.bright}HTTP Server: ${colors.reset}${colors.white}http://localhost:${port}${colors.reset}`,
+    `${colors.green}  ✓ ${colors.bright}HTTP Server:  ${colors.reset}${colors.white}http://localhost:${port}${colors.reset}`,
+  );
+  console.log(
+    `${colors.green}  ✓ ${colors.bright}Swagger UI:   ${colors.reset}${colors.white}http://localhost:${port}/ui${colors.reset}`,
+  );
+  console.log(
+    `${colors.green}  ✓ ${colors.bright}OpenAPI Spec: ${colors.reset}${colors.white}http://localhost:${port}/doc${colors.reset}`,
   );
   console.log();
   console.log(
@@ -170,13 +176,12 @@ export const startServer = async (preferredPort = 3141): Promise<ServerReturn> =
           `${colors.yellow}Port ${port} is already in use, trying next port...${colors.reset}`,
         );
         continue;
-      } else {
-        console.error(
-          `${colors.red}Unexpected error starting server on port ${port}:${colors.reset}`,
-          error,
-        );
-        throw error;
       }
+      console.error(
+        `${colors.red}Unexpected error starting server on port ${port}:${colors.reset}`,
+        error,
+      );
+      throw error;
     }
   }
 

--- a/packages/core/src/server/types.ts
+++ b/packages/core/src/server/types.ts
@@ -1,7 +1,8 @@
 import type { Context } from "hono";
-import type { AgentHistoryEntry } from "../agent/history";
 import type { AgentStatus } from "../agent/types";
 import type { ToolStatusInfo as CoreToolStatusInfo, ToolStatus } from "../tool";
+
+export type { AgentStatus };
 
 export type ApiContext = Context;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,15 +675,18 @@ importers:
 
   packages/core:
     dependencies:
-      '@dmitryrechkin/json-schema-to-zod':
-        specifier: ^1.0.1
-        version: 1.0.1
       '@hono/node-server':
         specifier: ^1.14.0
         version: 1.14.0(hono@4.7.7)
       '@hono/node-ws':
         specifier: ^1.1.1
         version: 1.1.1(@hono/node-server@1.14.0)(hono@4.7.7)
+      '@hono/swagger-ui':
+        specifier: ^0.5.1
+        version: 0.5.1(hono@4.7.7)
+      '@hono/zod-openapi':
+        specifier: ^0.19.6
+        version: 0.19.6(hono@4.7.7)(zod@3.24.2)
       '@libsql/client':
         specifier: ^0.15.0
         version: 0.15.0
@@ -1142,6 +1145,15 @@ packages:
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.0
     dev: true
+
+  /@asteasolutions/zod-to-openapi@7.3.0(zod@3.24.2):
+    resolution: {integrity: sha512-7tE/r1gXwMIvGnXVUdIqUhCU1RevEFC4Jk6Bussa0fk1ecbnnINkZzj1EOAJyE/M3AI25DnHT/zKQL1/FPFi8Q==}
+    peerDependencies:
+      zod: ^3.20.2
+    dependencies:
+      openapi3-ts: 4.4.0
+      zod: 3.24.2
+    dev: false
 
   /@babel/code-frame@7.26.2:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -1926,12 +1938,6 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@dmitryrechkin/json-schema-to-zod@1.0.1:
-    resolution: {integrity: sha512-cG9gC4NMu/7JZqmRZy6uIb+l+kxek2GFQ0/qrhw7xeFK2l5B9yF9FVuujoqFPLRGDHNFYqtBWht7hY4KB0ngrA==}
-    dependencies:
-      zod: 3.24.2
-    dev: false
-
   /@effect/schema@0.75.5(effect@3.12.7):
     resolution: {integrity: sha512-TQInulTVCuF+9EIbJpyLP6dvxbQJMphrnRqgexm/Ze39rSjfhJuufF7XvU3SxTgg3HnL7B/kpORTJbHhlE6thw==}
     deprecated: this package has been merged into the main effect package
@@ -2470,6 +2476,37 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
+
+  /@hono/swagger-ui@0.5.1(hono@4.7.7):
+    resolution: {integrity: sha512-XpUCfszLJ9b1rtFdzqOSHfdg9pfBiC2J5piEjuSanYpDDTIwpMz0ciiv5N3WWUaQpz9fEgH8lttQqL41vIFuDA==}
+    peerDependencies:
+      hono: '*'
+    dependencies:
+      hono: 4.7.7
+    dev: false
+
+  /@hono/zod-openapi@0.19.6(hono@4.7.7)(zod@3.24.2):
+    resolution: {integrity: sha512-qD2I0i5Ksry8gf47rXR6tuUAfv5S/wRZPRUNn+y8vOkgArDtIs30Ha3KGHeuGhcMk773D197IlPUppSCbHt6iQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: 3.*
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 7.3.0(zod@3.24.2)
+      '@hono/zod-validator': 0.5.0(hono@4.7.7)(zod@3.24.2)
+      hono: 4.7.7
+      zod: 3.24.2
+    dev: false
+
+  /@hono/zod-validator@0.5.0(hono@4.7.7)(zod@3.24.2):
+    resolution: {integrity: sha512-ds5bW6DCgAnNHP33E3ieSbaZFd5dkV52ZjyaXtGoR06APFrCtzAsKZxTHwOrJNBdXsi0e5wNwo5L4nVEVnJUdg==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.19.1
+    dependencies:
+      hono: 4.7.7
+      zod: 3.24.2
     dev: false
 
   /@humanwhocodes/config-array@0.13.0:
@@ -4406,23 +4443,23 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     dev: true
 
-  /@xsai/embed@0.2.0-beta.5:
-    resolution: {integrity: sha512-ZgCUOw6Jq2a0awUj9wdCuSHxjTPF65gZfUAzuIed9TE5XVrNqK5eBU4dVlgPQQJPBFR99TTCJUyH1f8nZqi75w==}
+  /@xsai/embed@0.2.0-beta.6:
+    resolution: {integrity: sha512-IO2K0HKG5D32Pp1vDO4NfP3/NVdzWJ0gqBqL4KQk9HI1qTo4jx7Z8uQXpG/7MPYnV3rD1umXhCE2PLEw7MLb2Q==}
     dependencies:
-      '@xsai/shared': 0.2.0-beta.5
+      '@xsai/shared': 0.2.0-beta.6
     dev: false
 
-  /@xsai/generate-image@0.2.0-beta.5:
-    resolution: {integrity: sha512-iH8mqsCujARYPMsp0+/yv0Z1BDoaDSGpfwiUQrgUb0Nd/6E6KMFHCc3qcJrZw2neSB7V1WDIue7NDiYLG7VLnA==}
+  /@xsai/generate-image@0.2.0-beta.6:
+    resolution: {integrity: sha512-lLbyFKDulMw93/DoT37hDCmhWZ5q7/4avRGERJZc364ZMDR5n18bVdhP0SXm3DZjX0DOhmE3TfM79pSmPdB4Pw==}
     dependencies:
-      '@xsai/shared': 0.2.0-beta.5
+      '@xsai/shared': 0.2.0-beta.6
     dev: false
 
-  /@xsai/generate-object@0.2.0-beta.5(effect@3.12.7)(zod@3.24.2):
-    resolution: {integrity: sha512-qdUpM237AyZ6UZPNTt8MF+2tBbIo1VhvtlPhnMGZhzqk42BmMdA++fzjivv+VcEO1yzwp6Vo7pl5IeW4dEGRTQ==}
+  /@xsai/generate-object@0.2.0-beta.6(effect@3.12.7)(zod@3.24.2):
+    resolution: {integrity: sha512-zrlJ+lOmn0MImzD9iL+BKzlohW0wI+O/sTg9vAUN3/1qb/sjM8L+iM8AEUDHfGEWUQu3+lB2aqHi1wMNxU0+xw==}
     dependencies:
-      '@xsai/generate-text': 0.2.0-beta.5
-      xsschema: 0.2.0-beta.5(effect@3.12.7)(zod@3.24.2)
+      '@xsai/generate-text': 0.2.0-beta.6
+      xsschema: 0.2.0-beta.6(effect@3.12.7)(zod@3.24.2)
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - '@zod/mini'
@@ -4432,46 +4469,46 @@ packages:
       - zod-to-json-schema
     dev: false
 
-  /@xsai/generate-speech@0.2.0-beta.5:
-    resolution: {integrity: sha512-8WC2C5tZddW+h5dfPhoTjD/eBWUn+i0iwtNbuZurWTICJ2yFB+r4f64uWGnNcXy4W9pDQbvKjDlOGHWfx7FKLA==}
+  /@xsai/generate-speech@0.2.0-beta.6:
+    resolution: {integrity: sha512-LzaPoqilKsCk1+FB3LfRkxhijupOHC2q/nmAxGUuoWiOnWJtct5R27LL1BDe62KPqrYoQNtuezBQC4TYKE4Y/Q==}
     dependencies:
-      '@xsai/shared': 0.2.0-beta.5
+      '@xsai/shared': 0.2.0-beta.6
     dev: false
 
-  /@xsai/generate-text@0.2.0-beta.5:
-    resolution: {integrity: sha512-Sft9v+2DBJE/rC79pK4GkiqVlWwhaZMKDOMr/Cp/7x4N6AVQR6p7WLmL4CPMRSQa0NLKXWR1Cs/CNSQCwmsj7w==}
+  /@xsai/generate-text@0.2.0-beta.6:
+    resolution: {integrity: sha512-8YWdvkD4JVh6q+9wlCwQc7kyHQ8+WFfzbM8ZyZNqEpHOpzkrZzqY1o1Sg3RR0j16hLfd//S6UzJft2187RuuKw==}
     dependencies:
-      '@xsai/shared': 0.2.0-beta.5
-      '@xsai/shared-chat': 0.2.0-beta.5
+      '@xsai/shared': 0.2.0-beta.6
+      '@xsai/shared-chat': 0.2.0-beta.6
     dev: false
 
-  /@xsai/generate-transcription@0.2.0-beta.5:
-    resolution: {integrity: sha512-Cvl4c1D74EFBnOYyUXHjNe1nXJu1r/1jEDoIu3nFT8nC3dBxzkKeqqFSOfOukECQCCiIW/eymmlAtfbM79gVuA==}
+  /@xsai/generate-transcription@0.2.0-beta.6:
+    resolution: {integrity: sha512-ML/iEyLhmobphOKFx7XcaJNJMnHPwmVx97Hr5HOAcjDt8NGNou1fHxBlwRGnPyh2kn5B/91UszUEGqjUFIRe9w==}
     dependencies:
-      '@xsai/shared': 0.2.0-beta.5
+      '@xsai/shared': 0.2.0-beta.6
     dev: false
 
-  /@xsai/model@0.2.0-beta.5:
-    resolution: {integrity: sha512-iIgrOTtScEliAfUeoK8rm562998XWbERgRiw9iq236JBI5M5jbbGifipTOPs1wbItLVw+m2Ycchpkgr+QPUZJg==}
+  /@xsai/model@0.2.0-beta.6:
+    resolution: {integrity: sha512-QcmssRoUEarGvHIz7+r+HcDTRDPSj/wHP8pL0nWQ41I1fvVjOcwFZ718voVc+ak4Bh39EAE/e14bf9JfDgRwwQ==}
     dependencies:
-      '@xsai/shared': 0.2.0-beta.5
+      '@xsai/shared': 0.2.0-beta.6
     dev: false
 
-  /@xsai/shared-chat@0.2.0-beta.5:
-    resolution: {integrity: sha512-GbjXeMFylP07sNlSpJIIsJysi866tUnTIw+yFLL5G9i8Bi8uHiBxcJJNxw5P5GUXJ1nuq5jEe4Vo+Gsnz0Xd1Q==}
+  /@xsai/shared-chat@0.2.0-beta.6:
+    resolution: {integrity: sha512-gzeMfPu7NHcHYeg1kIeET99wtrNezMbU6T85yk8xPovqJttcEkxpST0dAvXhPtwCyg4o3SYkKtT2Etl1xm3UEw==}
     dependencies:
-      '@xsai/shared': 0.2.0-beta.5
+      '@xsai/shared': 0.2.0-beta.6
     dev: false
 
-  /@xsai/shared@0.2.0-beta.5:
-    resolution: {integrity: sha512-3Ca5ORn49p5PRdhA156rw0izX1azUnM1K/falv0SEBVQhOEGNNGUQLGWCuh9JHKamoRMfkw47gCR+30Onr6r+g==}
+  /@xsai/shared@0.2.0-beta.6:
+    resolution: {integrity: sha512-mDKSXhQpiYansxwe0+oG20drKkYJrOuQM9fMiThgjNgTPBkGd1CvnwJWSwPZQeHgQ7ytNJ/Vd8P3s1lLUlT1Xg==}
     dev: false
 
-  /@xsai/stream-object@0.2.0-beta.5(effect@3.12.7)(zod@3.24.2):
-    resolution: {integrity: sha512-0Kqranr2Xvl5SO+e3xkCi24Me6eZVNqt3ve8GlR9Z8TptysOwB2bSbdPnw3aQ3FaNEWSKFBXzQWH5nk7lgaL5w==}
+  /@xsai/stream-object@0.2.0-beta.6(effect@3.12.7)(zod@3.24.2):
+    resolution: {integrity: sha512-gjeJb5lOH57goNmVc7vPOVJACnseYZokb+jhH3Hn/nHH5kHiljbjthVqx+BE9qFPgdqi6p+759WBUKnWNBVAlQ==}
     dependencies:
-      '@xsai/stream-text': 0.2.0-beta.5
-      xsschema: 0.2.0-beta.5(effect@3.12.7)(zod@3.24.2)
+      '@xsai/stream-text': 0.2.0-beta.6
+      xsschema: 0.2.0-beta.6(effect@3.12.7)(zod@3.24.2)
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - '@zod/mini'
@@ -4481,18 +4518,18 @@ packages:
       - zod-to-json-schema
     dev: false
 
-  /@xsai/stream-text@0.2.0-beta.5:
-    resolution: {integrity: sha512-nCxoQM2bl0HrT+tH1I4kwWKt01tBSDuGXSOQaIdtQCPZNYFqVWhrNm6YPFJSqySykw0afIb4/a6Q6xOlvYIGqg==}
+  /@xsai/stream-text@0.2.0-beta.6:
+    resolution: {integrity: sha512-AdamwWJvPiGmioSq1V8DlBIO73bjqJBFTiPySLLMDP6q/UOeoRxFuddAK7JIFWmdgVEdJbOWIwftPpbLNRWAAQ==}
     dependencies:
-      '@xsai/shared-chat': 0.2.0-beta.5
+      '@xsai/shared-chat': 0.2.0-beta.6
     dev: false
 
-  /@xsai/tool@0.2.0-beta.5(effect@3.12.7)(zod@3.24.2):
-    resolution: {integrity: sha512-3mA3+mOI2d6to799yKBdL7lYVMeLfUF/8ttKHlBb1XE2S95M01ZbXklit9uAUfrXaQd6/USA3toIawzcN55Jyg==}
+  /@xsai/tool@0.2.0-beta.6(effect@3.12.7)(zod@3.24.2):
+    resolution: {integrity: sha512-zBPxCP+c/MzWPHm5PQmLWhsDdQ7jlGl5QmqyiruF0WMYbC+Dmf2lwqsRR3pMyYC1rBlwBtRUOkQPwguaSLGDlw==}
     dependencies:
-      '@xsai/shared': 0.2.0-beta.5
-      '@xsai/shared-chat': 0.2.0-beta.5
-      xsschema: 0.2.0-beta.5(effect@3.12.7)(zod@3.24.2)
+      '@xsai/shared': 0.2.0-beta.6
+      '@xsai/shared-chat': 0.2.0-beta.6
+      xsschema: 0.2.0-beta.6(effect@3.12.7)(zod@3.24.2)
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - '@zod/mini'
@@ -4502,14 +4539,14 @@ packages:
       - zod-to-json-schema
     dev: false
 
-  /@xsai/utils-chat@0.2.0-beta.5:
-    resolution: {integrity: sha512-UxQi37u+x8xXNq6KeGPs296mxBRFHSkB/mQtQD8diMjFyYx+p5AmfmA2uuiWACqOVZy4PArxYuGuTHdEO6eS7w==}
+  /@xsai/utils-chat@0.2.0-beta.6:
+    resolution: {integrity: sha512-dmcIVEqwhlKMkuo+3hZ6ZyrcAL/5zHG3Bf/n2Un2uUfPhqBT00CEbECcWxthmesQ/eOSLw9AVmQ300dxsv6mQQ==}
     dependencies:
-      '@xsai/shared-chat': 0.2.0-beta.5
+      '@xsai/shared-chat': 0.2.0-beta.6
     dev: false
 
-  /@xsai/utils-stream@0.2.0-beta.5:
-    resolution: {integrity: sha512-FE7511JiLb4mjveiIvtjCqZcubzZNx0fWXYtP2EWMbJBtqGg4ng+tsb5u6jYrwN53f6dGcYAdOTRU+7x+qUi6w==}
+  /@xsai/utils-stream@0.2.0-beta.6:
+    resolution: {integrity: sha512-1r/SF2N1YEPceyXzLtaX6Ie423nw5zS3x86FDzGp4gVvOMAij+YI6iRIn/4f6Tytjc7oNGIjtq8ZYH9lF4TSlg==}
     dev: false
 
   /@yarnpkg/lockfile@1.1.0:
@@ -9883,6 +9920,12 @@ packages:
       - encoding
     dev: false
 
+  /openapi3-ts@4.4.0:
+    resolution: {integrity: sha512-9asTNB9IkKEzWMcHmVZE7Ts3kC9G7AFHfs8i7caD8HbI76gEjdkId4z/AkP83xdZsH7PLAnnbl47qZkXuxpArw==}
+    dependencies:
+      yaml: 2.7.0
+    dev: false
+
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -12254,20 +12297,20 @@ packages:
   /xsai@0.2.0-beta.3(effect@3.12.7)(zod@3.24.2):
     resolution: {integrity: sha512-tuDrdLV4wqkZ77EabA5nJ7Pv8Jye1Layq2QsuJAO76gcLqh2uZBx0pwr9Kdxm5DPPHorxjcckZK89qM4CwnRDw==}
     dependencies:
-      '@xsai/embed': 0.2.0-beta.5
-      '@xsai/generate-image': 0.2.0-beta.5
-      '@xsai/generate-object': 0.2.0-beta.5(effect@3.12.7)(zod@3.24.2)
-      '@xsai/generate-speech': 0.2.0-beta.5
-      '@xsai/generate-text': 0.2.0-beta.5
-      '@xsai/generate-transcription': 0.2.0-beta.5
-      '@xsai/model': 0.2.0-beta.5
-      '@xsai/shared': 0.2.0-beta.5
-      '@xsai/shared-chat': 0.2.0-beta.5
-      '@xsai/stream-object': 0.2.0-beta.5(effect@3.12.7)(zod@3.24.2)
-      '@xsai/stream-text': 0.2.0-beta.5
-      '@xsai/tool': 0.2.0-beta.5(effect@3.12.7)(zod@3.24.2)
-      '@xsai/utils-chat': 0.2.0-beta.5
-      '@xsai/utils-stream': 0.2.0-beta.5
+      '@xsai/embed': 0.2.0-beta.6
+      '@xsai/generate-image': 0.2.0-beta.6
+      '@xsai/generate-object': 0.2.0-beta.6(effect@3.12.7)(zod@3.24.2)
+      '@xsai/generate-speech': 0.2.0-beta.6
+      '@xsai/generate-text': 0.2.0-beta.6
+      '@xsai/generate-transcription': 0.2.0-beta.6
+      '@xsai/model': 0.2.0-beta.6
+      '@xsai/shared': 0.2.0-beta.6
+      '@xsai/shared-chat': 0.2.0-beta.6
+      '@xsai/stream-object': 0.2.0-beta.6(effect@3.12.7)(zod@3.24.2)
+      '@xsai/stream-text': 0.2.0-beta.6
+      '@xsai/tool': 0.2.0-beta.6(effect@3.12.7)(zod@3.24.2)
+      '@xsai/utils-chat': 0.2.0-beta.6
+      '@xsai/utils-stream': 0.2.0-beta.6
     transitivePeerDependencies:
       - '@valibot/to-json-schema'
       - '@zod/mini'
@@ -12277,8 +12320,8 @@ packages:
       - zod-to-json-schema
     dev: false
 
-  /xsschema@0.2.0-beta.5(effect@3.12.7)(zod@3.24.2):
-    resolution: {integrity: sha512-GecO7h/j+E7QOUbd5ssAd0ojYNj8stNdlkU3h8Sr/7N4moGcfVd+xGLOimKTKePORTORCmTteidM0/8bvhsEJQ==}
+  /xsschema@0.2.0-beta.6(effect@3.12.7)(zod@3.24.2):
+    resolution: {integrity: sha512-xlGzeFtQV3nVEmrJ9PH3RI3tABDbGfPva9P4NvbFeO3NZjc/dmR4Ne6YFKb7G6DEfaXHaz6R/HSpGXWPgkovNw==}
     peerDependencies:
       '@valibot/to-json-schema': ^1.0.0
       '@zod/mini': ^4.0.0-beta
@@ -12330,7 +12373,6 @@ packages:
     resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
     engines: {node: '>= 14'}
     hasBin: true
-    dev: true
 
   /yargs-parser@20.2.4:
     resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}

--- a/website/docs/api/overview.md
+++ b/website/docs/api/overview.md
@@ -1,0 +1,97 @@
+---
+title: API Overview
+sidebar_label: Overview
+---
+
+The VoltAgent Core API provides a programmatic interface to manage and interact with your VoltAgents. It allows you to list agents, generate text or structured object responses, manage agent history, check for updates, and more.
+
+The API is built using [Hono](https://hono.dev/), a fast and lightweight web framework for Node.js and other JavaScript runtimes.
+
+## Getting Started
+
+The Core API server is typically started as part of your application when you initialize VoltAgent. By default, it tries to run on port `3141`, but may use other ports (like 4310, 1337) if the default is unavailable. Check your console output when starting your application to see the exact URL.
+
+```bash
+# Example console output
+$ node your-app.js
+
+  ══════════════════════════════════════════════════
+    VOLTAGENT SERVER STARTED SUCCESSFULLY
+  ══════════════════════════════════════════════════
+    ✓ HTTP Server:  http://localhost:3141
+    ✓ Swagger UI:   http://localhost:3141/ui
+    ✓ OpenAPI Spec: http://localhost:3141/doc
+
+    Developer Console:    https://console.voltagent.dev
+  ══════════════════════════════════════════════════
+```
+
+## Interactive API Documentation (Swagger UI)
+
+![VoltAgent Swagger UI Demo](https://cdn.voltagent.dev/docs/swagger-ui-demo.gif)
+
+To make exploring and interacting with the API easier, we provide interactive documentation using Swagger UI.
+
+- **Access:** Navigate to `/ui` on your running API server (e.g., `http://localhost:3141/ui`).
+- **Features:**
+  - Lists all available API endpoints grouped by tags (e.g., "Agent Generation", "Agent Management").
+  - Shows details for each endpoint: HTTP method, path, parameters, request body structure, and possible responses.
+  - Provides example values and schemas.
+  - Allows you to **execute API calls directly from your browser** ("Try it out" button) and see the results.
+
+This is the recommended way to explore the API's capabilities.
+
+:::tip[Discoverability]
+Links to the Swagger UI (`/ui`) and the raw OpenAPI specification (`/doc`) are also conveniently available on the API server's root page (`/`) and printed in the console logs when the server starts.
+:::
+
+## OpenAPI Specification
+
+For developers needing the raw API specification for code generation or other tooling, the OpenAPI 3.1 specification is available in JSON format.
+
+- **Access:** Navigate to `/doc` on your running API server (e.g., `http://localhost:3141/doc`).
+
+## Key Endpoints (via Swagger UI)
+
+While the Swagger UI (`/ui`) provides the most comprehensive details, here's a brief overview of the main functionalities documented:
+
+- **`GET /agents`**: Lists all agents currently registered with the `AgentRegistry`.
+- **`POST /agents/{id}/text`**: Generates a plain text response from the specified agent based on the input prompt and options.
+- **`POST /agents/{id}/stream`**: Streams a text response chunk by chunk using Server-Sent Events (SSE).
+- **`POST /agents/{id}/object`**: Generates a structured JSON object response from the agent, guided by a provided schema.
+- **`POST /agents/{id}/stream-object`**: Streams parts of a structured JSON object response using SSE.
+- **(Other endpoints)**: Explore `/ui` for details on history, tool execution, update checks, etc.
+
+:::warning[Object Generation Schema Mismatch]
+Please note that while the API documentation for `/object` and `/stream-object` specifies that the `schema` parameter should be a standard JSON Schema object, the current backend implementation (`Agent.generateObject`, `Agent.streamObject`) still expects a Zod schema instance.
+
+Sending a JSON Schema object via the API will currently result in a runtime error on the backend. This is a known issue tracked for a future backend update. Until then, generating objects via the raw API requires careful handling or using the agent directly within your TypeScript code where you can pass a Zod schema.
+:::
+
+## Authentication
+
+Currently, the Core API does not implement built-in authentication routes. Ensure that your API server is deployed in a secure environment or protected by appropriate network-level security (e.g., firewall rules, reverse proxy authentication) if exposing it outside your local machine.
+
+## Basic Example (Using cURL)
+
+You can quickly test the API using `curl`.
+
+**List all agents:**
+
+```bash
+curl http://localhost:3141/agents
+```
+
+**Generate text:**
+
+```bash
+curl -X POST http://localhost:3141/agents/your-agent-id/text \
+     -H "Content-Type: application/json" \
+     -d '{ "input": "Tell me a short story about a robot learning to paint." }'
+```
+
+(Replace `your-agent-id` with the actual ID of one of your agents)
+
+---
+
+Explore the **Swagger UI at `/ui`** for detailed information on all endpoints, parameters, and schemas!

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -63,6 +63,11 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: "category",
+      label: "API",
+      items: ["api/overview"],
+    },
+    {
+      type: "category",
       label: "Community",
       items: [
         "community/overview",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

- Integrated `@hono/zod-openapi` and `@hono/swagger-ui` to provide interactive API documentation.
- Documented the following core endpoints with request/response schemas, parameters, and examples:
  - `GET /agents`: List all registered agents.
  - `POST /agents/{id}/text`: Generate text response.
  - `POST /agents/{id}/stream`: Stream text response (SSE).
  - `POST /agents/{id}/object`: Generate object response (Note: Requires backend update to fully support JSON Schema input).
  - `POST /agents/{id}/stream-object`: Stream object response (SSE) (Note: Requires backend update to fully support JSON Schema input).
- Added `/doc` endpoint serving the OpenAPI 3.1 specification in JSON format.
- Added `/ui` endpoint serving the interactive Swagger UI.
- Improved API discoverability:
  - Added links to Swagger UI and OpenAPI Spec on the root (`/`) endpoint.
  - Added links to Swagger UI and OpenAPI Spec in the server startup console logs.
- Refactored API schemas and route definitions into `api.routes.ts` for better organization.
- Standardized generation options (like `userId`, `temperature`, `maxTokens`) in the API schema with descriptions, examples, and sensible defaults.

fixes #64

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
