### PR TITLE
feat: Introduce userContext for agent operations

### DIFF
--- a/.changeset/dark-beers-fry.md
+++ b/.changeset/dark-beers-fry.md
@@ -1,0 +1,74 @@
+---
+"@voltagent/core": patch
+---
+
+feat: Introduce `userContext` for passing custom data through agent operations
+
+Introduced `userContext`, a `Map<string | symbol, unknown>` within the `OperationContext`. This allows developers to store and retrieve custom data across agent lifecycle hooks (`onStart`, `onEnd`) and tool executions for a specific agent operation (like a `generateText` call). This context is isolated per operation, providing a way to manage state specific to a single request or task.
+
+**Usage Example:**
+
+```typescript
+import {
+  Agent,
+  createHooks,
+  createTool,
+  type OperationContext,
+  type ToolExecutionContext,
+} from "@voltagent/core";
+import { z } from "zod";
+
+// Define hooks that set and retrieve data
+const hooks = createHooks({
+  onStart: (agent: Agent<any>, context: OperationContext) => {
+    // Set data needed throughout the operation and potentially by tools
+    const requestId = `req-${Date.now()}`;
+    const traceId = `trace-${Math.random().toString(16).substring(2, 8)}`;
+    context.userContext.set("requestId", requestId);
+    context.userContext.set("traceId", traceId);
+    console.log(`[${agent.name}] Operation started. RequestID: ${requestId}, TraceID: ${traceId}`);
+  },
+  onEnd: (agent: Agent<any>, result: any, context: OperationContext) => {
+    // Retrieve data at the end of the operation
+    const requestId = context.userContext.get("requestId");
+    const traceId = context.userContext.get("traceId"); // Can retrieve traceId here too
+    console.log(`[${agent.name}] Operation finished. RequestID: ${requestId}, TraceID: ${traceId}`);
+    // Use these IDs for logging, metrics, cleanup, etc.
+  },
+});
+
+// Define a tool that uses the context data set in onStart
+const customContextTool = createTool({
+  name: "custom_context_logger",
+  description: "Logs a message using trace ID from the user context.",
+  parameters: z.object({
+    message: z.string().describe("The message to log."),
+  }),
+  execute: async (params: { message: string }, options?: ToolExecutionContext) => {
+    // Access userContext via options.operationContext
+    const traceId = options?.operationContext?.userContext?.get("traceId") || "unknown-trace";
+    const requestId = options?.operationContext?.userContext?.get("requestId") || "unknown-request"; // Can access requestId too
+    const logMessage = `[RequestID: ${requestId}, TraceID: ${traceId}] Tool Log: ${params.message}`;
+    console.log(logMessage);
+    // In a real scenario, you might interact with external systems using these IDs
+    return `Logged message with RequestID: ${requestId} and TraceID: ${traceId}`;
+  },
+});
+
+// Create an agent with the tool and hooks
+const agent = new Agent({
+  name: "MyCombinedAgent",
+  llm: myLlmProvider, // Your LLM provider instance
+  model: myModel, // Your model instance
+  tools: [customContextTool],
+  hooks: hooks,
+});
+
+// Trigger the agent. The LLM might decide to use the tool.
+await agent.generateText(
+  "Log the following information using the custom logger: 'User feedback received.'"
+);
+
+// Console output will show logs from onStart, the tool (if called), and onEnd,
+// demonstrating context data flow.
+```

--- a/.changeset/lemon-points-switch.md
+++ b/.changeset/lemon-points-switch.md
@@ -1,0 +1,28 @@
+---
+"@voltagent/vercel-ai": patch
+"@voltagent/supabase": patch
+"@voltagent/groq-ai": patch
+"@voltagent/core": patch
+---
+
+feat: Standardize Agent Error and Finish Handling
+
+This change introduces a more robust and consistent way errors and successful finishes are handled across the `@voltagent/core` Agent and LLM provider implementations (like `@voltagent/vercel-ai`).
+
+**Key Improvements:**
+
+- **Standardized Errors (`VoltagentError`):**
+
+  - Introduced `VoltagentError`, `ToolErrorInfo`, and `StreamOnErrorCallback` types in `@voltagent/core`.
+  - LLM Providers (e.g., Vercel) now wrap underlying SDK/API errors into a structured `VoltagentError` before passing them to `onError` callbacks or throwing them.
+  - Agent methods (`generateText`, `streamText`, `generateObject`, `streamObject`) now consistently handle `VoltagentError`, enabling richer context (stage, code, tool details) in history events and logs.
+
+- **Standardized Stream Finish Results:**
+
+  - Introduced `StreamTextFinishResult`, `StreamTextOnFinishCallback`, `StreamObjectFinishResult`, and `StreamObjectOnFinishCallback` types in `@voltagent/core`.
+  - LLM Providers (e.g., Vercel) now construct these standardized result objects upon successful stream completion.
+  - Agent streaming methods (`streamText`, `streamObject`) now receive these standardized results in their `onFinish` handlers, ensuring consistent access to final output (`text` or `object`), `usage`, `finishReason`, etc., for history, events, and hooks.
+
+- **Updated Interfaces:** The `LLMProvider` interface and related options types (`StreamTextOptions`, `StreamObjectOptions`) have been updated to reflect these new standardized callback types and error-throwing expectations.
+
+These changes lead to more predictable behavior, improved debugging capabilities through structured errors, and a more consistent experience when working with different LLM providers.

--- a/examples/with-playwright/.env.example
+++ b/examples/with-playwright/.env.example
@@ -1,0 +1,1 @@
+MISTRAL_API_KEY=your_mistral_api_key

--- a/examples/with-playwright/README.md
+++ b/examples/with-playwright/README.md
@@ -1,0 +1,53 @@
+<div align="center">
+<a href="https://voltagent.dev/">
+<img width="1800" alt="435380213-b6253409-8741-462b-a346-834cd18565a9" src="https://github.com/user-attachments/assets/452a03e7-eeda-4394-9ee7-0ffbcf37245c" />
+</a>
+
+<br/>
+<br/>
+
+<div align="center">
+    <a href="https://voltagent.dev">Home Page</a> |
+    <a href="https://voltagent.dev/docs/">Documentation</a> |
+    <a href="https://github.com/voltagent/voltagent/tree/main/examples">Examples</a> |
+    <a href="https://s.voltagent.dev/discord">Discord</a> |
+    <a href="https://voltagent.dev/blog/">Blog</a>
+</div>
+</div>
+
+<br/>
+
+<div align="center">
+    <strong>VoltAgent is an open source TypeScript framework for building and orchestrating AI agents.</strong><br>
+Escape the limitations of no-code builders and the complexity of starting from scratch.
+    <br />
+    <br />
+</div>
+
+<div align="center">
+    
+[![npm version](https://img.shields.io/npm/v/@voltagent/core.svg)](https://www.npmjs.com/package/@voltagent/core)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
+[![Twitter Follow](https://img.shields.io/twitter/follow/voltagent_dev?style=social)](https://twitter.com/voltagent_dev)
+    
+</div>
+
+<br/>
+
+<div align="center">
+<a href="https://voltagent.dev/">
+<img width="896" alt="VoltAgent Schema" src="https://github.com/user-attachments/assets/f0627868-6153-4f63-ba7f-bdfcc5dd603d" />
+</a>
+
+</div>
+
+## VoltAgent: Build AI Agents Fast and Flexibly
+
+VoltAgent is an open-source TypeScript framework for creating and managing AI agents. It provides modular components to build, customize, and scale agents with ease. From connecting to APIs and memory management to supporting multiple LLMs, VoltAgent simplifies the process of creating sophisticated AI systems. It enables fast development, maintains clean code, and offers flexibility to switch between models and tools without vendor lock-in.
+
+## Try Example
+
+```bash
+npm create voltagent-app@latest -- --example with-playwright
+```

--- a/examples/with-playwright/package.json
+++ b/examples/with-playwright/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "voltagent-example-with-playwright",
+  "private": true,
+  "keywords": [
+    "voltagent",
+    "ai",
+    "agent"
+  ],
+  "license": "MIT",
+  "author": "",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --env-file=.env ./src ",
+    "start": "node dist/index.js",
+    "volt": "volt"
+  },
+  "dependencies": {
+    "@ai-sdk/mistral": "^1.2.7",
+    "@playwright/browser-chromium": "1.51.1",
+    "@playwright/browser-firefox": "1.51.1",
+    "@playwright/browser-webkit": "1.51.1",
+    "@playwright/test": "^1.51.1",
+    "@voltagent/cli": "^0.1.3",
+    "@voltagent/core": "^0.1.8",
+    "@voltagent/vercel-ai": "^0.1.3",
+    "axios": "^1.5.0",
+    "playwright": "1.51.1",
+    "uuid": "^9.0.1",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.5",
+    "@types/uuid": "^10.0.0",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  }
+}

--- a/examples/with-playwright/src/index.ts
+++ b/examples/with-playwright/src/index.ts
@@ -1,0 +1,99 @@
+import VoltAgent, { Agent, type OperationContext, type AgentHooks } from "@voltagent/core";
+import { VercelAIProvider } from "@voltagent/vercel-ai";
+import { resetBrowserState as resetBrowserStateInternal } from "./tools/playwrightToolHandler";
+import {
+  navigationTool,
+  goBackTool,
+  goForwardTool,
+  refreshPageTool,
+  closeBrowserTool,
+  clickTool,
+  typeTool,
+  getTextTool,
+  selectOptionTool,
+  checkTool,
+  uncheckTool,
+  hoverTool,
+  pressKeyTool,
+  waitForElementTool,
+  saveToFileTool,
+  exportPdfTool,
+  extractDataTool,
+  expectResponseTool,
+  assertResponseTool,
+  screenshotTool,
+  getUserAgentTool,
+  getVisibleTextTool,
+  getVisibleHtmlTool,
+  listInteractiveElementsTool,
+} from "./tools";
+import { mistral } from "@ai-sdk/mistral";
+
+// Define the onEnd hook for browser cleanup
+const browserCleanupHook: AgentHooks["onEnd"] = async (
+  _agent: Agent<any>,
+  _outputOrError: any,
+  context: OperationContext,
+  _isError?: boolean,
+) => {
+  console.log(`[${context.operationId}] Operation finished. Cleaning up browser state...`);
+  // Call the reset function from the handler using the operation context
+  await resetBrowserStateInternal(context);
+};
+
+// Create a specialized agent for browsing
+export const browserAgent = new Agent({
+  name: "Browser Agent",
+  description: "You are an AI agent specialized in web automation with Playwright.",
+  llm: new VercelAIProvider(),
+  model: mistral("mistral-large-latest"),
+
+  hooks: {
+    onEnd: browserCleanupHook,
+  },
+  tools: [
+    // Navigation tools
+    navigationTool,
+    goBackTool,
+    goForwardTool,
+    refreshPageTool,
+    closeBrowserTool,
+
+    //Interaction tools
+    clickTool,
+    typeTool,
+    getTextTool,
+    selectOptionTool,
+    checkTool,
+    uncheckTool,
+    hoverTool,
+    pressKeyTool,
+    waitForElementTool,
+
+    //Output tools
+    saveToFileTool,
+    exportPdfTool,
+    extractDataTool,
+
+    // Response tools
+    expectResponseTool,
+    assertResponseTool,
+
+    // Screenshot tool
+    screenshotTool,
+
+    // User agent tools
+    getUserAgentTool,
+
+    // Visibility tools
+    getVisibleTextTool,
+    getVisibleHtmlTool,
+    listInteractiveElementsTool,
+  ],
+});
+
+new VoltAgent({
+  agents: {
+    agent: browserAgent,
+  },
+});

--- a/examples/with-playwright/src/tools/browserBaseTools.ts
+++ b/examples/with-playwright/src/tools/browserBaseTools.ts
@@ -1,0 +1,32 @@
+import type { Page } from "playwright";
+import type { ToolExecuteOptions, ToolExecutionContext } from "@voltagent/core";
+import {
+  ensureBrowser,
+  resetBrowserState as resetBrowserStateInternal,
+} from "./playwrightToolHandler";
+
+/**
+ * Safe browser operation function to handle errors consistently across all browser tools
+ * This wraps operations with proper error handling and browser initialization using OperationContext.
+ */
+export async function safeBrowserOperation<T>(
+  toolExecCtx: ToolExecuteOptions,
+  operation: (page: Page) => Promise<T>,
+): Promise<T> {
+  try {
+    const { page } = await ensureBrowser(toolExecCtx.operationContext!);
+    return await operation(page);
+  } catch (error) {
+    const opId = toolExecCtx?.operationContext?.operationId || "unknown";
+    console.error(`[${opId}] Browser operation failed:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Export the resetBrowserState function that now requires OperationContext.
+ * Note: Tools calling this directly will need access to the context.
+ */
+export const resetBrowserState = async (context: ToolExecutionContext): Promise<void> => {
+  await resetBrowserStateInternal(context.operationContext!);
+};

--- a/examples/with-playwright/src/tools/index.ts
+++ b/examples/with-playwright/src/tools/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @file Browser Tools Index
+ * @description Exports all browser-related tools for the VoltAgent application
+ */
+
+// Export browser base functionality
+export * from "./browserBaseTools";
+
+// Export browser tools
+export * from "./navigationTool";
+export * from "./screenshotTool";
+export * from "./interactionTool";
+export * from "./responseTool";
+
+export * from "./outputTool";
+
+export * from "./visiblePageTool";

--- a/examples/with-playwright/src/tools/interactionTool.ts
+++ b/examples/with-playwright/src/tools/interactionTool.ts
@@ -1,0 +1,291 @@
+/**
+ * @file Browser Interaction Tools
+ * @description VoltAgent tools for interacting with page elements
+ */
+
+import { z } from "zod";
+import { createTool, type ToolExecuteOptions } from "@voltagent/core";
+import { safeBrowserOperation } from "./browserBaseTools";
+import type { ToolExecutionContext } from "@voltagent/core";
+
+/**
+ * Tool for clicking on an element
+ */
+export const clickTool = createTool({
+  name: "click",
+  description: "Click on an element on the page",
+  parameters: z.object({
+    selector: z.string().describe("CSS or XPath selector for the element"),
+    timeout: z.number().positive().optional().default(30000).describe("Timeout in milliseconds"),
+    button: z
+      .enum(["left", "right", "middle"])
+      .optional()
+      .default("left")
+      .describe("Mouse button to use"),
+    clickCount: z.number().positive().optional().default(1).describe("Number of clicks"),
+    force: z.boolean().optional().default(false).describe("Bypass actionability checks"),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      await page.click(args.selector, {
+        button: args.button,
+        clickCount: args.clickCount,
+        force: args.force,
+        timeout: args.timeout,
+      });
+
+      return { result: `Clicked on element with selector: ${args.selector}` };
+    });
+  },
+});
+
+/**
+ * Tool for typing text into an input field
+ */
+export const typeTool = createTool({
+  name: "typeText",
+  description: "Types text into a specified element.",
+  parameters: z.object({
+    selector: z.string().describe("CSS or XPath selector for the target element."),
+    text: z.string().describe("The text to type into the element."),
+    delay: z
+      .number()
+      .optional()
+      .default(50)
+      .describe("Time to wait between key presses in milliseconds."),
+    timeout: z
+      .number()
+      .optional()
+      .default(30000)
+      .describe("Maximum time in milliseconds to wait for the element."),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      await page.type(args.selector, args.text, { delay: args.delay, timeout: args.timeout });
+      return {
+        result: `Typed "${args.text}" into element with selector: ${args.selector}`,
+      };
+    });
+  },
+});
+
+/**
+ * Tool for extracting text content from an element
+ */
+export const getTextTool = createTool({
+  name: "getText",
+  description: "Get text content from an element",
+  parameters: z.object({
+    selector: z.string().describe("CSS or XPath selector for the element"),
+    timeout: z.number().positive().optional().default(30000).describe("Timeout in milliseconds"),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      await page.waitForSelector(args.selector, { timeout: args.timeout });
+      const text = await page.$eval(args.selector, (el) => el.textContent?.trim() || "");
+
+      return {
+        result: `Text content: ${text}`,
+        text,
+      };
+    });
+  },
+});
+
+/**
+ * Tool for selecting options from dropdown or select elements
+ */
+export const selectOptionTool = createTool({
+  name: "selectOption",
+  description: "Selects an option in a dropdown (select element).",
+  parameters: z.object({
+    selector: z.string().describe("CSS or XPath selector for the select element."),
+    value: z.string().optional().describe("The value of the option to select."),
+    label: z.string().optional().describe("The label of the option to select."),
+    index: z.number().optional().describe("The index of the option to select."),
+    timeout: z
+      .number()
+      .optional()
+      .default(30000)
+      .describe("Maximum time in milliseconds to wait for the element."),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    const { selector, value, label, index, timeout } = args;
+    let selectCriteria: { value: string } | { label: string } | { index: number };
+    if (value !== undefined) selectCriteria = { value };
+    else if (label !== undefined) selectCriteria = { label };
+    else if (index !== undefined) selectCriteria = { index };
+    else throw new Error("Either value, label, or index must be provided for selectOption.");
+
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      const selectedValues = await page.selectOption(selector, selectCriteria, { timeout });
+      return {
+        result: `Selected option in ${selector}. Selected values: ${selectedValues.join(", ")}`,
+      };
+    });
+  },
+});
+
+/**
+ * Tool for checking a checkbox or radio button
+ */
+export const checkTool = createTool({
+  name: "check",
+  description: "Check a checkbox or radio button",
+  parameters: z.object({
+    selector: z.string().describe("CSS or XPath selector for the checkbox or radio"),
+    timeout: z.number().positive().optional().default(30000).describe("Timeout in milliseconds"),
+    force: z.boolean().optional().default(false).describe("Bypass actionability checks"),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      await page.check(args.selector, {
+        timeout: args.timeout,
+        force: args.force,
+      });
+      return { result: `Checked element with selector: ${args.selector}` };
+    });
+  },
+});
+
+/**
+ * Tool for unchecking a checkbox
+ */
+export const uncheckTool = createTool({
+  name: "uncheck",
+  description: "Uncheck a checkbox",
+  parameters: z.object({
+    selector: z.string().describe("CSS or XPath selector for the checkbox"),
+    timeout: z.number().positive().optional().default(30000).describe("Timeout in milliseconds"),
+    force: z.boolean().optional().default(false).describe("Bypass actionability checks"),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      await page.uncheck(args.selector, {
+        timeout: args.timeout,
+        force: args.force,
+      });
+      return { result: `Unchecked element with selector: ${args.selector}` };
+    });
+  },
+});
+
+/**
+ * Tool for hovering over an element
+ */
+export const hoverTool = createTool({
+  name: "hover",
+  description: "Hover over an element",
+  parameters: z.object({
+    selector: z.string().describe("CSS or XPath selector for the element"),
+    timeout: z.number().positive().optional().default(30000).describe("Timeout in milliseconds"),
+    force: z.boolean().optional().default(false).describe("Bypass actionability checks"),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      await page.hover(args.selector, {
+        timeout: args.timeout,
+        force: args.force,
+      });
+      return { result: `Hovered over element with selector: ${args.selector}` };
+    });
+  },
+});
+
+/**
+ * Tool for pressing a keyboard key
+ */
+export const pressKeyTool = createTool({
+  name: "pressKey",
+  description: "Press a keyboard key or key combination",
+  parameters: z.object({
+    key: z.string().describe("Key or key combination to press (e.g., 'Enter', 'Control+A')"),
+    selector: z.string().optional().describe("Optional selector to focus before pressing key"),
+    delay: z.number().optional().default(0).describe("Delay between keystrokes in milliseconds"),
+    timeout: z.number().positive().optional().default(30000).describe("Timeout in milliseconds"),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      if (args.selector) {
+        await page.focus(args.selector, { timeout: args.timeout });
+      }
+
+      await page.keyboard.press(args.key, { delay: args.delay });
+      return {
+        result: args.selector
+          ? `Pressed ${args.key} on element with selector: ${args.selector}`
+          : `Pressed ${args.key}`,
+      };
+    });
+  },
+});
+
+/**
+ * Tool for waiting for an element to appear or become visible
+ */
+export const waitForElementTool = createTool({
+  name: "waitForElement",
+  description: "Wait for an element to appear or become visible",
+  parameters: z.object({
+    selector: z.string().describe("CSS or XPath selector for the element"),
+    state: z
+      .enum(["attached", "detached", "visible", "hidden"])
+      .optional()
+      .default("visible")
+      .describe("Element state to wait for"),
+    timeout: z.number().positive().optional().default(30000).describe("Timeout in milliseconds"),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    if (!options?.operationContext?.userContext) {
+      throw new Error("OperationContext is missing or invalid.");
+    }
+    return safeBrowserOperation(options as ToolExecutionContext, async (page) => {
+      await page.waitForSelector(args.selector, {
+        state: args.state,
+        timeout: args.timeout,
+      });
+      return {
+        result: `Element with selector: ${args.selector} is now in state: ${args.state}`,
+      };
+    });
+  },
+});
+
+/**
+ * Export all interaction tools as a group
+ */
+export const interactionTools = {
+  clickTool,
+  typeTool,
+  getTextTool,
+  selectOptionTool,
+  checkTool,
+  uncheckTool,
+  hoverTool,
+  pressKeyTool,
+  waitForElementTool,
+};

--- a/examples/with-playwright/src/tools/navigationTool.ts
+++ b/examples/with-playwright/src/tools/navigationTool.ts
@@ -1,0 +1,133 @@
+/**
+ * @file Browser Navigation Tools
+ * @description VoltAgent tools for browser navigation operations
+ *
+ * This module provides tools for:
+ * - URL navigation (navigate)
+ * - Browser history navigation (back, forward)
+ * - Page refreshing
+ * - Browser closing
+ *
+ * Each tool is created using VoltAgent's createTool() function with:
+ * - Zod validation schemas for parameters
+ * - Safe browser operation handling
+ * - Consistent error reporting
+ */
+
+import { z } from "zod";
+import { createTool, type ToolExecuteOptions } from "@voltagent/core";
+import { safeBrowserOperation } from "./browserBaseTools";
+import type { ToolExecutionContext } from "@voltagent/core";
+import { resetBrowserState as resetBrowserStateInternal } from "./playwrightToolHandler";
+
+/**
+ * Tool for navigating to URLs
+ */
+export const navigationTool = createTool({
+  name: "navigate",
+  description: "Navigate to a URL in the browser",
+  parameters: z.object({
+    url: z
+      .string()
+      .url({ message: "Please provide a valid URL" })
+      .describe("The URL to navigate to"),
+    timeout: z.number().positive().optional().default(60000).describe("Timeout in milliseconds"),
+    waitUntil: z
+      .enum(["load", "domcontentloaded", "networkidle", "commit"])
+      .optional()
+      .default("load")
+      .describe("Navigation wait condition"),
+  }),
+  execute: async (args, options) => {
+    const context = options;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+
+    return safeBrowserOperation(context, async (page) => {
+      const response = await page.goto(args.url, {
+        timeout: args.timeout,
+        waitUntil: args.waitUntil,
+      });
+
+      return {
+        result: `Navigated to ${args.url}. Status: ${response?.status()}`,
+      };
+    });
+  },
+});
+
+/**
+ * Tool for navigating back in browser history
+ */
+export const goBackTool = createTool({
+  name: "goBack",
+  description: "Navigate back in browser history",
+  parameters: z.object({}),
+  execute: async (_args, options?: ToolExecuteOptions) => {
+    const context = options;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      await page.goBack();
+      return { result: "Navigated back in browser history" };
+    });
+  },
+});
+
+/**
+ * Tool for navigating forward in browser history
+ */
+export const goForwardTool = createTool({
+  name: "goForward",
+  description: "Navigate forward in browser history",
+  parameters: z.object({}),
+  execute: async (_args, options?: ToolExecuteOptions) => {
+    const context = options;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      await page.goForward();
+      return { result: "Navigated forward in browser history" };
+    });
+  },
+});
+
+/**
+ * Tool for refreshing the current page
+ */
+export const refreshPageTool = createTool({
+  name: "refreshPage",
+  description: "Refresh the current page",
+  parameters: z.object({}),
+  execute: async (_args, options?: ToolExecuteOptions) => {
+    const context = options;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      await page.reload();
+      return { result: "Page refreshed successfully" };
+    });
+  },
+});
+
+/**
+ * Tool for closing the browser
+ */
+export const closeBrowserTool = createTool({
+  name: "closeBrowser",
+  description: "Close the current browser instance",
+  parameters: z.object({}),
+  execute: async (_args, options?: ToolExecuteOptions) => {
+    const context = options;
+    if (!context?.operationContext) {
+      console.warn("Attempting to close browser with missing operationContext.");
+      return { result: "Browser context missing, nothing to close." };
+    }
+    await resetBrowserStateInternal(context.operationContext);
+    return { result: "Browser closed." };
+  },
+});

--- a/examples/with-playwright/src/tools/outputTool.ts
+++ b/examples/with-playwright/src/tools/outputTool.ts
@@ -1,0 +1,201 @@
+/**
+ * @file Browser Output Tools
+ * @description Tools for saving and outputting data from the browser
+ */
+
+import { z } from "zod";
+import { createTool, type ToolExecuteOptions } from "@voltagent/core";
+import type { ToolExecutionContext } from "@voltagent/core";
+import { safeBrowserOperation } from "./browserBaseTools";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+/**
+ * Tool for saving content to a file
+ */
+export const saveToFileTool = createTool({
+  name: "saveToFile",
+  description: "Save content to a file",
+  parameters: z.object({
+    content: z.string().describe("Content to save to the file"),
+    filePath: z.string().describe("Path where the file should be saved"),
+    overwrite: z.boolean().optional().default(false).describe("Whether to overwrite existing file"),
+    timeout: z.number().positive().optional().default(30000),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    try {
+      const dirPath = path.dirname(args.filePath);
+
+      // Check existence and handle overwrite asynchronously
+      try {
+        await fs.access(dirPath); // Check directory access
+        // Directory exists, now check file if overwrite is false
+        if (!args.overwrite) {
+          try {
+            await fs.access(args.filePath); // Check file access
+            // File exists and overwrite is false, throw error
+            throw new Error(
+              `File already exists: ${args.filePath}. Set overwrite to true to replace it.`,
+            );
+          } catch (fileError: any) {
+            if (fileError.code !== "ENOENT") {
+              throw fileError; // Re-throw unexpected file access errors
+            }
+            // File does not exist, proceed to write
+          }
+        }
+        // Overwrite is true or file doesn't exist, proceed
+      } catch (dirError: any) {
+        if (dirError.code === "ENOENT") {
+          // Directory doesn't exist, create it
+          await fs.mkdir(dirPath, { recursive: true });
+          // No need to check file existence if directory was just created
+        } else {
+          // Other directory access error
+          throw dirError;
+        }
+      }
+
+      // Write content to file asynchronously
+      await fs.writeFile(args.filePath, args.content);
+
+      return {
+        result: `Content successfully saved to ${args.filePath}`,
+      };
+    } catch (error: any) {
+      console.error(`Error in saveToFileTool: ${error.message}`);
+      throw error; // Re-throw after logging
+    }
+  },
+});
+
+/**
+ * Tool for exporting page as PDF
+ */
+export const exportPdfTool = createTool({
+  name: "exportToPdf",
+  description: "Exports the current page content to a PDF file.",
+  parameters: z.object({
+    filename: z.string().describe("The path where the PDF file will be saved."),
+    format: z
+      .enum(["Letter", "Legal", "Tabloid", "Ledger", "A0", "A1", "A2", "A3", "A4", "A5"])
+      .optional()
+      .default("A4"),
+    printBackground: z.boolean().optional().default(true),
+    timeout: z.number().positive().optional().default(60000),
+    // Add other Playwright PDF options as needed (scale, margins, etc.)
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      // Ensure the directory exists asynchronously
+      const dir = path.dirname(args.filename);
+      try {
+        await fs.access(dir);
+      } catch (error: any) {
+        if (error.code === "ENOENT") {
+          await fs.mkdir(dir, { recursive: true });
+        } else {
+          throw error;
+        }
+      }
+
+      // Generate PDF (Playwright handles file writing here)
+      await page.pdf({
+        path: args.filename,
+        format: args.format,
+        printBackground: args.printBackground,
+        // timeout: args.timeout, // Timeout is not a direct option for page.pdf
+        // Pass other valid Playwright PDF options here if needed
+      });
+
+      return { result: `Page exported successfully to PDF: ${args.filename}` };
+    });
+  },
+});
+
+/**
+ * Tool for extracting structured data from the page
+ */
+export const extractDataTool = createTool({
+  name: "extractData",
+  description: "Extract structured data from the page using CSS selectors",
+  parameters: z.object({
+    selectors: z.record(z.string()).describe("Map of data keys to CSS selectors"),
+    includeHtml: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe("Include HTML content for each selector"),
+    schema: z.any().describe("Zod schema defining the structure of the data to extract."),
+    selector: z
+      .string()
+      .optional()
+      .describe("Optional CSS selector for the container element to extract from."),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      const extractedData = await page.evaluate(
+        (params) => {
+          const { selectors, includeHtml } = params;
+          const result: Record<string, { text: string; html?: string }> = {};
+
+          for (const [key, selector] of Object.entries(selectors)) {
+            const element = document.querySelector(selector);
+            if (element) {
+              result[key] = {
+                text: (element.textContent || "").trim(),
+              };
+
+              if (includeHtml) {
+                result[key].html = element.innerHTML;
+              }
+            } else {
+              result[key] = { text: "" };
+            }
+          }
+
+          return result;
+        },
+        { selectors: args.selectors, includeHtml: args.includeHtml },
+      );
+
+      // Validate extracted data against schema (optional but recommended)
+      try {
+        const zodSchema = args.schema as z.ZodObject<any>; // Assume object schema
+        zodSchema.parse(extractedData);
+        return {
+          result: `Extracted data for ${Object.keys(args.selectors).length} selectors`,
+          data: extractedData,
+        };
+      } catch (validationError) {
+        console.error("Extracted data failed validation:", validationError);
+        return {
+          result: "Extracted data failed validation.",
+          error: validationError,
+          data: extractedData, // Return partial data even if validation fails
+        };
+      }
+    });
+  },
+});
+
+/**
+ * Export all output tools as a group
+ */
+export const outputTools = {
+  saveToFileTool,
+  exportPdfTool,
+  extractDataTool,
+};

--- a/examples/with-playwright/src/tools/playwrightToolHandler.ts
+++ b/examples/with-playwright/src/tools/playwrightToolHandler.ts
@@ -1,0 +1,119 @@
+/**
+ * @file Playwright Browser Management
+ * @description Handles browser lifecycle management, initialization, and cleanup
+ *
+ * This module provides core browser functionality for VoltAgent Playwright tools:
+ * - Maintains global browser state (browser, context, page)
+ * - Ensures browser is available when needed with ensureBrowser()
+ * - Provides clean browser state reset with resetBrowserState()
+ * - Supports different browser types (chromium, firefox, webkit)
+ * - Preserves browser state between tool invocations when possible
+ */
+
+import { chromium, firefox, webkit, type Browser, type Page } from "playwright";
+import type { OperationContext } from "@voltagent/core";
+
+// Define keys for storing browser/page in userContext
+const BROWSER_INSTANCE_KEY = Symbol("playwrightBrowserInstance");
+const PAGE_INSTANCE_KEY = Symbol("playwrightPageInstance");
+const INITIALIZING_KEY = Symbol("playwrightInitializing");
+
+/**
+ * Ensures a browser instance is available within the operation's context
+ * and returns it along with an active page.
+ * Manages initialization lock within the context.
+ */
+export async function ensureBrowser(
+  context: OperationContext,
+): Promise<{ browser: Browser; page: Page }> {
+  const userCtx = context.userContext;
+
+  // Use context-specific lock
+  if (userCtx.get(INITIALIZING_KEY)) {
+    console.log("Browser initialization in progress for this context, waiting...");
+    while (userCtx.get(INITIALIZING_KEY)) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+
+  let browserInstance = userCtx.get(BROWSER_INSTANCE_KEY) as Browser | undefined;
+  let pageInstance = userCtx.get(PAGE_INSTANCE_KEY) as Page | undefined;
+
+  // Check if browser is already initialized *in this context*
+  if (!browserInstance || !browserInstance.isConnected()) {
+    try {
+      userCtx.set(INITIALIZING_KEY, true);
+      console.log(`[${context.operationId}] Launching new browser instance for context...`);
+
+      // Launch a new browser
+      browserInstance = await chromium.launch({
+        headless: process.env.NODE_ENV === "production", // Headless in prod
+        slowMo: 50, // Slightly adjusted slowMo
+      });
+
+      // Create a new context and page
+      const browserContext = await browserInstance.newContext({
+        viewport: {
+          width: 1280,
+          height: 720,
+        },
+        deviceScaleFactor: 1,
+      });
+      pageInstance = await browserContext.newPage();
+
+      // Store instances in the *operation-specific* context
+      userCtx.set(BROWSER_INSTANCE_KEY, browserInstance);
+      userCtx.set(PAGE_INSTANCE_KEY, pageInstance);
+
+      console.log(`[${context.operationId}] Browser launched successfully for context.`);
+    } catch (error) {
+      console.error(`[${context.operationId}] Failed to initialize browser for context:`, error);
+      // Clean up partial state if error occurred during init
+      await browserInstance?.close();
+      userCtx.delete(BROWSER_INSTANCE_KEY);
+      userCtx.delete(PAGE_INSTANCE_KEY);
+      throw error;
+    } finally {
+      userCtx.set(INITIALIZING_KEY, false);
+    }
+  } else if (!pageInstance || pageInstance.isClosed()) {
+    // Browser exists in context, but page doesn't or is closed
+    console.log(`[${context.operationId}] Creating new page in existing browser context...`);
+    const currentContext = browserInstance.contexts()[0]; // Assume single context per browser for simplicity
+    if (!currentContext) {
+      // This case shouldn't happen if browser exists but handle defensively
+      console.error(`[${context.operationId}] Browser exists but has no context!`);
+      throw new Error("Browser context not found");
+    }
+    pageInstance = await currentContext.newPage();
+    userCtx.set(PAGE_INSTANCE_KEY, pageInstance); // Update context with new page
+    console.log(`[${context.operationId}] New page created.`);
+  }
+
+  // Ensure instances are valid after logic
+  if (!browserInstance || !pageInstance) {
+    throw new Error("Failed to ensure browser and page instances within context.");
+  }
+
+  return { browser: browserInstance, page: pageInstance };
+}
+
+/**
+ * Function to reset/close browser state for a specific operation context
+ */
+export async function resetBrowserState(context: OperationContext): Promise<void> {
+  const userCtx = context.userContext;
+  const browser = userCtx.get(BROWSER_INSTANCE_KEY) as Browser | undefined;
+
+  console.log(`[${context.operationId}] Resetting browser state for context...`);
+  if (browser?.isConnected()) {
+    try {
+      await browser.close();
+      console.log(`[${context.operationId}] Browser closed successfully.`);
+    } catch (error) {
+      console.error(`[${context.operationId}] Error closing browser:`, error);
+    }
+  }
+
+  console.log(`[${context.operationId}] Browser state reset complete for context.`);
+}

--- a/examples/with-playwright/src/tools/responseTool.ts
+++ b/examples/with-playwright/src/tools/responseTool.ts
@@ -1,0 +1,162 @@
+/**
+ * @file Browser Response Tools
+ * @description Tools for handling and asserting network responses
+ */
+
+import { z } from "zod";
+import { createTool, type ToolExecuteOptions } from "@voltagent/core";
+import { safeBrowserOperation } from "./browserBaseTools";
+import type { ToolExecutionContext } from "@voltagent/core";
+
+/**
+ * Tool for setting up response wait operations
+ */
+export const expectResponseTool = createTool({
+  name: "expectResponse",
+  description: "Waits for a network response matching a URL pattern.",
+  parameters: z.object({
+    urlPattern: z
+      .string()
+      .describe("A glob pattern, regex, or predicate function to match the response URL."),
+    timeout: z
+      .number()
+      .positive()
+      .optional()
+      .default(30000)
+      .describe("Maximum time in milliseconds to wait for the response."),
+    // status: z.number().optional().describe("Expected status code of the response."), // Predicate function is more flexible
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      try {
+        const response = await page.waitForResponse(args.urlPattern, {
+          timeout: args.timeout,
+        });
+        // Optional: Check status if needed, though waitForResponse doesn't directly filter by it.
+        // if (args.status && response.status() !== args.status) {
+        //   throw new Error(`Expected status ${args.status} but received ${response.status()} for ${response.url()}`);
+        // }
+        return {
+          result: `Response received from URL matching pattern: ${args.urlPattern}. Status: ${response.status()}`,
+          status: response.status(),
+          url: response.url(),
+        };
+      } catch (error: any) {
+        if (error.name === "TimeoutError") {
+          return {
+            result: `Timeout: No response received matching pattern ${args.urlPattern} within ${args.timeout}ms.`,
+          };
+        }
+        throw error; // Re-throw other errors
+      }
+    });
+  },
+});
+
+/**
+ * Tool for asserting and validating responses
+ */
+export const assertResponseTool = createTool({
+  name: "assertResponse",
+  description:
+    "Asserts properties of the last received network response (or a specific one by URL).",
+  parameters: z.object({
+    expectedStatus: z.number().optional().describe("Expected HTTP status code."),
+    expectedBodyContains: z
+      .string()
+      .optional()
+      .describe("Substring expected to be present in the response body."),
+    urlPattern: z
+      .string()
+      .optional()
+      .describe("Optional URL pattern to identify a specific response if needed."),
+    timeout: z
+      .number()
+      .positive()
+      .optional()
+      .default(5000)
+      .describe("Timeout if waiting for a specific response."),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      let targetResponse: any = null; // Consider using Playwright's Response type
+
+      if (args.urlPattern) {
+        // Wait for a specific response if pattern provided
+        try {
+          targetResponse = await page.waitForResponse(args.urlPattern, { timeout: args.timeout });
+        } catch (error: any) {
+          if (error.name === "TimeoutError") {
+            return {
+              result: `Timeout: No response received matching ${args.urlPattern} for assertion.`,
+            };
+          }
+          throw error;
+        }
+      } else {
+        // How to reliably get the "last" response needs a better mechanism.
+        // Playwright doesn't directly expose a "last response" easily.
+        // This might require listening to response events and storing them in context.
+        // For now, this part is non-functional.
+        console.warn("assertResponse without urlPattern is not reliably implemented.");
+        return {
+          result:
+            "Assertion failed: Cannot reliably determine the last response without a URL pattern.",
+        };
+      }
+
+      let assertionsPassed = true;
+      let failureMessages: string[] = [];
+
+      // Assert Status Code
+      if (args.expectedStatus !== undefined) {
+        if (targetResponse.status() !== args.expectedStatus) {
+          assertionsPassed = false;
+          failureMessages.push(
+            `Expected status ${args.expectedStatus}, but got ${targetResponse.status()}.`,
+          );
+        }
+      }
+
+      // Assert Body Content
+      if (args.expectedBodyContains !== undefined) {
+        try {
+          const body = await targetResponse.text();
+          if (!body.includes(args.expectedBodyContains)) {
+            assertionsPassed = false;
+            failureMessages.push(`Response body did not contain "${args.expectedBodyContains}".`);
+          }
+        } catch (error) {
+          assertionsPassed = false;
+          failureMessages.push(
+            `Failed to read response body: ${error instanceof Error ? error.message : error}`,
+          );
+        }
+      }
+
+      return {
+        result: assertionsPassed
+          ? "All assertions passed."
+          : `Assertions failed: ${failureMessages.join(" ")}`,
+        passed: assertionsPassed,
+        failures: failureMessages,
+      };
+    });
+  },
+});
+
+/**
+ * Export all response tools as a group
+ */
+export const responseTools = {
+  expectResponseTool,
+  assertResponseTool,
+};

--- a/examples/with-playwright/src/tools/screenshotTool.ts
+++ b/examples/with-playwright/src/tools/screenshotTool.ts
@@ -1,0 +1,87 @@
+/**
+ * @file Browser Screenshot Tools
+ * @description VoltAgent tools for capturing screenshots in browser
+ */
+
+import { z } from "zod";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import { createTool, type ToolExecuteOptions } from "@voltagent/core";
+import { safeBrowserOperation } from "./browserBaseTools";
+import type { ToolExecutionContext } from "@voltagent/core";
+
+/**
+ * Tool for capturing a screenshot of the current page
+ */
+export const screenshotTool = createTool({
+  name: "takeScreenshot",
+  description: "Takes a screenshot of the current page.",
+  parameters: z.object({
+    filename: z
+      .string()
+      .optional()
+      .describe(
+        "Optional path to save the screenshot file. If not provided, returns base64 string.",
+      ),
+    fullPage: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe("Take screenshot of the full scrollable page."),
+    quality: z
+      .number()
+      .min(0)
+      .max(100)
+      .optional()
+      .describe("JPEG quality (0-100). Only for JPEG format."),
+    type: z.enum(["png", "jpeg"]).optional().default("png").describe("Image format."),
+    timeout: z
+      .number()
+      .positive()
+      .optional()
+      .default(30000)
+      .describe("Maximum time in milliseconds for the screenshot operation."),
+  }),
+  execute: async (args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      const screenshotOptions: Parameters<typeof page.screenshot>[0] = {
+        fullPage: args.fullPage,
+        quality: args.quality,
+        type: args.type,
+        timeout: args.timeout,
+      };
+
+      if (args.filename) {
+        const dir = path.dirname(args.filename);
+        try {
+          await fs.access(dir);
+        } catch (error: any) {
+          if (error.code === "ENOENT") {
+            await fs.mkdir(dir, { recursive: true });
+          } else {
+            throw error;
+          }
+        }
+        screenshotOptions.path = args.filename;
+        await page.screenshot(screenshotOptions);
+        return { result: `Screenshot saved to ${args.filename}` };
+      }
+      const buffer = await page.screenshot(screenshotOptions);
+      return {
+        result: "Screenshot taken successfully.",
+        base64Image: buffer.toString("base64"),
+      };
+    });
+  },
+});
+
+/**
+ * Export all screenshot tools as a group
+ */
+export const screenshotTools = {
+  screenshotTool,
+};

--- a/examples/with-playwright/src/tools/visiblePageTool.ts
+++ b/examples/with-playwright/src/tools/visiblePageTool.ts
@@ -1,0 +1,119 @@
+/**
+ * @file Browser Visible Page Tools
+ * @description Tools for working with visible elements on the page
+ */
+
+import { z } from "zod";
+import { createTool, type ToolExecuteOptions } from "@voltagent/core";
+import { safeBrowserOperation } from "./browserBaseTools";
+import type { ToolExecutionContext } from "@voltagent/core";
+
+/**
+ * Tool for getting all visible text on a page
+ */
+export const getVisibleTextTool = createTool({
+  name: "getVisibleText",
+  description: "Extracts all visible text content from the current page body.",
+  parameters: z.object({}),
+  execute: async (_args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      const visibleText = await page.evaluate(() => document.body.innerText);
+      return {
+        result: "Extracted visible text from the page.",
+        text: visibleText,
+      };
+    });
+  },
+});
+
+/**
+ * Tool for getting the visible HTML content of the current page
+ */
+export const getVisibleHtmlTool = createTool({
+  name: "getVisibleHtml",
+  description: "Gets the HTML structure of the page body.",
+  parameters: z.object({}),
+  execute: async (_args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      const pageHtml = await page.content();
+      return {
+        result: "Retrieved HTML structure.",
+        rawHtml: pageHtml,
+      };
+    });
+  },
+});
+
+/**
+ * Tool for listing visible interactive elements
+ */
+export const listInteractiveElementsTool = createTool({
+  name: "listInteractiveElements",
+  description: "Lists interactive elements like buttons, links, and inputs visible on the page.",
+  parameters: z.object({}),
+  execute: async (_args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      const interactiveElements = await page.evaluate(() => {
+        const selectors =
+          "a[href], button, input, select, textarea, [role='button'], [role='link']";
+        const elements = Array.from(document.querySelectorAll(selectors));
+        // Simplify elements for the response
+        return elements.map((el) => ({
+          tag: el.tagName.toLowerCase(),
+          text: el.textContent?.trim().slice(0, 100),
+          attributes: Object.fromEntries(
+            Array.from(el.attributes).map((attr) => [attr.name, attr.value]),
+          ),
+        }));
+      });
+      return {
+        result: `Found ${interactiveElements.length} interactive elements.`,
+        elements: interactiveElements,
+      };
+    });
+  },
+});
+
+/**
+ * Get User Agent Tool (Moved from userAgentTool.ts)
+ */
+export const getUserAgentTool = createTool({
+  name: "getUserAgent",
+  description: "Gets the current user agent string of the browser.",
+  parameters: z.object({}),
+  execute: async (_args, options?: ToolExecuteOptions) => {
+    const context = options as ToolExecutionContext;
+    if (!context?.operationContext?.userContext) {
+      throw new Error("ToolExecutionContext is missing or invalid.");
+    }
+    return safeBrowserOperation(context, async (page) => {
+      const userAgent = await page.evaluate(() => navigator.userAgent);
+      return {
+        result: `Current user agent: ${userAgent}`,
+        userAgent: userAgent,
+      };
+    });
+  },
+});
+
+/**
+ * Export all visible page tools as a group
+ */
+export const visiblePageTools = {
+  getVisibleTextTool,
+  getVisibleHtmlTool,
+  listInteractiveElementsTool,
+  getUserAgentTool,
+};

--- a/examples/with-playwright/tsconfig.json
+++ b/examples/with-playwright/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/src/agent/hooks/index.spec.ts
+++ b/packages/core/src/agent/hooks/index.spec.ts
@@ -86,7 +86,7 @@ describe("Agent Hooks Functionality", () => {
       await agent.generateText("Test input");
 
       // Verify onStart was called with the agent
-      expect(onStartSpy).toHaveBeenCalledWith(agent);
+      expect(onStartSpy).toHaveBeenCalledWith(agent, expect.anything());
     });
   });
 
@@ -102,7 +102,7 @@ describe("Agent Hooks Functionality", () => {
       const response = await agent.generateText("Test input");
 
       // Verify onEnd was called with the agent and response
-      expect(onEndSpy).toHaveBeenCalledWith(agent, response);
+      expect(onEndSpy).toHaveBeenCalledWith(agent, response, expect.anything());
     });
   });
 

--- a/packages/core/src/agent/hooks/index.spec.ts
+++ b/packages/core/src/agent/hooks/index.spec.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 import { type AgentHooks, createHooks } from ".";
 import { createTool, type AgentTool } from "../../tool";
 import { Agent } from "../index";
+// Import only OperationContext
+import type { OperationContext } from "../types";
+
+// Removed unused mock types
 
 // Mock LLM provider
 class MockProvider {
@@ -22,6 +26,31 @@ const createTestAgent = (name: string) => {
     llm: new MockProvider() as any,
     model: "mock-model",
   });
+};
+
+// Create mock OperationContext for tests
+const createMockContext = (id = "mock-op-1") => {
+  // No explicit type annotation here
+  const mockHistoryEntry = {
+    id: `history-${id}`,
+    timestamp: new Date(),
+    input: "test input",
+    output: "",
+    status: "working", // Use a valid AgentStatus string literal
+    steps: [] as any[],
+    events: [] as any[],
+    agentId: "test-agent",
+    conversationId: "conv-1",
+  };
+
+  // Cast the return object to OperationContext to satisfy the usage
+  return {
+    operationId: id,
+    userContext: new Map<string | symbol, any>(),
+    historyEntry: mockHistoryEntry,
+    eventUpdaters: new Map<string, any>(),
+    isActive: true,
+  } as OperationContext; // Add cast here
 };
 
 describe("Agent Hooks Functionality", () => {
@@ -86,7 +115,7 @@ describe("Agent Hooks Functionality", () => {
       });
 
       // Simulate a handoff (by calling the hook directly)
-      await agent.hooks.onHandoff!(agent, sourceAgent);
+      await agent.hooks.onHandoff?.(agent, sourceAgent);
 
       // Verify onHandoff was called with the agent and source agent
       expect(onHandoffSpy).toHaveBeenCalledWith(agent, sourceAgent);
@@ -106,13 +135,18 @@ describe("Agent Hooks Functionality", () => {
       // Add a test tool to the agent
       agent.addItems([tool]);
 
-      // Directly execute the hooks to test their functionality
-      await agent.hooks.onToolStart?.(agent, tool);
-      await agent.hooks.onToolEnd?.(agent, tool, "Tool result");
+      // Create a mock context for this test
+      const mockContext = createMockContext();
 
-      // Verify hooks were called with correct arguments
-      expect(onToolStartSpy).toHaveBeenCalledWith(agent, tool);
-      expect(onToolEndSpy).toHaveBeenCalledWith(agent, tool, "Tool result");
+      // Directly execute the hooks to test their functionality
+      // Pass the mock context
+      await agent.hooks.onToolStart?.(agent, tool, mockContext);
+      // Pass the mock context
+      await agent.hooks.onToolEnd?.(agent, tool, "Tool result", mockContext);
+
+      // Verify hooks were called with correct arguments, including the context
+      expect(onToolStartSpy).toHaveBeenCalledWith(agent, tool, mockContext);
+      expect(onToolEndSpy).toHaveBeenCalledWith(agent, tool, "Tool result", mockContext);
     });
   });
 });

--- a/packages/core/src/agent/hooks/index.ts
+++ b/packages/core/src/agent/hooks/index.ts
@@ -1,5 +1,6 @@
 import type { AgentTool } from "../../tool";
 import type { Agent } from "../index";
+import type { OperationContext } from "../types";
 
 /**
  * Type definition for agent hooks
@@ -8,15 +9,23 @@ export type AgentHooks = {
   /**
    * Called before the agent is invoked
    * @param agent The agent being invoked
+   * @param context The context for the current operation
    */
-  onStart?: (agent: Agent<any>) => Promise<void> | void;
+  onStart?: (agent: Agent<any>, context: OperationContext) => Promise<void> | void;
 
   /**
-   * Called when the agent produces a final output
-   * @param agent The agent that produced the output
-   * @param output The output produced by the agent
+   * Called when the agent produces a final output or encounters an error
+   * @param agent The agent that produced the output or error
+   * @param outputOrError The output produced by the agent or the error encountered
+   * @param context The context for the current operation
+   * @param isError Flag indicating if the second argument is an error
    */
-  onEnd?: (agent: Agent<any>, output: any) => Promise<void> | void;
+  onEnd?: (
+    agent: Agent<any>,
+    outputOrError: any,
+    context: OperationContext,
+    isError?: boolean,
+  ) => Promise<void> | void;
 
   /**
    * Called when the agent is being handed off to
@@ -29,16 +38,27 @@ export type AgentHooks = {
    * Called before a tool is invoked
    * @param agent The agent invoking the tool
    * @param tool The tool being invoked
+   * @param context The context for the current operation
    */
-  onToolStart?: (agent: Agent<any>, tool: AgentTool) => Promise<void> | void;
+  onToolStart?: (
+    agent: Agent<any>,
+    tool: AgentTool,
+    context: OperationContext,
+  ) => Promise<void> | void;
 
   /**
    * Called after a tool is invoked
    * @param agent The agent that invoked the tool
    * @param tool The tool that was invoked
    * @param result The result of the tool invocation
+   * @param context The context for the current operation
    */
-  onToolEnd?: (agent: Agent<any>, tool: AgentTool, result: any) => Promise<void> | void;
+  onToolEnd?: (
+    agent: Agent<any>,
+    tool: AgentTool,
+    result: any,
+    context: OperationContext,
+  ) => Promise<void> | void;
 };
 
 /**

--- a/packages/core/src/agent/providers/base/types.ts
+++ b/packages/core/src/agent/providers/base/types.ts
@@ -1,6 +1,6 @@
 import type { z } from "zod";
-import type { ProviderOptions } from "../../types";
-import { Tool } from "../../../tool";
+import type { ProviderOptions, ToolExecutionContext, OperationContext } from "../../types";
+import type { Tool } from "../../../tool";
 
 /**
  * Token usage information
@@ -194,6 +194,12 @@ export type ToolExecuteOptions = {
   signal?: AbortSignal;
 
   /**
+   * The operation context associated with the agent invocation triggering this tool execution.
+   * Provides access to operation-specific state like userContext.
+   */
+  operationContext?: OperationContext;
+
+  /**
    * Additional options can be added in the future
    */
   [key: string]: any;
@@ -244,6 +250,7 @@ export interface GenerateTextOptions<TModel> {
   provider?: ProviderOptions;
   onStepFinish?: StepFinishCallback;
   signal?: AbortSignal;
+  toolExecutionContext?: ToolExecutionContext;
 }
 
 export interface StreamTextOptions<TModel> {
@@ -257,6 +264,7 @@ export interface StreamTextOptions<TModel> {
   onFinish?: (result: { text: string }) => void | Promise<void>;
   onError?: (error: any) => void | Promise<void>;
   signal?: AbortSignal;
+  toolExecutionContext?: ToolExecutionContext;
 }
 
 export interface GenerateObjectOptions<TModel, TSchema extends z.ZodType> {
@@ -266,6 +274,7 @@ export interface GenerateObjectOptions<TModel, TSchema extends z.ZodType> {
   provider?: ProviderOptions;
   onStepFinish?: StepFinishCallback;
   signal?: AbortSignal;
+  toolExecutionContext?: ToolExecutionContext;
 }
 
 export interface StreamObjectOptions<TModel, TSchema extends z.ZodType> {
@@ -277,6 +286,7 @@ export interface StreamObjectOptions<TModel, TSchema extends z.ZodType> {
   onFinish?: (result: { object: z.infer<TSchema> }) => void | Promise<void>;
   onError?: (error: any) => void | Promise<void>;
   signal?: AbortSignal;
+  toolExecutionContext?: ToolExecutionContext;
 }
 
 // Utility types to infer provider-specific types

--- a/packages/core/src/agent/providers/base/types.ts
+++ b/packages/core/src/agent/providers/base/types.ts
@@ -1,5 +1,12 @@
 import type { z } from "zod";
-import type { ProviderOptions, ToolExecutionContext, OperationContext } from "../../types";
+import type {
+  ProviderOptions,
+  ToolExecutionContext,
+  OperationContext,
+  StreamOnErrorCallback,
+  StreamTextOnFinishCallback,
+  StreamObjectOnFinishCallback,
+} from "../../types";
 import type { Tool } from "../../../tool";
 
 /**
@@ -261,8 +268,8 @@ export interface StreamTextOptions<TModel> {
   provider?: ProviderOptions;
   onStepFinish?: StepFinishCallback;
   onChunk?: StepChunkCallback;
-  onFinish?: (result: { text: string }) => void | Promise<void>;
-  onError?: (error: any) => void | Promise<void>;
+  onFinish?: StreamTextOnFinishCallback;
+  onError?: StreamOnErrorCallback;
   signal?: AbortSignal;
   toolExecutionContext?: ToolExecutionContext;
 }
@@ -283,8 +290,8 @@ export interface StreamObjectOptions<TModel, TSchema extends z.ZodType> {
   schema: TSchema;
   provider?: ProviderOptions;
   onStepFinish?: StepFinishCallback;
-  onFinish?: (result: { object: z.infer<TSchema> }) => void | Promise<void>;
-  onError?: (error: any) => void | Promise<void>;
+  onFinish?: StreamObjectOnFinishCallback<z.infer<TSchema>>;
+  onError?: StreamOnErrorCallback;
   signal?: AbortSignal;
   toolExecutionContext?: ToolExecutionContext;
 }
@@ -343,6 +350,11 @@ export type InferProviderParams<T> = T extends {
 // Base provider type
 export type LLMProvider<TProvider> = {
   // Core methods
+  /**
+   * Generates a text response based on the provided options.
+   * Implementers should catch underlying SDK/API errors and throw a VoltagentError.
+   * @throws {VoltagentError} If an error occurs during generation.
+   */
   generateText(
     options: GenerateTextOptions<InferModel<TProvider>>,
   ): Promise<ProviderTextResponse<InferGenerateTextResponse<TProvider>>>;
@@ -351,6 +363,11 @@ export type LLMProvider<TProvider> = {
     options: StreamTextOptions<InferModel<TProvider>>,
   ): Promise<ProviderTextStreamResponse<InferStreamResponse<TProvider>>>;
 
+  /**
+   * Generates a structured object response based on the provided options and schema.
+   * Implementers should catch underlying SDK/API errors and throw a VoltagentError.
+   * @throws {VoltagentError} If an error occurs during generation.
+   */
   generateObject<TSchema extends z.ZodType>(
     options: GenerateObjectOptions<InferModel<TProvider>, TSchema>,
   ): Promise<ProviderObjectResponse<InferGenerateObjectResponse<TProvider>, z.infer<TSchema>>>;

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -82,24 +82,6 @@ export type AgentOptions = {
    * Sub-agents that this agent can delegate tasks to
    */
   subAgents?: any[]; // Using any to avoid circular dependency
-
-  // Remove duplicated fields below - they belong in CommonGenerateOptions
-  /*
-  // Context limit for conversation
-  contextLimit?: number;
-
-  // Specific tools to use for this generation (overrides agent's tools)
-  tools?: BaseTool[];
-
-  // Signal for aborting the operation
-  signal?: AbortSignal;
-
-  // Current history entry ID for parent context in tool execution
-  historyEntryId?: string;
-
-  // The OperationContext associated with this specific generation call
-  operationContext?: OperationContext;
-  */
 };
 
 /**

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -7,6 +7,7 @@ import type { StepWithContent } from "./providers";
 import type { AgentHistoryEntry } from "./history";
 import type { EventUpdater } from "../events";
 import type { ToolExecuteOptions } from "./providers/base/types";
+import type { UsageInfo } from "./providers/base/types";
 
 /**
  * Provider options type for LLM configurations
@@ -353,3 +354,107 @@ export type ToolExecutionContext = ToolExecuteOptions & {
   /** History ID associated with the current operation */
   historyEntryId: string;
 };
+
+/**
+ * Specific information related to a tool execution error.
+ */
+export interface ToolErrorInfo {
+  /** The unique identifier of the tool call. */
+  toolCallId: string;
+
+  /** The name of the tool that was executed. */
+  toolName: string;
+
+  /** The original error thrown directly by the tool during execution (if available). */
+  toolExecutionError?: unknown;
+
+  /** The arguments passed to the tool when the error occurred (for debugging). */
+  toolArguments?: unknown;
+}
+
+/**
+ * Standardized error structure for Voltagent agent operations.
+ * Providers should wrap their specific errors in this structure before
+ * passing them to onError callbacks.
+ */
+export interface VoltagentError {
+  /** A clear, human-readable error message. This could be a general message or derived from toolError info. */
+  message: string;
+
+  /** The original error object thrown by the provider or underlying system (if available). */
+  originalError?: unknown;
+
+  /** Optional error code or identifier from the provider. */
+  code?: string | number;
+
+  /** Additional metadata related to the error (e.g., retry info, request ID). */
+  metadata?: Record<string, any>;
+
+  /** Information about the step or stage where the error occurred (optional, e.g., 'llm_request', 'tool_execution', 'response_parsing'). */
+  stage?: string;
+
+  /** If the error occurred during tool execution, this field contains the relevant details. Otherwise, it's undefined. */
+  toolError?: ToolErrorInfo;
+}
+
+/**
+ * Type for onError callbacks in streaming operations.
+ * Providers must pass an error conforming to the VoltagentError structure.
+ */
+export type StreamOnErrorCallback = (error: VoltagentError) => Promise<void> | void;
+
+/**
+ * Standardized object structure passed to the onFinish callback
+ * when streamText completes successfully.
+ */
+export interface StreamTextFinishResult {
+  /** The final, consolidated text output from the stream. */
+  text: string;
+
+  /** Token usage information (if available). */
+  usage?: UsageInfo;
+
+  /** The reason the stream finished (if available, e.g., 'stop', 'length', 'tool-calls'). */
+  finishReason?: string;
+
+  /** The original completion response object from the provider (if available). */
+  providerResponse?: unknown;
+
+  /** Any warnings generated during the completion (if available). */
+  warnings?: unknown[];
+}
+
+/**
+ * Type for the onFinish callback function for streamText.
+ */
+export type StreamTextOnFinishCallback = (result: StreamTextFinishResult) => Promise<void> | void;
+
+/**
+ * Standardized object structure passed to the onFinish callback
+ * when streamObject completes successfully.
+ * @template TObject The expected type of the fully formed object.
+ */
+export interface StreamObjectFinishResult<TObject> {
+  /** The final, fully formed object from the stream. */
+  object: TObject;
+
+  /** Token usage information (if available). */
+  usage?: UsageInfo;
+
+  /** The original completion response object from the provider (if available). */
+  providerResponse?: unknown;
+
+  /** Any warnings generated during the completion (if available). */
+  warnings?: unknown[];
+
+  /** The reason the stream finished (if available). Although less common for object streams. */
+  finishReason?: string;
+}
+
+/**
+ * Type for the onFinish callback function for streamObject.
+ * @template TObject The expected type of the fully formed object.
+ */
+export type StreamObjectOnFinishCallback<TObject> = (
+  result: StreamObjectFinishResult<TObject>,
+) => Promise<void> | void;

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -1,7 +1,7 @@
 /**
  * Event statuses
  */
-export type EventStatus = "idle" | "working" | "completed" | "error";
+export type EventStatus = "working" | "idle" | "error" | "completed" | "tool_calling";
 
 /**
  * Standard event data interface
@@ -17,19 +17,25 @@ export interface StandardEventData {
   timestamp: string;
 
   // Input data - to be used consistently for all event types
-  input?: any;
+  input?: unknown;
 
   // Output data - to be used consistently for all event types
-  output?: any;
+  output?: unknown;
 
   // In case of error
-  error?: any;
+  error?: unknown;
 
   // Error message (user-friendly message)
   errorMessage?: string;
 
   // For tool-specific additional information and other custom information
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
+
+  // ID of the agent that originated the event (especially for sub-agent events)
+  sourceAgentId?: string;
+
+  // Optional serialized user context at the time of the event
+  userContext?: Record<string, unknown>;
 }
 
 /**

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -1,7 +1,7 @@
 /**
  * Event statuses
  */
-export type EventStatus = "working" | "idle" | "error" | "completed" | "tool_calling";
+export type EventStatus = "idle" | "working" | "completed" | "error";
 
 /**
  * Standard event data interface

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,12 @@ export type {
   ModelToolCall,
   OperationContext,
   ToolExecutionContext,
+  VoltagentError,
+  StreamTextFinishResult,
+  StreamTextOnFinishCallback,
+  StreamObjectFinishResult,
+  StreamObjectOnFinishCallback,
+  ToolErrorInfo,
 } from "./agent/types";
 export type { AgentHistoryEntry } from "./agent/history";
 export type { AgentHooks } from "./agent/hooks";
@@ -51,9 +57,7 @@ export class VoltAgent {
 
     // Auto-start server if enabled
     if (options.autoStart !== false) {
-      const port =
-        options.port || process.env.PORT ? Number.parseInt(process.env.PORT || "3000") : 3000;
-      this.startServer(port).catch((err) => {
+      this.startServer().catch((err) => {
         console.error("[VoltAgent] Failed to start server:", err);
         process.exit(1);
       });
@@ -105,13 +109,13 @@ export class VoltAgent {
   /**
    * Start the server
    */
-  public async startServer(port = 3000): Promise<void> {
+  public async startServer(): Promise<void> {
     if (this.serverStarted) {
       console.log("[VoltAgent] Server is already running");
       return;
     }
 
-    await startServer(port);
+    await startServer();
     this.serverStarted = true;
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,14 @@ export * from "./tool";
 export * from "./tool/reasoning/index";
 export * from "./memory";
 export * from "./agent/providers";
-export type { AgentOptions, AgentResponse, ModelToolCall } from "./agent/types";
+export type {
+  AgentOptions,
+  AgentResponse,
+  ModelToolCall,
+  OperationContext,
+  ToolExecutionContext,
+} from "./agent/types";
+export type { AgentHistoryEntry } from "./agent/history";
 export type { AgentHooks } from "./agent/hooks";
 export * from "./types";
 export * from "./utils";

--- a/packages/core/src/memory/manager/index.spec.ts
+++ b/packages/core/src/memory/manager/index.spec.ts
@@ -62,6 +62,8 @@ const createMockContext = (): OperationContext => {
     historyEntry: mockHistoryEntry,
     eventUpdaters: new Map(),
     isActive: true,
+    operationId: "test-operation",
+    userContext: new Map(),
   };
 };
 
@@ -195,7 +197,7 @@ class MockMemory implements Memory {
     this.historyEvents[id] = { ...this.historyEvents[id], ...updates };
 
     // Update event in the history entry's events array
-    if (this.historyEntries[historyId] && this.historyEntries[historyId].events) {
+    if (this.historyEntries[historyId]?.events) {
       const eventIndex = this.historyEntries[historyId].events.findIndex((e: any) => e.id === id);
       if (eventIndex !== -1) {
         this.historyEntries[historyId].events[eventIndex] = this.historyEvents[id];
@@ -235,7 +237,7 @@ class MockMemory implements Memory {
     this.historySteps[id] = { ...this.historySteps[id], ...updates };
 
     // Update step in the history entry's steps array
-    if (this.historyEntries[historyId] && this.historyEntries[historyId].steps) {
+    if (this.historyEntries[historyId]?.steps) {
       const stepIndex = this.historyEntries[historyId].steps.findIndex((s: any) => s.id === id);
       if (stepIndex !== -1) {
         this.historyEntries[historyId].steps[stepIndex] = this.historySteps[id];

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -69,7 +69,7 @@ const preferredPorts: PortConfig[] = [
 ];
 
 // To make server startup logs visually more attractive
-const printServerStartup = (port: number, message: string) => {
+const printServerStartup = (port: number) => {
   const divider = `${colors.cyan}${"═".repeat(50)}${colors.reset}`;
 
   console.log("\n");
@@ -121,7 +121,7 @@ const tryStartServer = (port: number): Promise<ReturnType<typeof serve>> => {
 };
 
 // Function to start the server
-export const startServer = async (preferredPort = 3141): Promise<ServerReturn> => {
+export const startServer = async (): Promise<ServerReturn> => {
   // Collect all ports in an array - first preferred ports, then fallback ports
   const portsToTry: Array<PortConfig> = [
     ...preferredPorts,
@@ -134,9 +134,7 @@ export const startServer = async (preferredPort = 3141): Promise<ServerReturn> =
 
   // Try each port in sequence
   for (const portConfig of portsToTry) {
-    const { port, messages } = portConfig;
-    const randomIndex = Math.floor(Math.random() * messages.length);
-    const randomMessage = messages[randomIndex];
+    const { port } = portConfig;
 
     try {
       // Try to start the server and wait until successful
@@ -161,7 +159,7 @@ export const startServer = async (preferredPort = 3141): Promise<ServerReturn> =
         }
       });
 
-      printServerStartup(port, randomMessage);
+      printServerStartup(port);
 
       return { server, ws, port };
     } catch (error) {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,6 +2,8 @@
  * Utility functions for VoltAgent
  */
 
-export * from "./toolParser";
-export * from "./node-utils";
 export * from "./createPrompt";
+export * from "./node-utils";
+export * from "./toolParser";
+export * from "./update";
+export * from "./serialization";

--- a/packages/core/src/utils/serialization/index.spec.ts
+++ b/packages/core/src/utils/serialization/index.spec.ts
@@ -1,0 +1,142 @@
+import { serializeValueForDebug } from "../serialization";
+
+describe("serializeValueForDebug", () => {
+  it("should return primitives as is", () => {
+    expect(serializeValueForDebug("hello")).toBe("hello");
+    expect(serializeValueForDebug(123)).toBe(123);
+    expect(serializeValueForDebug(true)).toBe(true);
+    expect(serializeValueForDebug(false)).toBe(false);
+    expect(serializeValueForDebug(null)).toBeNull();
+    expect(serializeValueForDebug(undefined)).toBeUndefined();
+  });
+
+  it("should serialize named functions", () => {
+    function namedFunction() {}
+    expect(serializeValueForDebug(namedFunction)).toBe("[Function: namedFunction]");
+  });
+
+  it("should serialize anonymous functions", () => {
+    const anonFunc = () => {};
+    const arrowFunc = () => {};
+    expect(serializeValueForDebug(anonFunc)).toBe("[Function: anonFunc]"); // Inference might name it
+    expect(serializeValueForDebug(arrowFunc)).toBe("[Function: arrowFunc]"); // Inference might name it
+    expect(serializeValueForDebug(() => {})).toBe("[Function: anonymous]");
+  });
+
+  it("should serialize symbols", () => {
+    expect(serializeValueForDebug(Symbol("desc"))).toBe("Symbol(desc)");
+    expect(serializeValueForDebug(Symbol())).toBe("Symbol()");
+  });
+
+  it("should serialize dates", () => {
+    const date = new Date();
+    expect(serializeValueForDebug(date)).toBe(`[Date: ${date.toISOString()}]`);
+  });
+
+  it("should serialize regular expressions", () => {
+    const regex = /ab+c/i;
+    expect(serializeValueForDebug(regex)).toBe(`[RegExp: ${regex.toString()}]`);
+  });
+
+  it("should serialize Maps", () => {
+    const map = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(serializeValueForDebug(map)).toBe("[Map size=2]");
+  });
+
+  it("should serialize Sets", () => {
+    const set = new Set([1, 2, 3]);
+    expect(serializeValueForDebug(set)).toBe("[Set size=3]");
+  });
+
+  it("should serialize simple arrays", () => {
+    expect(serializeValueForDebug([1, "a", true])).toEqual([1, "a", true]);
+  });
+
+  it("should serialize nested arrays with complex types", () => {
+    const date = new Date();
+    const func = () => {};
+    expect(serializeValueForDebug([1, [date, func]])).toEqual([
+      1,
+      [`[Date: ${date.toISOString()}]`, "[Function: func]"],
+    ]);
+  });
+
+  it("should serialize simple plain objects", () => {
+    expect(serializeValueForDebug({ a: 1, b: "hello" })).toEqual({ a: 1, b: "hello" });
+  });
+
+  it("should serialize plain objects with nested complex types", () => {
+    const date = new Date();
+    const sym = Symbol("id");
+    class MyClass {}
+    const instance = new MyClass();
+    const map = new Map();
+
+    const input = {
+      num: 1,
+      dateVal: date,
+      symVal: sym,
+      instVal: instance,
+      mapVal: map,
+      funcVal: () => {},
+      arrVal: [1, date],
+    };
+
+    const expected = {
+      num: 1,
+      dateVal: `[Date: ${date.toISOString()}]`,
+      symVal: "Symbol(id)",
+      instVal: "[Object: MyClass]",
+      mapVal: "[Map size=0]",
+      funcVal: "[Function: anonymous]", // Depending on context, could be named
+      arrVal: [1, `[Date: ${date.toISOString()}]`],
+    };
+
+    // Need to serialize the whole input object using the function
+    // The current implementation tries to serialize plain objects directly.
+    // Let's adjust the test to reflect how individual complex values *within* an object would be serialized
+    // when the main function iterates over the map.
+    const serializedInput = Object.fromEntries(
+      Object.entries(input).map(([k, v]) => [k, serializeValueForDebug(v)]),
+    );
+    expect(serializedInput).toEqual(expected);
+  });
+
+  it("should serialize class instances", () => {
+    class MyClass {}
+    class AnotherClass {
+      constructor(public name: string) {}
+    }
+    expect(serializeValueForDebug(new MyClass())).toBe("[Object: MyClass]");
+    expect(serializeValueForDebug(new AnotherClass("test"))).toBe("[Object: AnotherClass]");
+  });
+
+  it("should handle anonymous classes", () => {
+    const AnonClass = class {};
+    expect(serializeValueForDebug(new AnonClass())).toBe("[Object: AnonClass]"); // Might infer name
+  });
+
+  it("should handle JSON serialization errors gracefully for plain objects", () => {
+    const circular: any = {};
+    circular.self = circular;
+    // Note: Our simple check using JSON.stringify/parse handles top-level circular refs
+    expect(serializeValueForDebug(circular)).toMatch(/^\[SerializationError:/);
+  });
+
+  it("should handle unsupported types", () => {
+    // Example: BigInt might not be directly supported depending on environment/needs
+    // Check if BigInt is supported in the environment first
+    if (typeof BigInt !== "undefined") {
+      expect(serializeValueForDebug(BigInt(123))).toBe("[Unsupported Type: bigint]");
+    } else {
+      console.warn("Skipping BigInt test: BigInt not supported in this environment.");
+    }
+
+    // Let's test with a generic object that might fail other checks
+    const customProto = Object.create({ custom: true });
+    expect(serializeValueForDebug(customProto)).toBe("[Object: UnknownClass]"); // Falls through to class instance logic
+  });
+});

--- a/packages/core/src/utils/serialization/index.spec.ts
+++ b/packages/core/src/utils/serialization/index.spec.ts
@@ -91,7 +91,7 @@ describe("serializeValueForDebug", () => {
       symVal: "Symbol(id)",
       instVal: "[Object: MyClass]",
       mapVal: "[Map size=0]",
-      funcVal: "[Function: anonymous]", // Depending on context, could be named
+      funcVal: "[Function: funcVal]", // Depending on context, could be named
       arrVal: [1, `[Date: ${date.toISOString()}]`],
     };
 
@@ -137,6 +137,6 @@ describe("serializeValueForDebug", () => {
 
     // Let's test with a generic object that might fail other checks
     const customProto = Object.create({ custom: true });
-    expect(serializeValueForDebug(customProto)).toBe("[Object: UnknownClass]"); // Falls through to class instance logic
+    expect(serializeValueForDebug(customProto)).toBe("[Object: Object]"); // Falls through to class instance logic
   });
 });

--- a/packages/core/src/utils/serialization/index.ts
+++ b/packages/core/src/utils/serialization/index.ts
@@ -1,0 +1,51 @@
+// Helper function to safely serialize complex values for debugging
+export function serializeValueForDebug(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  const type = typeof value;
+  if (type === "string" || type === "number" || type === "boolean") {
+    return value;
+  }
+  if (type === "function") {
+    // Assert the type to access the optional name property
+    return `[Function: ${(value as { name?: string }).name || "anonymous"}]`;
+  }
+  if (type === "symbol") {
+    return value.toString(); // e.g., "Symbol(description)"
+  }
+  if (type === "object") {
+    if (value instanceof Date) {
+      return `[Date: ${value.toISOString()}]`;
+    }
+    if (value instanceof RegExp) {
+      return `[RegExp: ${value.toString()}]`;
+    }
+    if (value instanceof Map) {
+      return `[Map size=${value.size}]`; // Avoid serializing potentially complex Map values
+    }
+    if (value instanceof Set) {
+      return `[Set size=${value.size}]`; // Avoid serializing potentially complex Set values
+    }
+    if (Array.isArray(value)) {
+      // For arrays, serialize elements recursively, but keep it as an array
+      // Limit depth or size if needed to prevent large payloads
+      return value.map(serializeValueForDebug);
+    }
+    // For plain objects, try to serialize, but handle potential errors
+    try {
+      // Basic check for prototype to differentiate plain objects from class instances
+      if (Object.getPrototypeOf(value) === Object.prototype) {
+        // Attempt to stringify/parse to handle simple cases, could use a more robust method
+        // This basic version might still fail on circular refs within plain objects
+        // Consider a library or depth limiting for robustness
+        return JSON.parse(JSON.stringify(value));
+      }
+      // For class instances
+      return `[Object: ${value.constructor?.name || "UnknownClass"}]`;
+    } catch (e) {
+      return `[SerializationError: ${e instanceof Error ? e.message : "Unknown"}]`;
+    }
+  }
+  return `[Unsupported Type: ${type}]`;
+}

--- a/packages/groq-ai/package.json
+++ b/packages/groq-ai/package.json
@@ -30,5 +30,8 @@
     "ts-jest": "^29.1.0",
     "tsup": "^6.7.0",
     "typescript": "^5.0.4"
+  },
+  "peerDependencies": {
+    "@voltagent/core": "^0.1.0"
   }
 }

--- a/packages/groq-ai/src/index.ts
+++ b/packages/groq-ai/src/index.ts
@@ -222,7 +222,8 @@ export class GroqProvider implements LLMProvider<string> {
             // Handle errors during streaming
             console.error("Error during Groq stream processing:", error);
             controller.error(error);
-            if (options.onError) options.onError(error);
+            // TODO: fix this
+            if (options.onError) options.onError(error as any);
           }
         },
       });
@@ -235,7 +236,8 @@ export class GroqProvider implements LLMProvider<string> {
     } catch (error) {
       // Handle API errors
       console.error("Groq streaming API error:", error);
-      if (options.onError) options.onError(error);
+      // TODO: fix this
+      if (options.onError) options.onError(error as any);
       throw error;
     }
   }

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",
-    "@voltagent/core": "^0.1.6"
+    "@voltagent/core": "^0.1.8"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.10",
-    "@voltagent/core": "^0.1.6",
+    "@voltagent/core": "^0.1.8",
     "ai": "^4.2.11",
     "zod": "^3.24.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1049,7 +1049,7 @@ importers:
         specifier: ^2.49.4
         version: 2.49.4
       '@voltagent/core':
-        specifier: ^0.1.6
+        specifier: ^0.1.8
         version: link:../core
     devDependencies:
       '@types/jest':
@@ -1077,7 +1077,7 @@ importers:
         specifier: ^1.3.10
         version: 1.3.10(zod@3.24.2)
       '@voltagent/core':
-        specifier: ^0.1.6
+        specifier: ^0.1.8
         version: link:../core
       ai:
         specifier: ^4.2.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,9 +411,6 @@ importers:
       '@ai-sdk/mistral':
         specifier: ^1.2.7
         version: 1.2.7(zod@3.24.2)
-      '@ai-sdk/openai':
-        specifier: ^1.3.10
-        version: 1.3.10(zod@3.24.2)
       '@playwright/browser-chromium':
         specifier: 1.51.1
         version: 1.51.1
@@ -432,9 +429,6 @@ importers:
       '@voltagent/core':
         specifier: ^0.1.8
         version: link:../../packages/core
-      '@voltagent/groq-ai':
-        specifier: ^0.1.1
-        version: link:../../packages/groq-ai
       '@voltagent/vercel-ai':
         specifier: ^0.1.3
         version: link:../../packages/vercel-ai

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,64 @@ importers:
         specifier: ^5.8.2
         version: 5.8.2
 
+  examples/with-playwright:
+    dependencies:
+      '@ai-sdk/mistral':
+        specifier: ^1.2.7
+        version: 1.2.7(zod@3.24.2)
+      '@ai-sdk/openai':
+        specifier: ^1.3.10
+        version: 1.3.10(zod@3.24.2)
+      '@playwright/browser-chromium':
+        specifier: 1.51.1
+        version: 1.51.1
+      '@playwright/browser-firefox':
+        specifier: 1.51.1
+        version: 1.51.1
+      '@playwright/browser-webkit':
+        specifier: 1.51.1
+        version: 1.51.1
+      '@playwright/test':
+        specifier: ^1.51.1
+        version: 1.52.0
+      '@voltagent/cli':
+        specifier: ^0.1.3
+        version: link:../../packages/cli
+      '@voltagent/core':
+        specifier: ^0.1.8
+        version: link:../../packages/core
+      '@voltagent/groq-ai':
+        specifier: ^0.1.1
+        version: link:../../packages/groq-ai
+      '@voltagent/vercel-ai':
+        specifier: ^0.1.3
+        version: link:../../packages/vercel-ai
+      axios:
+        specifier: ^1.5.0
+        version: 1.8.4
+      playwright:
+        specifier: 1.51.1
+        version: 1.51.1
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.5
+        version: 22.14.0
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
+      tsx:
+        specifier: ^4.19.3
+        version: 4.19.3
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
+
   examples/with-rag-chatbot:
     dependencies:
       '@ai-sdk/openai':
@@ -1123,6 +1181,17 @@ importers:
 
 packages:
 
+  /@ai-sdk/mistral@1.2.7(zod@3.24.2):
+    resolution: {integrity: sha512-MbOMGfnHKcsvjbv4d6OT7Oaz+Wp4jD8yityqC4hASoKoW1s7L52woz25ES8RgAgTRlfbEZ3MOxEzLu58I228bQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.2)
+      zod: 3.24.2
+    dev: false
+
   /@ai-sdk/openai@1.3.10(zod@3.24.2):
     resolution: {integrity: sha512-XO0wF2lmAMWCYjkM5bLpWTKoXet61fBiIimTi+blqEGiLUjAvivt/1zZL1Lzhrv9+p19IC1rn9EWZI1dCelV8w==}
     engines: {node: '>=18'}
@@ -1158,6 +1227,18 @@ packages:
       zod: 3.24.2
     dev: false
 
+  /@ai-sdk/provider-utils@2.2.7(zod@3.24.2):
+    resolution: {integrity: sha512-kM0xS3GWg3aMChh9zfeM+80vEZfXzR3JEUBdycZLtbRZ2TRT8xOj3WodGHPb06sUK5yD7pAXC/P7ctsi2fvUGQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.8
+      secure-json-parse: 2.7.0
+      zod: 3.24.2
+    dev: false
+
   /@ai-sdk/provider@1.1.0:
     resolution: {integrity: sha512-0M+qjp+clUD0R1E5eWQFhxEvWLNaOtGQRUaBn8CUABnSKredagq92hUS9VjOzGsTm37xLfpaxl97AVtbeOsHew==}
     engines: {node: '>=18'}
@@ -1167,6 +1248,13 @@ packages:
 
   /@ai-sdk/provider@1.1.2:
     resolution: {integrity: sha512-ITdgNilJZwLKR7X5TnUr1BsQW6UTX5yFp0h66Nfx8XjBYkWD9W3yugr50GOz3CnE9m/U/Cd5OyEbTMI0rgi6ZQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      json-schema: 0.4.0
+    dev: false
+
+  /@ai-sdk/provider@1.1.3:
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
     dependencies:
       json-schema: 0.4.0
@@ -4476,6 +4564,38 @@ packages:
     dev: true
     optional: true
 
+  /@playwright/browser-chromium@1.51.1:
+    resolution: {integrity: sha512-Xebxk0SrDKttd8VGiUwLxOMbuH/Lf/+vFyzFG7QHVvqsAOw3Ec7Xdl1HRB4dnVP/RTEytkH4OgQ4OFy6K2c1xw==}
+    engines: {node: '>=18'}
+    requiresBuild: true
+    dependencies:
+      playwright-core: 1.51.1
+    dev: false
+
+  /@playwright/browser-firefox@1.51.1:
+    resolution: {integrity: sha512-F7RaES/0JtMafS5E4hdAWsvu01aalKOC6VSidklkoeDO5/duM3Ubl/C6eaBP+qHuwqZN/XGBxKHyYC3UoZwM8Q==}
+    engines: {node: '>=18'}
+    requiresBuild: true
+    dependencies:
+      playwright-core: 1.51.1
+    dev: false
+
+  /@playwright/browser-webkit@1.51.1:
+    resolution: {integrity: sha512-He51aydblwT1qx0IKI4hFgVlE7rQBayFaj5PQBLedrcDlMeoGOQsKVgqgo7/VsO7WHhDdJkkSuBoVXNyX7UodQ==}
+    engines: {node: '>=18'}
+    requiresBuild: true
+    dependencies:
+      playwright-core: 1.51.1
+    dev: false
+
+  /@playwright/test@1.52.0:
+    resolution: {integrity: sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.52.0
+    dev: false
+
   /@publint/pack@0.1.2:
     resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
     engines: {node: '>=18'}
@@ -5201,7 +5321,6 @@ packages:
 
   /@types/uuid@10.0.0:
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-    dev: false
 
   /@types/uuid@9.0.8:
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -5765,7 +5884,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: false
 
   /babel-jest@29.7.0(@babel/core@7.26.9):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -7958,6 +8076,14 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
+
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -11356,7 +11482,7 @@ packages:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
-      axios: 1.8.1
+      axios: 1.8.4
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
@@ -12007,6 +12133,38 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 3.0.0
+    dev: false
+
+  /playwright-core@1.51.1:
+    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dev: false
+
+  /playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dev: false
+
+  /playwright@1.51.1:
+    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.51.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
+  /playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.52.0
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: false
 
   /postcss-load-config@3.1.4:

--- a/website/docs/agents/context.md
+++ b/website/docs/agents/context.md
@@ -30,6 +30,83 @@ Common use cases include:
 4.  **Resource Management**: Store references to resources allocated in `onStart` (like database connections specific to the request) and release them in `onEnd`.
 5.  **Passing Data Between Hooks**: Set a value in `onStart` and retrieve it in `onEnd` for the same operation.
 
+### Advanced Use Case: Managing Playwright Browser Instances
+
+Another powerful use case for `userContext` is managing stateful resources that should be isolated per operation, such as a Playwright `Browser` or `Page` instance. This avoids the complexity of passing the instance explicitly between hooks and tools.
+
+**Scenario:** You want an agent to perform browser automation tasks using Playwright. Each agent operation should have its own isolated browser session.
+
+1.  **Initialization (in Tools or Hooks):** Instead of initializing the browser directly in `onStart`, you can create a helper function (e.g., `ensureBrowser`) that tools call. This function checks `userContext` first. If a `Page` instance for the current `operationId` doesn't exist, it launches Playwright, creates a `Page`, and stores it in `userContext` using a unique key (like a `Symbol`).
+2.  **Tool Access:** Tools needing browser access (e.g., `clickElement`, `navigateToUrl`) call the `ensureBrowser` helper, passing their `options.operationContext`. The helper retrieves the correct `Page` instance from `userContext`.
+3.  **Cleanup (`onEnd` Hook):** An `onEnd` hook retrieves the `Browser` instance from `userContext` using the operation's context and calls `browser.close()` to ensure resources are released when the operation finishes.
+
+```typescript
+// Simplified Example Structure
+import {
+  Agent,
+  createHooks,
+  createTool,
+  type OperationContext,
+  type ToolExecutionContext,
+} from "@voltagent/core";
+import { chromium, type Browser, type Page } from "playwright";
+
+const PAGE_KEY = Symbol("playwrightPage");
+const BROWSER_KEY = Symbol("playwrightBrowser");
+
+// Helper to get/create page within the context
+async function ensurePage(context: OperationContext): Promise<Page> {
+  let page = context.userContext.get(PAGE_KEY) as Page | undefined;
+  if (!page || page.isClosed()) {
+    console.log(`[${context.operationId}] Creating new browser/page for context...`);
+    const browser = await chromium.launch();
+    page = await browser.newPage();
+    context.userContext.set(BROWSER_KEY, browser); // Store browser for cleanup
+    context.userContext.set(PAGE_KEY, page);
+  }
+  return page;
+}
+
+// Hook for cleanup
+const hooks = createHooks({
+  onEnd: async (_agent, _result, context: OperationContext) => {
+    const browser = context.userContext.get(BROWSER_KEY) as Browser | undefined;
+    if (browser) {
+      console.log(`[${context.operationId}] Closing browser for context...`);
+      await browser.close();
+    }
+  },
+});
+
+// Example Tool
+const navigateTool = createTool({
+  name: "navigate",
+  parameters: z.object({ url: z.string().url() }),
+  execute: async ({ url }, options?: ToolExecutionContext) => {
+    if (!options?.operationContext) throw new Error("Context required");
+    const page = await ensurePage(options.operationContext); // Get page via context
+    await page.goto(url);
+    return `Navigated to ${url}`;
+  },
+});
+
+// Agent setup (LLM/Model details omitted)
+const browserAgent = new Agent({
+  name: "Browser Agent",
+  // ... llm, model ...
+  hooks: hooks,
+  tools: [navigateTool],
+});
+
+// Usage:
+// await browserAgent.generateText("Navigate to https://example.com");
+// await browserAgent.generateText("Navigate to https://google.com"); // Uses a *different* browser instance
+```
+
+This pattern ensures each `generateText` call gets its own clean browser environment managed via the isolated `userContext`.
+
+For a full implementation of this pattern, see the [VoltAgent Playwright Example](https://github.com/voltagent/voltagent/tree/main/examples/with-playwright).
+
 ## How it Works
 
 1.  **Initialization**: When an agent operation (e.g., `agent.generateText(...)`) begins, VoltAgent creates a unique `OperationContext`.

--- a/website/docs/agents/context.md
+++ b/website/docs/agents/context.md
@@ -1,0 +1,110 @@
+---
+title: Operation Context (userContext)
+slug: /agents/context
+description: Pass custom data through agent operations using userContext.
+---
+
+# Operation Context (`userContext`)
+
+VoltAgent provides a powerful mechanism called `userContext` to pass custom data through the lifecycle of a single agent operation (like a `generateText` or `streamObject` call). This context is isolated to each individual operation, ensuring that data doesn't leak between concurrent or subsequent requests.
+
+## What is `userContext`?
+
+`userContext` is a property within the `OperationContext` object. `OperationContext` itself encapsulates information about a specific agent task, including its unique ID (`operationId`), the associated history entry, and event tracking details.
+
+`userContext` is specifically a `Map<string | symbol, unknown>`.
+
+- **Map**: It allows you to store key-value pairs.
+- **Keys**: Can be strings or symbols, providing flexibility in how you identify your context data.
+- **Values**: Can be of `unknown` type, meaning you can store virtually any kind of data – strings, numbers, objects, custom class instances, etc.
+
+## Why Use `userContext`?
+
+`userContext` solves the problem of needing to maintain and access request-specific state or data across different parts of an agent's execution flow, particularly between lifecycle hooks and tool executions.
+
+Common use cases include:
+
+1.  **Tracing & Logging**: Propagate unique request IDs or trace IDs generated at the start (`onStart`) into tool executions for distributed tracing or detailed logging.
+2.  **Request-Specific Configuration**: Pass configuration details relevant only to the current operation (e.g., user preferences, tenant IDs) from `onStart` to tools.
+3.  **Metrics & Analytics**: Store timing information or other metrics in `onStart` and finalize/report them in `onEnd`.
+4.  **Resource Management**: Store references to resources allocated in `onStart` (like database connections specific to the request) and release them in `onEnd`.
+5.  **Passing Data Between Hooks**: Set a value in `onStart` and retrieve it in `onEnd` for the same operation.
+
+## How it Works
+
+1.  **Initialization**: When an agent operation (e.g., `agent.generateText(...)`) begins, VoltAgent creates a unique `OperationContext`.
+2.  **Empty Map**: Within this context, `userContext` is initialized as an empty `Map`.
+3.  **Access via Hooks**: The `OperationContext` (including `userContext`) is passed as an argument to the `onStart` and `onEnd` agent lifecycle hooks.
+4.  **Access via Tools**: The `OperationContext` is also accessible within a tool's `execute` function via the optional `options` parameter (specifically `options.operationContext`).
+5.  **Isolation**: Each call to an agent generation method (`generateText`, `streamText`, etc.) gets its own independent `OperationContext` and `userContext`. Data stored in one operation's `userContext` is not visible to others.
+
+## Usage Example
+
+This example demonstrates how to set context data in the `onStart` hook and access it in both the `onEnd` hook and within a tool's `execute` function.
+
+```typescript
+import {
+  Agent,
+  createHooks,
+  createTool,
+  type OperationContext,
+  type ToolExecutionContext,
+} from "@voltagent/core";
+import { z } from "zod";
+import { VercelAIProvider } from "@voltagent/vercel-ai";
+import { openai } from "@ai-sdk/openai";
+
+// Define hooks that set and retrieve data
+const hooks = createHooks({
+  onStart: (agent: Agent<any>, context: OperationContext) => {
+    // Set a unique request ID for this operation
+    const requestId = `req-${Date.now()}`;
+    context.userContext.set("requestId", requestId);
+    console.log(`[${agent.name}] Operation started. RequestID: ${requestId}`);
+  },
+  onEnd: (agent: Agent<any>, result: any, context: OperationContext) => {
+    // Retrieve the request ID at the end of the operation
+    const requestId = context.userContext.get("requestId");
+    console.log(`[${agent.name}] Operation finished. RequestID: ${requestId}`);
+    // Use this ID for logging, metrics, cleanup, etc.
+  },
+});
+
+// Define a tool that uses the context data set in onStart
+const customContextTool = createTool({
+  name: "custom_context_logger",
+  description: "Logs a message using the request ID from the user context.",
+  parameters: z.object({
+    message: z.string().describe("The message to log."),
+  }),
+  execute: async (params: { message: string }, options?: ToolExecutionContext) => {
+    // Access userContext via options.operationContext
+    const requestId = options?.operationContext?.userContext?.get("requestId") || "unknown-request";
+    const logMessage = `[RequestID: ${requestId}] Tool Log: ${params.message}`;
+    console.log(logMessage);
+    // In a real scenario, you might interact with external systems using this ID
+    return `Logged message with RequestID: ${requestId}`;
+  },
+});
+
+const agent = new Agent({
+  name: "MyCombinedAgent",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
+  tools: [customContextTool],
+  hooks: hooks,
+});
+
+// Trigger the agent.
+await agent.generateText(
+  "Log the following information using the custom logger: 'User feedback received.'"
+);
+
+// Console output will show logs from onStart, the tool (if called), and onEnd,
+```
+
+In this example:
+
+1.  The `onStart` hook generates a `requestId` and stores it in `userContext`.
+2.  If the LLM decides to use the `custom_context_logger` tool, the tool's `execute` function accesses the `requestId` from `userContext` via the `options.operationContext` provided to it.
+3.  The `onEnd` hook retrieves the same `requestId` from the context, demonstrating that the data persisted throughout the operation's lifecycle.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -29,6 +29,7 @@ const sidebars: SidebarsConfig = {
         "agents/providers",
         "agents/subagents",
         "agents/voice",
+        "agents/context",
       ],
     },
     {


### PR DESCRIPTION
This PR introduces the `userContext` feature to VoltAgent, providing a mechanism to pass custom, operation-specific data through the lifecycle of an agent execution (e.g., a single `generateText` call).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Previously, there was no clean, isolated way to share request-specific information (like tracing IDs, user configurations, temporary state) between agent lifecycle hooks (`onStart`, `onEnd`) and tool executions within the same operation without resorting to potentially unsafe or complex workarounds.

## What is the new behavior?

This PR implements `OperationContext`, which includes:
- A unique `operationId`.
- A `userContext: Map<string | symbol, unknown>` property.

This `OperationContext` is now accessible within:
- Agent hooks (`onStart`, `onEnd`).
- Tool `execute` functions via the `options` parameter (`options.operationContext`).

- **`@voltagent/core`:**
    - Added `OperationContext` type and integrated it into agent generation methods (`generateText`, `streamText`, etc.).
    - Passed `OperationContext` to hooks and tool execution contexts.
    - Implemented `serializeValueForDebug` utility (moved to `src/utils/serialization.ts`) to safely represent `userContext` (including complex types like functions, Symbols, classes) in history events.
    - Updated history event creation (`createStandardTimelineEvent`, `addToolEvent`) to include the serialized `userContext`.
    - Added unit tests for `serializeValueForDebug`.
- **`console`:**
    - Updated `ExecutionDrawer.tsx` in the debug UI to display the `userContext` associated with the selected timeline event, using the `JsonViewer`.
- **`website`:**
    - Added new documentation page `docs/agents/context.md` explaining the `userContext` feature with usage examples.
- **Utils:**
    - Created `packages/core/src/utils/serialization.ts` for the serialization logic.

closes 
- #70 
- #66

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
