### PR TITLE
refactor: replace 'description' with 'instructions' in Agent definitions

### DIFF
--- a/.changeset/whole-showers-walk.md
+++ b/.changeset/whole-showers-walk.md
@@ -1,0 +1,30 @@
+---
+"create-voltagent-app": patch
+"@voltagent/langfuse-exporter": patch
+"@voltagent/google-ai": patch
+"@voltagent/vercel-ai": patch
+"@voltagent/supabase": patch
+"@voltagent/groq-ai": patch
+"@voltagent/voice": patch
+"@voltagent/core": patch
+"@voltagent/xsai": patch
+"@voltagent/cli": patch
+---
+
+refactor: use 'instructions' field for Agent definitions in examples - #88
+
+Updated documentation examples (READMEs, docs, blogs) and relevant package code examples to use the `instructions` field instead of `description` when defining `Agent` instances.
+
+This change aligns the examples with the preferred API usage for the `Agent` class, where `instructions` provides behavioral guidance to the agent/LLM. This prepares for the eventual deprecation of the `description` field specifically for `Agent` class definitions.
+
+**Example Change for Agent Definition:**
+
+```diff
+  const agent = new Agent({
+    name: "My Assistant",
+-   description: "A helpful assistant.",
++   instructions: "A helpful assistant.",
+    llm: new VercelAIProvider(),
+    model: openai("gpt-4o-mini"),
+  });
+```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/examples/with-langfuse/src/index.ts
+++ b/examples/with-langfuse/src/index.ts
@@ -6,7 +6,7 @@ import { weatherTool, searchTool, checkCalendarTool, addCalendarEventTool } from
 
 const agent = new Agent({
   name: "Base Agent",
-  description: "You are a helpful assistant",
+  description: "s222ss",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: [weatherTool, searchTool, checkCalendarTool, addCalendarEventTool],

--- a/examples/with-langfuse/src/index.ts
+++ b/examples/with-langfuse/src/index.ts
@@ -6,7 +6,7 @@ import { weatherTool, searchTool, checkCalendarTool, addCalendarEventTool } from
 
 const agent = new Agent({
   name: "Base Agent",
-  description: "s222ss",
+  instructions: "You are a helpful assistant",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: [weatherTool, searchTool, checkCalendarTool, addCalendarEventTool],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,7 +100,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -42,7 +42,7 @@
   // Define your agent(s)
   const agent = new Agent({
     name: "my-voltagent-app",
-    description: "A helpful assistant that answers questions without using tools",
+    instructions: "A helpful assistant that answers questions without using tools",
     llm: new VercelAIProvider(),
     model: openai("gpt-4o-mini"),
   });
@@ -461,7 +461,6 @@
   const webInfoToolkit = createToolkit({
     name: "web_information",
     description: "Tools for getting information from the web.",
-    instructions: "Use these tools to find current information online.",
     addInstructions: true, // Add the instructions to the system prompt
     tools: [getWeather, searchWeb],
   });
@@ -524,7 +523,7 @@
 
   const agent = new Agent({
     name: "MyThinkingAgent",
-    description: "An agent equipped with reasoning tools.",
+    instructions: "An agent equipped with reasoning tools.",
     llm: new VercelAIProvider(),
     model: openai("gpt-4o-mini"),
     tools: [reasoningToolkit], // Pass the toolkit

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -100,7 +100,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/packages/core/src/agent/hooks/index.spec.ts
+++ b/packages/core/src/agent/hooks/index.spec.ts
@@ -124,6 +124,7 @@ describe("Agent Hooks Functionality", () => {
       };
       const errorAgent = new Agent({
         name: "ErrorAgent",
+        instructions: "Error agent",
         llm: errorProvider as any,
         model: "mock-error-model",
         hooks: createHooks({ onEnd: onEndSpy }),

--- a/packages/core/src/agent/index.spec.ts
+++ b/packages/core/src/agent/index.spec.ts
@@ -358,6 +358,7 @@ describe("Agent", () => {
       memory: mockMemory,
       memoryOptions: {},
       tools: [],
+      instructions: "A helpful AI assistant",
     });
   });
 
@@ -367,6 +368,7 @@ describe("Agent", () => {
         name: "Default Agent",
         model: mockModel,
         llm: mockProvider,
+        instructions: "A helpful AI assistant",
       });
 
       expect(defaultAgent.id).toBeDefined();
@@ -389,6 +391,30 @@ describe("Agent", () => {
       expect(customAgent.name).toBe("Custom Agent");
       expect(customAgent.instructions).toBe("Custom description");
       expect(customAgent.llm).toBe(mockProvider);
+    });
+
+    it("should use description for instructions if instructions property is not provided", () => {
+      const agentWithDesc = new TestAgent({
+        name: "Agent With Description Only",
+        description: "Uses provided description",
+        model: mockModel,
+        llm: mockProvider,
+        // instructions property is intentionally omitted
+      });
+      expect(agentWithDesc.instructions).toBe("Uses provided description");
+      expect(agentWithDesc.description).toBe("Uses provided description"); // Verifying this.description is also updated
+    });
+
+    it("should use instructions if both instructions and description are provided", () => {
+      const agentWithBoth = new TestAgent({
+        name: "Agent With Both Properties",
+        instructions: "Uses provided instructions",
+        description: "This description should be ignored",
+        model: mockModel,
+        llm: mockProvider,
+      });
+      expect(agentWithBoth.instructions).toBe("Uses provided instructions");
+      expect(agentWithBoth.description).toBe("Uses provided instructions"); // Verifying this.description is also updated
     });
   });
 
@@ -709,6 +735,7 @@ describe("Agent", () => {
         name: "New Agent",
         model: mockModel,
         llm: mockProvider,
+        instructions: "A helpful AI assistant",
       });
 
       // Register the agent through AgentRegistry
@@ -722,6 +749,7 @@ describe("Agent", () => {
         name: "New Agent",
         model: mockModel,
         llm: mockProvider,
+        instructions: "A helpful AI assistant",
       });
 
       newAgent.unregister();
@@ -792,6 +820,7 @@ describe("Agent", () => {
         name: "Error Stream Agent",
         model: mockModel,
         llm: errorProvider,
+        instructions: "Error Stream Agent instructions",
       });
 
       await expect(errorAgent.streamText("Hello")).rejects.toThrow("Stream error");
@@ -805,6 +834,7 @@ describe("Agent", () => {
         name: "Error Object Stream Agent",
         model: mockModel,
         llm: errorProvider,
+        instructions: "Error Object Stream Agent instructions",
       });
 
       const schema = z.object({
@@ -851,6 +881,7 @@ describe("Agent", () => {
         llm: mockProvider,
         // Use any type to bypass type checking for the mock retriever
         retriever: mockRetriever as any,
+        instructions: "Retriever Test Agent instructions",
       });
 
       // Generate text to trigger retriever
@@ -879,6 +910,7 @@ describe("Agent", () => {
         llm: mockProvider,
         // Use any type to bypass type checking for the mock retriever
         retriever: errorRetriever as any,
+        instructions: "Error Retriever Test Agent instructions",
       });
 
       // Generate text should still work despite retriever error
@@ -904,6 +936,7 @@ describe("Agent", () => {
         llm: mockProvider,
         // Use any type to bypass type checking for the mock retriever
         retriever: mockRetriever as any,
+        instructions: "State Retriever Test Agent instructions",
       });
 
       // Get full state
@@ -928,6 +961,7 @@ describe("Agent", () => {
         model: mockModel,
         llm: mockProvider,
         hooks: createHooks({ onStart: onStartSpy }),
+        instructions: "Context Test Agent instructions",
       });
 
       await agentWithHook.generateText("test initialization");
@@ -952,6 +986,7 @@ describe("Agent", () => {
         model: mockModel,
         llm: mockProvider,
         hooks: createHooks({ onStart: onStartSpy, onEnd: onEndSpy }),
+        instructions: "Hook Context Agent instructions",
       });
 
       await agentWithHooks.generateText("test hooks");
@@ -990,6 +1025,7 @@ describe("Agent", () => {
         llm: mockProvider,
         // Pass the updated hooks
         hooks: createHooks({ onStart: onStartHook, onEnd: onEndHook }),
+        instructions: "Modify Context Agent instructions",
       });
 
       await agentWithModifyHooks.generateText("test modification");
@@ -1025,6 +1061,7 @@ describe("Agent", () => {
         tools: [mockTool],
         // Pass the updated hook
         hooks: createHooks({ onStart: onStartHook }),
+        instructions: "Tool Context Agent instructions",
       });
 
       // Need to trigger the tool
@@ -1095,6 +1132,7 @@ describe("Agent", () => {
         llm: mockProvider,
         // Pass the updated hooks
         hooks: createHooks({ onStart: onStartHook, onEnd: onEndHook }),
+        instructions: "Isolation Test Agent instructions",
       });
 
       // Run operations sequentially to ensure isolation

--- a/packages/core/src/agent/index.spec.ts
+++ b/packages/core/src/agent/index.spec.ts
@@ -371,7 +371,7 @@ describe("Agent", () => {
 
       expect(defaultAgent.id).toBeDefined();
       expect(defaultAgent.name).toBe("Default Agent");
-      expect(defaultAgent.description).toBe("A helpful AI assistant");
+      expect(defaultAgent.instructions).toBe("A helpful AI assistant");
       expect(defaultAgent.model).toBe(mockModel);
       expect(defaultAgent.llm).toBe(mockProvider);
     });
@@ -380,14 +380,14 @@ describe("Agent", () => {
       const customAgent = new TestAgent({
         id: "custom-id",
         name: "Custom Agent",
-        description: "Custom description",
+        instructions: "Custom description",
         model: mockModel,
         llm: mockProvider,
       });
 
       expect(customAgent.id).toBe("custom-id");
       expect(customAgent.name).toBe("Custom Agent");
-      expect(customAgent.description).toBe("Custom description");
+      expect(customAgent.instructions).toBe("Custom description");
       expect(customAgent.llm).toBe(mockProvider);
     });
   });
@@ -633,7 +633,7 @@ describe("Agent", () => {
       // Check basic properties
       expect(state.id).toBe(agent.id);
       expect(state.name).toBe(agent.name);
-      expect(state.description).toBe(agent.description);
+      expect(state.description).toBe(agent.instructions);
       expect(state.node_id).toBe(`agent_${agent.id}`);
 
       // Check tools property

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -62,9 +62,14 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
   readonly name: string;
 
   /**
-   * Agent description
+   * @deprecated Use `instructions` instead. Will be removed in a future version.
    */
   readonly description: string;
+
+  /**
+   * Agent instructions. This is the preferred field over `description`.
+   */
+  readonly instructions: string;
 
   /**
    * The LLM provider to use
@@ -120,7 +125,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
    * Create a new agent
    */
   constructor(
-    options: Omit<AgentOptions, "provider" | "model"> &
+    options: AgentOptions &
       TProvider & {
         model: ModelType<TProvider>;
         subAgents?: Agent<any>[]; // Keep any for now
@@ -133,7 +138,8 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
   ) {
     this.id = options.id || options.name;
     this.name = options.name;
-    this.description = options.description || "A helpful AI assistant";
+    this.instructions = options.instructions ?? options.description ?? "A helpful AI assistant";
+    this.description = this.instructions;
     this.llm = options.llm as ProviderInstance<TProvider>;
     this.model = options.model;
     this.retriever = options.retriever;
@@ -176,7 +182,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
     historyEntryId: string;
     contextMessages: BaseMessage[];
   }): Promise<BaseMessage> {
-    let baseDescription = this.description || ""; // Ensure baseDescription is a string
+    let baseInstructions = this.instructions || ""; // Ensure baseInstructions is a string
 
     // --- Add Instructions from Toolkits --- (Simplified Logic)
     let toolInstructions = "";
@@ -191,16 +197,16 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       }
     }
     if (toolInstructions) {
-      baseDescription = `${baseDescription}${toolInstructions}`;
+      baseInstructions = `${baseInstructions}${toolInstructions}`;
     }
     // --- End Add Instructions from Toolkits ---
 
     // Add Markdown Instruction if Enabled
     if (this.markdown) {
-      baseDescription = `${baseDescription}\n\nUse markdown to format your answers.`;
+      baseInstructions = `${baseInstructions}\n\nUse markdown to format your answers.`;
     }
 
-    let description = baseDescription;
+    let finalInstructions = baseInstructions;
 
     // If retriever exists and we have input, get context
     if (this.retriever && input && historyEntryId) {
@@ -226,7 +232,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       try {
         const context = await this.retriever.retrieve(input);
         if (context?.trim()) {
-          description = `${description}\n\nRelevant Context:\n${context}`;
+          finalInstructions = `${finalInstructions}\n\nRelevant Context:\n${context}`;
 
           // Update the event
           eventUpdater({
@@ -256,17 +262,20 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       const agentsMemory = await this.prepareAgentsMemory(contextMessages);
 
       // Generate the supervisor message with the agents memory inserted
-      description = this.subAgentManager.generateSupervisorSystemMessage(description, agentsMemory);
+      finalInstructions = this.subAgentManager.generateSupervisorSystemMessage(
+        finalInstructions,
+        agentsMemory,
+      );
 
       return {
         role: "system",
-        content: description,
+        content: finalInstructions,
       };
     }
 
     return {
       role: "system",
-      content: `You are ${this.name}. ${description}`,
+      content: `You are ${this.name}. ${finalInstructions}`,
     };
   }
 
@@ -484,6 +493,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       id: this.id,
       name: this.name,
       description: this.description,
+      instructions: this.instructions,
       status: "idle",
       model: this.getModelName(),
       // Create a node representing this agent

--- a/packages/core/src/agent/subagent/index.spec.ts
+++ b/packages/core/src/agent/subagent/index.spec.ts
@@ -122,12 +122,12 @@ describe("SubAgentManager", () => {
       const subAgentAgent1 = {
         id: "agent1",
         name: "Agent 1",
-        description: "First agent",
+        instructions: "First agent",
       } as Agent<any>;
       const subAgentAgent2 = {
         id: "agent2",
         name: "Agent 2",
-        description: "Second agent",
+        instructions: "Second agent",
       } as Agent<any>;
 
       const subAgentManager = new SubAgentManager("TestAgent", [subAgentAgent1, subAgentAgent2]);

--- a/packages/core/src/agent/subagent/index.ts
+++ b/packages/core/src/agent/subagent/index.ts
@@ -86,13 +86,13 @@ export class SubAgentManager {
    * @param baseDescription - The base description of the agent
    * @param agentsMemory - Optional string containing formatted memory from previous agent interactions
    */
-  public generateSupervisorSystemMessage(baseDescription: string, agentsMemory = ""): string {
+  public generateSupervisorSystemMessage(baseInstructions: string, agentsMemory = ""): string {
     if (this.subAgents.length === 0) {
-      return baseDescription;
+      return baseInstructions;
     }
 
     const subAgentList = this.subAgents
-      .map((agent) => `- ${agent.name}: ${agent.description}`)
+      .map((agent) => `- ${agent.name}: ${agent.instructions}`)
       .join("\n");
 
     return `
@@ -103,7 +103,7 @@ ${subAgentList}
 </specialized_agents>
 
 <instructions>
-${baseDescription}
+${baseInstructions}
 </instructions>
 
 <guidelines>

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -62,11 +62,6 @@ export type AgentOptions = {
   name: string;
 
   /**
-   * Agent description
-   */
-  description?: string;
-
-  /**
    * Memory storage for the agent (optional)
    * Set to false to explicitly disable memory
    */
@@ -86,7 +81,31 @@ export type AgentOptions = {
    * Sub-agents that this agent can delegate tasks to
    */
   subAgents?: any[]; // Using any to avoid circular dependency
-};
+} & (
+  | {
+      /**
+       * @deprecated Use `instructions` instead.
+       * Agent description (deprecated, use instructions)
+       */
+      description: string;
+      /**
+       * Agent instructions. This is the preferred field.
+       */
+      instructions?: string;
+    }
+  | {
+      /**
+       * @deprecated Use `instructions` instead.
+       * Agent description (deprecated, use instructions)
+       */
+      description?: undefined; // Ensure description is treated as absent
+      /**
+       * Agent instructions. This is the preferred field.
+       * Required if description is not provided.
+       */
+      instructions: string;
+    }
+);
 
 /**
  * Provider instance type helper

--- a/packages/create-voltagent-app/README.md
+++ b/packages/create-voltagent-app/README.md
@@ -100,7 +100,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/packages/create-voltagent-app/templates/base/index.ts.template
+++ b/packages/create-voltagent-app/templates/base/index.ts.template
@@ -5,7 +5,7 @@ import { openai } from "@ai-sdk/openai";
 
 const agent = new Agent({
   name: "{{projectName}}",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: [],

--- a/packages/google-ai/README.md
+++ b/packages/google-ai/README.md
@@ -117,7 +117,7 @@ const googleProvider = new GoogleGenAIProvider({
 // Create an agent using a Google model
 const agent = new Agent({
   name: "Google Assistant",
-  description: "A helpful and friendly assistant that can answer questions clearly and concisely.",
+  instructions: "A helpful and friendly assistant that can answer questions clearly and concisely.",
   llm: googleProvider,
   model: "gemini-1.5-pro-latest", // Specify the desired Google model
 });
@@ -174,7 +174,7 @@ const googleVertexProvider = new GoogleGenAIProvider({
 
 const agent = new Agent({
   name: "Google Assistant",
-  description: "A helpful and friendly assistant that can answer questions clearly and concisely.",
+  instructions: "A helpful and friendly assistant that can answer questions clearly and concisely.",
   llm: googleProvider,
   model: "gemini-1.5-pro-latest", // Specify the desired Google model
 });

--- a/packages/groq-ai/README.md
+++ b/packages/groq-ai/README.md
@@ -24,7 +24,7 @@ import { GroqProvider } from "@voltagent/groq-ai";
 
 const agent = new Agent({
   name: "finance",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   llm: new GroqProvider(),
   model: "meta-llama/llama-4-scout-17b-16e-instruct",
 });

--- a/packages/langfuse-exporter/CHANGELOG.md
+++ b/packages/langfuse-exporter/CHANGELOG.md
@@ -34,7 +34,7 @@
   // Define your agent(s)
   const agent = new Agent({
     name: "my-voltagent-app",
-    description: "A helpful assistant that answers questions without using tools",
+    instructions: "A helpful assistant that answers questions without using tools",
     llm: new VercelAIProvider(),
     model: openai("gpt-4o-mini"),
   });

--- a/packages/langfuse-exporter/README.md
+++ b/packages/langfuse-exporter/README.md
@@ -144,7 +144,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/packages/supabase/README.md
+++ b/packages/supabase/README.md
@@ -166,6 +166,8 @@ const memory = new SupabaseMemory({
 
 // Pass the memory instance to your Agent
 const agent = new Agent({
+  name: "my-agent",
+  instructions: "A helpful assistant that answers questions without using tools",
   // ... other agent config
   memory: memory,
 });
@@ -231,7 +233,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/packages/vercel-ai/README.md
+++ b/packages/vercel-ai/README.md
@@ -100,7 +100,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -100,7 +100,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/packages/xsai/README.md
+++ b/packages/xsai/README.md
@@ -100,7 +100,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/website/blog/2025-04-21-first-ai-agent-github-repo-analyzer/index.md
+++ b/website/blog/2025-04-21-first-ai-agent-github-repo-analyzer/index.md
@@ -115,7 +115,7 @@ const mockFetchRepoContributorsTool = {
 // 1. Create the stars fetcher agent
 const starsFetcherAgent = new Agent({
   name: "StarsFetcher",
-  description: "Fetches the number of stars for a GitHub repository using a tool.",
+  instructions: "Fetches the number of stars for a GitHub repository using a tool.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: [mockFetchRepoStarsTool], // Use the mock tool
@@ -124,7 +124,7 @@ const starsFetcherAgent = new Agent({
 // 2. Create the contributors fetcher agent
 const contributorsFetcherAgent = new Agent({
   name: "ContributorsFetcher",
-  description: "Fetches the list of contributors for a GitHub repository using a tool.",
+  instructions: "Fetches the list of contributors for a GitHub repository using a tool.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: [mockFetchRepoContributorsTool], // Use the mock tool
@@ -133,7 +133,7 @@ const contributorsFetcherAgent = new Agent({
 // 3. Create the analyzer agent (no tools needed)
 const analyzerAgent = new Agent({
   name: "RepoAnalyzer",
-  description: "Analyzes repository statistics (stars, contributors) and provides insights.",
+  instructions: "Analyzes repository statistics (stars, contributors) and provides insights.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   // This agent doesn't need tools; it processes data provided by the supervisor.
@@ -142,7 +142,7 @@ const analyzerAgent = new Agent({
 // 4. Create the supervisor agent that coordinates all the sub-agents
 const supervisorAgent = new Agent({
   name: "Supervisor",
-  description: `You are a GitHub repository analyzer. When given a GitHub repository URL or owner/repo format, you will:
+  instructions: `You are a GitHub repository analyzer. When given a GitHub repository URL or owner/repo format, you will:
 1. Extract the owner/repo name.
 2. Use the StarsFetcher agent to get the repository's star count.
 3. Use the ContributorsFetcher agent to get the repository's contributors.

--- a/website/blog/2025-04-23-multi-agent-llm/index.md
+++ b/website/blog/2025-04-23-multi-agent-llm/index.md
@@ -71,7 +71,7 @@ Remember, these are just starting points. Ultimately, I recommend experimenting.
 
 I've found VoltAgent to be an effective tool for creating AI agents, and I can develop multiple agents simply using its **Supervisor Agents** and **Subagents**.
 
-1. **Define Agents:** First, I define my subagents that specialize in a particular task (e.g., "Story Writer" agent, "Translator" agent). An agent consists of a name, description (instructions), and the LLM it uses.
+1. **Define Agents:** First, I define my subagents that specialize in a particular task (e.g., "Story Writer" agent, "Translator" agent). An agent consists of a name, instructions, and the LLM it uses.
 2. **Build the Supervisor:** Second, I build the supervisor agent that will manage these subagents. In defining the supervisor, I simply specify which subagents it will manage using the `subAgents` parameter.
 3. **Automatic Installation:** What I like is that whenever I install a supervisor agent, VoltAgent automatically configures the following in the background:
 
@@ -116,16 +116,16 @@ import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { openai } from "@ai-sdk/openai";
 
 // 1. Create Subagents
-const storyWriter = new Agent({
-  name: "Story Writer",
-  description: "You are an expert at writing creative and engaging short stories.",
+const storyAgent = new Agent({
+  name: "Story Agent",
+  instructions: "You are an expert at writing creative and engaging short stories.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
 });
 
-const translator = new Agent({
-  name: "Translator",
-  description: "You are a skilled translator, proficient in translating text accurately.",
+const translatorAgent = new Agent({
+  name: "Translator Agent",
+  instructions: "You are a skilled translator, proficient in translating text accurately.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
 });
@@ -133,14 +133,14 @@ const translator = new Agent({
 // 2. Create the Supervisor Agent (linking subagents)
 const supervisorAgent = new Agent({
   name: "Supervisor Agent",
-  description:
-    "You manage workflows between specialized agents. " +
-    "When asked for a story, use the Story Writer. " +
-    "Then, use the Translator to translate the story. Present both versions to the user.",
+  instructions:
+    "You manage a workflow between specialized agents. When asked for a story, " +
+    "use the Story Agent. Then, use the Translator Agent to translate the story. " +
+    "Present both versions to the user.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   // Connect the subagents here
-  subAgents: [storyWriter, translator],
+  subAgents: [storyAgent, translatorAgent],
 });
 
 new VoltAgent({
@@ -184,7 +184,7 @@ Inside the console:
 
 ![Multi-Agent LLM Example](https://cdn.voltagent.dev/2025-04-23-multi-agent-llm/multi-agent-llm-demo.gif)
 
-The Supervisor Agent then executed the workflow: it first delegated the story writing task to the `Story Writer` subagent, then delegated the translation task to the `Translator` subagent, and finally presented both results in the chat interface. I found that VoltAgent handled all the background coordination automatically.
+The Supervisor Agent then executed the workflow: it first delegated the story writing task to the `Story Agent` subagent, then delegated the translation task to the `Translator Agent` subagent, and finally presented both results in the chat interface. I found that VoltAgent handled all the background coordination automatically.
 
 ## My Final Thoughts
 

--- a/website/blog/2025-04-24-rag-chatbot/index.md
+++ b/website/blog/2025-04-24-rag-chatbot/index.md
@@ -176,11 +176,11 @@ class KnowledgeBaseRetriever extends BaseRetriever {
 const knowledgeRetriever = new KnowledgeBaseRetriever();
 
 // Define the agent that uses the retriever directly
-const ragAgent = new Agent({
-  name: "RAG Chatbot",
-  description: "A chatbot that answers questions based on its internal knowledge base.",
-  llm: new VercelAIProvider(), // Using Vercel AI SDK Provider
-  model: openai("gpt-4o-mini"), // Using OpenAI model via Vercel
+const simpleAgent = new Agent({
+  name: "Simple Assistant",
+  instructions: "A chatbot that answers questions based on its internal knowledge base.",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o-mini"),
   // Attach the retriever directly
   retriever: knowledgeRetriever,
 });
@@ -189,8 +189,8 @@ const ragAgent = new Agent({
 
 new VoltAgent({
   agents: {
-    // Make the agent available under the key 'ragAgent'
-    ragAgent,
+    // Make the agent available under the key 'simpleAgent'
+    simpleAgent,
   },
 });
 ```
@@ -198,12 +198,12 @@ new VoltAgent({
 **Code Breakdown:**
 
 - **`KnowledgeBaseRetriever`:** Extends `BaseRetriever`. It holds a small array of `documents`. The `retrieve` method performs a simple case-insensitive search. If it finds matches, it formats them into a string prefixed with "Relevant Information Found:"; otherwise, it returns a "not found" message.
-- **`ragAgent`:** An `Agent` instance.
-  - We give it a name and description.
+- **`simpleAgent`:** An `Agent` instance.
+  - We give it a name and instructions.
   - We configure the `llm` provider and `model`.
   - Crucially, we set `retriever: knowledgeRetriever`. This tells VoltAgent to automatically run our retriever before calling the LLM.
-  - The `systemPrompt` is important here. It explicitly tells the LLM to base its answers _only_ on the "Relevant Information Found" (which our retriever provides) and what to do if no information is found. This helps prevent the LLM from falling back on its general knowledge.
-- **`new VoltAgent(...)`:** Initializes the VoltAgent server and registers our `ragAgent`.
+  - The `instructions` is important here. It explicitly tells the LLM to base its answers _only_ on the "Relevant Information Found" (which our retriever provides) and what to do if no information is found. This helps prevent the LLM from falling back on its general knowledge.
+- **`new VoltAgent(...)`:** Initializes the VoltAgent server and registers our `simpleAgent`.
 
 ### Running the Agent
 
@@ -284,7 +284,7 @@ You should see the VoltAgent server startup message, including a link to the Dev
 Now for the fun part!
 
 1.  **Open Console:** Go to [`https://console.voltagent.dev`](https://console.voltagent.dev) in your browser.
-2.  **Find Agent:** You should see your "RAG Chatbot" listed. Click on it.
+2.  **Find Agent:** You should see your "Simple Assistant" listed. Click on it.
 3.  **Chat:** Click the chat icon (usually bottom-right) to open the chat window.
 4.  **Ask Questions:** Try asking questions related to the `documents` in our retriever:
     - `What is VoltAgent?` (Should use doc1)

--- a/website/blog/2025-04-25-what-is-an-mcp-server/index.md
+++ b/website/blog/2025-04-25-what-is-an-mcp-server/index.md
@@ -153,10 +153,9 @@ const mcpConfig = new MCPConfiguration({
   },
 });
 
-const agent = new Agent({
+const mcpAgent = new Agent({
   name: "MCP Filesystem Agent",
-  description:
-    "I am an agent that can read and write files inside a specific 'data' directory, using tools provided by an MCP server.",
+  instructions: "You can interact with the local filesystem. List files, read files, write files.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: await mcpConfig.getTools(),
@@ -164,7 +163,7 @@ const agent = new Agent({
 
 new VoltAgent({
   agents: {
-    fsAgent: agent,
+    fsAgent: mcpAgent,
   },
 });
 ```
@@ -176,7 +175,7 @@ new VoltAgent({
   - `command: "npx"` specifies _how_ to run it.
   - `args: [...]` provides the details: the MCP server package (`@modelcontextprotocol/server-filesystem`) and, crucially, `path.resolve("./data")`. This locks the server down, only allowing it to see inside a `./data` folder within my project. **I had to remember to actually create this `data` folder later (`mkdir data`)!** This is super important for security.
 - **`Agent` Definition:** I created my `Agent` instance. The key part is `tools: await mcpConfig.getTools()`. This line tells VoltAgent: "Go connect to all the servers I defined in `mcpConfig`, find out what tools they offer (like `readFile`, `writeFile` from the filesystem server), and make those tools available for this agent's LLM to use."
-- **`VoltAgent` Initialization:** I started the main VoltAgent server and registered my `agent` under the key `fsAgent`. This key is how I'll select it in the VoltAgent Console.
+- **`VoltAgent` Initialization:** I started the main VoltAgent server and registered my `mcpAgent` under the key `fsAgent`. This key is how I'll select it in the VoltAgent Console.
 
 #### Running the Agent
 

--- a/website/blog/2025-04-26-peaka-mcp-voltagent/index.md
+++ b/website/blog/2025-04-26-peaka-mcp-voltagent/index.md
@@ -97,8 +97,8 @@ const mcp = new MCPConfiguration({
 
   // 3. Create our actual chatbot agent
   const agent = new Agent({
-    name: "Peaka Data Assistant",
-    description: "I can look things up in Peaka's data.",
+    name: "Peaka Data Agent",
+    instructions: "I can look things up in Peaka's data.",
     llm: new VercelAIProvider(), // Which AI service to use
     model: openai("gpt-4o-mini"), // Which specific AI brain
     tools, // <-- Super important! Give the agent the tools from Peaka!

--- a/website/docs/agents/context.md
+++ b/website/docs/agents/context.md
@@ -150,12 +150,10 @@ const hooks = createHooks({
 });
 
 // Define a tool that uses the context data set in onStart
-const customContextTool = createTool({
-  name: "custom_context_logger",
-  description: "Logs a message using the request ID from the user context.",
-  parameters: z.object({
-    message: z.string().describe("The message to log."),
-  }),
+const loggerTool = createTool({
+  name: "context_aware_logger",
+  description: "Logs a message using the request ID from context.",
+  parameters: z.object({ message: z.string() }),
   execute: async (params: { message: string }, options?: ToolExecutionContext) => {
     // Access userContext via options.operationContext
     const requestId = options?.operationContext?.userContext?.get("requestId") || "unknown-request";
@@ -170,7 +168,7 @@ const agent = new Agent({
   name: "MyCombinedAgent",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
-  tools: [customContextTool],
+  tools: [loggerTool],
   hooks: hooks,
 });
 

--- a/website/docs/agents/hooks.md
+++ b/website/docs/agents/hooks.md
@@ -104,7 +104,7 @@ const provider = new VercelAIProvider();
 // Assign the hooks when creating an agent
 const agentWithHooks = new Agent({
   name: "My Agent with Hooks",
-  description: "An assistant demonstrating hooks",
+  instructions: "An assistant demonstrating hooks",
   llm: provider,
   model: openai("gpt-4o"),
   // Pass the hooks object during initialization
@@ -114,7 +114,7 @@ const agentWithHooks = new Agent({
 // Alternatively, define hooks inline (less reusable)
 const agentWithInlineHooks = new Agent({
   name: "Inline Hooks Agent",
-  description: "Another assistant",
+  instructions: "Another assistant",
   llm: provider,
   model: openai("gpt-4o"),
   hooks: {

--- a/website/docs/agents/mcp.md
+++ b/website/docs/agents/mcp.md
@@ -155,8 +155,8 @@ import { openai } from "@ai-sdk/openai";
 const allTools = await mcpConfig.getTools();
 
 const agent = new Agent({
-  name: "MCP-enabled Assistant",
-  description: "An assistant that can use MCP tools configured at startup",
+  name: "MCP Aware Agent",
+  instructions: "An assistant that can use MCP tools configured at startup",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   tools: allTools, // Add MCP tools during initialization

--- a/website/docs/agents/memory/in-memory.md
+++ b/website/docs/agents/memory/in-memory.md
@@ -34,7 +34,7 @@ const memory = new InMemoryStorage({
 
 const agent = new Agent({
   name: "Ephemeral Agent",
-  description: "An agent using in-memory storage (history resets on restart).",
+  instructions: "An agent using in-memory storage (history resets on restart).",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   memory: memory, // Assign the InMemoryStorage instance

--- a/website/docs/agents/memory/libsql.md
+++ b/website/docs/agents/memory/libsql.md
@@ -48,7 +48,7 @@ const memoryStorage = new LibSQLStorage({
 
 const agent = new Agent({
   name: "LibSQL Memory Agent",
-  description: "An agent using LibSQL for memory.",
+  instructions: "An agent using LibSQL for memory.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   memory: memoryStorage,

--- a/website/docs/agents/memory/overview.md
+++ b/website/docs/agents/memory/overview.md
@@ -31,7 +31,7 @@ import { openai } from "@ai-sdk/openai";
 
 const agent = new Agent({
   name: "My Assistant",
-  description: "This agent automatically uses local file memory.",
+  instructions: "This agent automatically uses local file memory.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   // No memory provider specified - uses default LibSQLStorage to .voltagent/memory.db
@@ -47,7 +47,7 @@ You can completely disable memory persistence and retrieval by setting the `memo
 ```ts
 const agent = new Agent({
   name: "Stateless Assistant",
-  description: "This agent has no memory.",
+  instructions: "This agent has no memory.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   memory: false, // Memory completely disabled

--- a/website/docs/agents/memory/supabase.md
+++ b/website/docs/agents/memory/supabase.md
@@ -172,7 +172,7 @@ const memory = new SupabaseMemory({
 
 const agent = new Agent({
   name: "Supabase Memory Agent",
-  description: "An agent using Supabase for memory.",
+  instructions: "An agent using Supabase for memory.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   memory: memory, // Assign the memory provider instance

--- a/website/docs/agents/overview.md
+++ b/website/docs/agents/overview.md
@@ -11,8 +11,6 @@ The `Agent` class is the fundamental building block of VoltAgent. It acts as the
 
 At its core, an agent needs a name, instructions (which guides its behavior), an LLM Provider to handle communication with an AI model, and the specific model to use.
 
-**Note: The `description` field for `Agent` is deprecated and will be removed in a future version. Please use `instructions` instead.**
-
 ```ts
 import { Agent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai"; // Handles communication

--- a/website/docs/agents/overview.md
+++ b/website/docs/agents/overview.md
@@ -9,7 +9,9 @@ The `Agent` class is the fundamental building block of VoltAgent. It acts as the
 
 ## Creating an Agent
 
-At its core, an agent needs a name, a description (which guides its behavior), an LLM Provider to handle communication with an AI model, and the specific model to use.
+At its core, an agent needs a name, instructions (which guides its behavior), an LLM Provider to handle communication with an AI model, and the specific model to use.
+
+**Note: The `description` field for `Agent` is deprecated and will be removed in a future version. Please use `instructions` instead.**
 
 ```ts
 import { Agent } from "@voltagent/core";
@@ -18,7 +20,7 @@ import { openai } from "@ai-sdk/openai"; // Defines the specific model source
 
 const agent = new Agent({
   name: "My Assistant",
-  description: "A helpful and friendly assistant that can answer questions clearly and concisely.",
+  instructions: "A helpful and friendly assistant that can answer questions clearly and concisely.",
   // The LLM Provider acts as the bridge to the AI service
   llm: new VercelAIProvider(),
   // The model specifies which AI model to use (e.g., from OpenAI via Vercel AI SDK)
@@ -46,7 +48,7 @@ import { z } from "zod";
 // Example Tool (see Tools section for details)
 const weatherTool = createTool({
   name: "get_weather",
-  description: "Get the current weather for a specific location",
+  instructions: "Get the current weather for a specific location",
   parameters: z.object({ location: z.string().describe("City and state") }),
   execute: async ({ location }) => {
     console.log(`Tool: Getting weather for ${location}`);
@@ -57,7 +59,7 @@ const weatherTool = createTool({
 
 const agent = new Agent({
   name: "Chat Assistant",
-  description: "A helpful assistant that can check the weather.",
+  instructions: "A helpful assistant that can check the weather.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   tools: [weatherTool],
@@ -95,7 +97,7 @@ import { openai } from "@ai-sdk/openai";
 
 const agent = new Agent({
   name: "Markdown Assistant",
-  description: "A helpful assistant that formats answers clearly.",
+  instructions: "A helpful assistant that formats answers clearly.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   markdown: true, // Enable automatic Markdown formatting
@@ -124,7 +126,7 @@ import { z } from "zod";
 
 const agent = new Agent({
   name: "Data Extractor",
-  description: "Extracts structured data.",
+  instructions: "Extracts structured data.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"), // Ensure model supports structured output/function calling
 });
@@ -203,7 +205,7 @@ import { z } from "zod";
 // Create a weather tool using the helper function
 const weatherTool = createTool({
   name: "get_weather",
-  description: "Get the current weather for a specific location",
+  instructions: "Get the current weather for a specific location",
   parameters: z.object({
     location: z.string().describe("The city and state, e.g., San Francisco, CA"),
   }),
@@ -221,7 +223,7 @@ const weatherTool = createTool({
 
 const agent = new Agent({
   name: "Weather Assistant",
-  description: "An assistant that can check the weather using available tools.",
+  instructions: "An assistant that can check the weather using available tools.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"), // Models supporting tool use are required
   tools: [weatherTool], // Provide the list of tools to the agent
@@ -253,7 +255,7 @@ const writingAgent = new Agent({ name: "Writer" /* ... */ });
 // Create a coordinator agent that uses the others
 const mainAgent = new Agent({
   name: "Coordinator",
-  description: "Coordinates research and writing tasks by delegating to specialized sub-agents.",
+  instructions: "Coordinates research and writing tasks by delegating to specialized sub-agents.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   // List the agents this one can delegate tasks to
@@ -326,7 +328,7 @@ const hooks = createHooks({
 
 const agent = new Agent({
   name: "Observable Agent",
-  description: "An agent with logging hooks.",
+  instructions: "An agent with logging hooks.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   hooks, // Attach the defined hooks
@@ -367,7 +369,7 @@ const hooks = createHooks({
 
 const loggerTool = createTool({
   name: "context_aware_logger",
-  description: "Logs a message using the request ID from context.",
+  instructions: "Logs a message using the request ID from context.",
   parameters: z.object({ message: z.string() }),
   execute: async (params: { message: string }, options?: ToolExecutionContext) => {
     const requestId = options?.operationContext?.userContext?.get("requestId") || "unknown";
@@ -379,7 +381,7 @@ const loggerTool = createTool({
 
 const agent = new Agent({
   name: "Context Agent",
-  description: "Uses userContext.",
+  instructions: "Uses userContext.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   hooks: hooks,
@@ -435,7 +437,7 @@ class SimpleRetriever extends BaseRetriever {
 // Create agent with the retriever
 const agent = new Agent({
   name: "Knowledge Assistant",
-  description: "An assistant that uses retrieved documents to answer questions.",
+  instructions: "An assistant that uses retrieved documents to answer questions.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   retriever: new SimpleRetriever(), // Add the retriever instance
@@ -475,7 +477,7 @@ import { anthropic } from "@ai-sdk/anthropic"; // Model definition for Anthropic
 // Agent using OpenAI via Vercel
 const vercelOpenAIAgent = new Agent({
   name: "Vercel OpenAI Assistant",
-  description: "Assistant using Vercel AI SDK with OpenAI.",
+  instructions: "Assistant using Vercel AI SDK with OpenAI.",
   llm: new VercelAIProvider(), // The provider
   model: openai("gpt-4o"), // The specific model
 });
@@ -483,7 +485,7 @@ const vercelOpenAIAgent = new Agent({
 // Agent using Anthropic via Vercel
 const vercelAnthropicAgent = new Agent({
   name: "Vercel Anthropic Assistant",
-  description: "Assistant using Vercel AI SDK with Anthropic.",
+  instructions: "Assistant using Vercel AI SDK with Anthropic.",
   llm: new VercelAIProvider(), // Same provider
   model: anthropic("claude-3-5-sonnet-20240620"), // Different model
 });
@@ -494,7 +496,7 @@ import { XsAIProvider } from "@voltagent/xsai";
 // Agent using XsAI Provider (might use different model naming)
 const xsaiAgent = new Agent({
   name: "XsAI Assistant",
-  description: "Assistant using XsAI Provider.",
+  instructions: "Assistant using XsAI Provider.",
   llm: new XsAIProvider({ apiKey: process.env.OPENAI_API_KEY }), // Provider instance
   model: "xsai-model-name", // Model identifier specific to this provider
 });
@@ -522,7 +524,7 @@ import { openai } from "@ai-sdk/openai";
 
 const agent = new Agent({
   name: "Configurable Assistant",
-  description: "An assistant with configurable generation parameters",
+  instructions: "An assistant with configurable generation parameters",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
 });
@@ -604,7 +606,7 @@ const mcpTools = await mcpConfig.getTools();
 // Create an agent that can utilize these external MCP tools
 const agent = new Agent({
   name: "MCP Agent",
-  description: "Uses external model capabilities via MCP",
+  instructions: "Uses external model capabilities via MCP",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   // Add the tools fetched from the MCP server
@@ -667,7 +669,7 @@ await pipeline(elAudioStream, createWriteStream("elevenlabs_output.mp3"));
 
 const agent = new Agent({
   name: "Voice Assistant",
-  description: "A helpful voice assistant",
+  instructions: "A helpful voice assistant",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   // Assign a voice provider instance to the agent's voice property

--- a/website/docs/agents/providers.md
+++ b/website/docs/agents/providers.md
@@ -43,7 +43,7 @@ const myProvider = new VercelAIProvider();
 // 3. Create the Agent, passing the provider and model ID
 const agent = new Agent({
   name: "My Configured Agent",
-  description: "An agent ready to interact via the specified provider",
+  instructions: "An agent ready to interact via the specified provider",
   llm: myProvider, // Assign the provider instance
   model: openai("gpt-4o-mini"), // Pass the model object from Vercel AI SDK
 });

--- a/website/docs/agents/retriever.md
+++ b/website/docs/agents/retriever.md
@@ -83,7 +83,7 @@ const provider = new VercelAIProvider();
 // Create an agent and attach the retriever directly
 const agent = new Agent({
   name: "RAG Assistant",
-  description: "A helpful assistant with access to document knowledge",
+  instructions: "A helpful assistant with access to document knowledge",
   llm: provider,
   model: openai("gpt-4o"),
   // Attach the retriever instance directly
@@ -133,10 +133,10 @@ const provider = new VercelAIProvider();
 
 // Create an agent and add the retriever as a tool
 const agent = new Agent({
-  name: "Tool-using Assistant",
-  description: "A helpful assistant that can search internal docs when needed",
-  llm: provider,
-  model: openai("gpt-4o"), // Ensure model supports tool use
+  name: "Selective Assistant",
+  instructions: "A helpful assistant that can search internal docs when needed",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
   // Add the retriever's tool interface to the tools array
   // highlight-next-line
   tools: [retrieverAsTool.tool],

--- a/website/docs/agents/subagents.md
+++ b/website/docs/agents/subagents.md
@@ -29,7 +29,7 @@ import { openai } from "@ai-sdk/openai";
 // Create a specialized agent for writing stories
 const storyAgent = new Agent({
   name: "Story Agent",
-  description: "You are a creative story writer. Create original, engaging short stories.",
+  instructions: "You are a creative story writer. Create original, engaging short stories.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
 });
@@ -37,7 +37,7 @@ const storyAgent = new Agent({
 // Create a specialized agent for translation
 const translatorAgent = new Agent({
   name: "Translator Agent",
-  description: "You are a skilled translator. Translate text accurately.",
+  instructions: "You are a skilled translator. Translate text accurately.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
 });
@@ -55,7 +55,7 @@ import { openai } from "@ai-sdk/openai";
 // Create a supervisor agent with specialized agents as subagents
 const supervisorAgent = new Agent({
   name: "Supervisor Agent",
-  description: "You manage a workflow between specialized agents.",
+  instructions: "You manage a workflow between specialized agents.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   // Specify subagents during initialization
@@ -121,14 +121,14 @@ import { openai } from "@ai-sdk/openai";
 // Create specialized agents
 const storyAgent = new Agent({
   name: "Story Agent",
-  description: "You are a creative story writer. Create original, engaging short stories.",
+  instructions: "You are a creative story writer. Create original, engaging short stories.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
 });
 
 const translatorAgent = new Agent({
   name: "Translator Agent",
-  description: "You are a skilled translator. Translate text accurately.",
+  instructions: "You are a skilled translator. Translate text accurately.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
 });
@@ -136,7 +136,7 @@ const translatorAgent = new Agent({
 // Create the supervisor agent
 const supervisorAgent = new Agent({
   name: "Supervisor Agent",
-  description:
+  instructions:
     "You manage a workflow between specialized agents. When asked for a story, " +
     "use the Story Agent to create it. Then use the Translator Agent to translate the story. " +
     "Present both versions to the user.",
@@ -168,7 +168,7 @@ import { openai } from "@ai-sdk/openai";
 // Create a supervisor agent with hooks for monitoring subagent interactions
 const supervisorAgent = new Agent({
   name: "Supervisor Agent",
-  description: "You manage a workflow between specialized agents.",
+  instructions: "You manage a workflow between specialized agents.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   subAgents: [storyAgent, translatorAgent],
@@ -208,7 +208,7 @@ import { openai } from "@ai-sdk/openai";
 // Create a new specialized agent
 const factCheckerAgent = new Agent({
   name: "Fact Checker Agent",
-  description: "You verify facts and provide accurate information.",
+  instructions: "You verify facts and provide accurate information.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
 });

--- a/website/docs/agents/tools.md
+++ b/website/docs/agents/tools.md
@@ -414,7 +414,6 @@ const agent = new Agent({
   name: "Dynamic Assistant",
   description: "An assistant that can gain new abilities",
   llm: new VercelAIProvider(),
-  model: openai("gpt-4o"),
 });
 
 // Later, add tools to the agent

--- a/website/docs/agents/voice.md
+++ b/website/docs/agents/voice.md
@@ -213,7 +213,7 @@ const provider = new OpenAIAgentProvider({
 // Create the agent, passing the voice instance
 const voiceEnabledAgent = new Agent({
   name: "VoiceBot",
-  description: "An agent that can speak.",
+  instructions: "An agent that can speak.",
   provider,
   model: "gpt-4o", // Choose an appropriate model
   voice: voice, // Assign the voice provider here

--- a/website/docs/getting-started/overview.md
+++ b/website/docs/getting-started/overview.md
@@ -32,7 +32,7 @@ import { openai } from "@ai-sdk/openai";
 
 const agent = new Agent({
   name: "my-voltagent-app",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
 });

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -213,7 +213,7 @@ import { openai } from "@ai-sdk/openai"; // Example model
 // Define a simple agent
 const agent = new Agent({
   name: "my-agent",
-  description: "A helpful assistant that answers questions without using tools",
+  instructions: "A helpful assistant that answers questions without using tools",
   // Note: You can swap VercelAIProvider and openai with other supported providers/models
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),

--- a/website/docs/observability/langfuse.md
+++ b/website/docs/observability/langfuse.md
@@ -56,17 +56,16 @@ When creating your main `VoltAgent` instance, pass the configured `langfuseExpor
 
 ```typescript
 // Define your agent(s)
-const myAgent = new Agent({
-  name: "My Assistant",
-  description: "A helpful assistant that answers questions without using tools",
+const agent = new Agent({
+  name: "my-voltagent-app",
+  instructions: "A helpful assistant that answers questions without using tools",
   llm: new VercelAIProvider(),
-  model: openai("gpt-4o-mini"),
 });
 
 // Initialize VoltAgent with the exporter
 new VoltAgent({
   agents: {
-    myAgent, // Register your agent(s)
+    agent, // Register your agent(s)
   },
   // highlight-next-line
   telemetryExporter: langfuseExporter, // Pass the exporter instance

--- a/website/docs/providers/anthropic-ai.md
+++ b/website/docs/providers/anthropic-ai.md
@@ -67,7 +67,7 @@ const anthropicProvider = new AnthropicProvider({ apiKey: "YOUR_ANTHROPIC_API_KE
 
 const agent = new Agent({
   name: "Claude Agent",
-  description: "An agent powered by Claude",
+  instructions: "An agent powered by Claude",
   llm: anthropicProvider,
   model: "claude-3-sonnet-20240229", // Specify the desired Claude model
 });
@@ -115,7 +115,7 @@ const weatherTool = createTool({
 
 const agent = new Agent({
   name: "weather-agent",
-  description: "A helpful weather assistant",
+  instructions: "A helpful weather assistant",
   llm: new AnthropicProvider(),
   model: "claude-3-sonnet-20240229",
   tools: [weatherTool],

--- a/website/docs/providers/google-ai.md
+++ b/website/docs/providers/google-ai.md
@@ -97,7 +97,7 @@ const googleProvider = new GoogleGenAIProvider({ apiKey: "YOUR_GEMINI_API_KEY" }
 
 const agent = new Agent({
   name: "Google Gemini Agent",
-  description: "An agent powered by Google Gemini",
+  instructions: "An agent powered by Google Gemini",
   llm: googleProvider,
   model: "gemini-1.5-flash", // Specify the desired Google model ID
 });
@@ -170,7 +170,7 @@ async function main() {
 
   const agent = new Agent({
     name: "Google Text Agent",
-    description: "Generates text using Google AI",
+    instructions: "Generates text using Google AI",
     llm: googleProvider,
     model: "gemini-1.5-flash",
   });
@@ -203,7 +203,7 @@ async function main() {
 
   const agent = new Agent({
     name: 'Google Streaming Agent',
-    description: 'Streams text using Google AI',
+    instructions: 'Streams text using Google AI',
     llm: googleProvider,
     model: 'gemini-1.5-flash',
   });
@@ -253,7 +253,7 @@ async function main() {
   // Ensure the model supports function calling/JSON mode
   const agent = new Agent({
     name: "Google Object Agent",
-    description: "Generates structured data using Google AI",
+    instructions: "Generates structured data using Google AI",
     llm: googleProvider,
     model: "gemini-1.5-pro", // Models like Pro are generally better for structured output
   });

--- a/website/docs/providers/groq-ai.md
+++ b/website/docs/providers/groq-ai.md
@@ -70,19 +70,19 @@ For a complete, runnable example demonstrating the use of this provider, please 
 Instantiate your `Agent` with the configured `GroqProvider`:
 
 ```typescript
-import { Agent } from '@voltagent/core';
-import { GroqProvider } from '@voltagent/groq-ai';
+import { Agent } from "@voltagent/core";
+import { GroqProvider } from "@voltagent/groq-ai";
 
 // Using environment variable configuration from above
 const groqProvider = new GroqProvider();
 
 const agent = new Agent({
-  name: 'Groq Speed Agent',
-  description: 'An agent powered by Groq's fast inference',
+  name: "Groq Speed Agent",
+  instructions: "An agent powered by Groq's fast inference",
   llm: groqProvider,
   // Specify the desired Groq model ID (e.g., Llama3, Mixtral)
   // Find available models: https://console.groq.com/docs/models
-  model: 'llama3-8b-8192',
+  model: "llama3-8b-8192",
 });
 
 // Example call
@@ -152,7 +152,7 @@ async function main() {
 
   const agent = new Agent({
     name: "Groq Text Agent",
-    description: "Generates text using Groq AI",
+    instructions: "Generates text using Groq AI",
     llm: groqProvider,
     model: "mixtral-8x7b-32768", // Example model
   });
@@ -187,7 +187,7 @@ async function main() {
 
   const agent = new Agent({
     name: "Groq Streaming Agent",
-    description: "Streams text using Groq AI",
+    instructions: "Streams text using Groq AI",
     llm: groqProvider,
     model: "llama3-8b-8192", // Example model
   });
@@ -238,7 +238,7 @@ async function main() {
   // Use a model supporting JSON mode
   const agent = new Agent({
     name: "Groq Object Agent",
-    description: "Generates structured data using Groq AI",
+    instructions: "Generates structured data using Groq AI",
     llm: groqProvider,
     model: "llama3-70b-8192",
   });

--- a/website/docs/providers/vercel-ai.md
+++ b/website/docs/providers/vercel-ai.md
@@ -62,7 +62,7 @@ const vercelProvider = new VercelProvider();
 
 const agent = new Agent({
   name: "Vercel Chat Agent",
-  description: "An agent powered by models via Vercel AI SDK",
+  instructions: "An agent powered by models via Vercel AI SDK",
   llm: vercelProvider,
   model: openai("gpt-4o"),
 });
@@ -119,7 +119,7 @@ const openAIAgent = new Agent({
   id: "openai-agent",
   llm: new VercelProvider(),
   model: openai("gpt-4o"),
-  description: "Uses OpenAI",
+  instructions: "Uses OpenAI",
 });
 
 // Example: Agent configured with Anthropic model
@@ -127,7 +127,7 @@ const anthropicAgent = new Agent({
   id: "anthropic-agent",
   llm: new VercelProvider(),
   model: anthropic("claude-3-sonnet-20240229"),
-  description: "Uses Anthropic",
+  instructions: "Uses Anthropic",
 });
 
 // Example: Using generateText with the configured agent
@@ -157,7 +157,7 @@ async function main() {
 
   const agent = new Agent({
     name: "Simple Vercel Agent",
-    description: "A simple agent powered by Vercel AI SDK",
+    instructions: "A simple agent powered by Vercel AI SDK",
     llm: vercelProvider,
     model: openai("gpt-4o-mini"),
   });
@@ -188,7 +188,7 @@ async function main() {
 
   const agent = new Agent({
     name: "Vercel Streaming Agent",
-    description: "A streaming agent powered by Vercel AI SDK",
+    instructions: "A streaming agent powered by Vercel AI SDK",
     llm: vercelProvider,
     model: anthropic("claude-3-haiku-20240307"),
   });
@@ -232,7 +232,7 @@ async function main() {
   // Ensure the model supports object generation (e.g., gpt-4o)
   const agent = new Agent({
     name: "Vercel Object Agent",
-    description: "An agent that generates structured data via Vercel AI SDK",
+    instructions: "An agent that generates structured data via Vercel AI SDK",
     llm: vercelProvider,
     model: openai("gpt-4o"),
   });
@@ -278,7 +278,7 @@ async function main() {
   // Ensure the model supports object streaming (e.g., gpt-4o)
   const agent = new Agent({
     name: "Vercel Object Streaming Agent",
-    description: "An agent that streams structured data via Vercel AI SDK",
+    instructions: "An agent that streams structured data via Vercel AI SDK",
     llm: vercelProvider,
     model: openai("gpt-4o"),
   });

--- a/website/docs/providers/xsai.md
+++ b/website/docs/providers/xsai.md
@@ -86,7 +86,7 @@ const xsaiProvider = new XsAIProvider({ apiKey: process.env.OPENAI_API_KEY! });
 
 const agent = new Agent({
   name: "Compatible Agent",
-  description: "An agent using an OpenAI-compatible API via xsAI",
+  instructions: "An agent using an OpenAI-compatible API via xsAI",
   llm: xsaiProvider,
   // Model identifier specific to the target API (e.g., OpenAI, Groq, local)
   model: "gpt-4o-mini",
@@ -166,7 +166,7 @@ async function main() {
 
   const agent = new Agent({
     name: "xsAI Text Agent",
-    description: "Generates text using an OpenAI-compatible API",
+    instructions: "Generates text using an OpenAI-compatible API",
     llm: provider,
     model: "gpt-4o-mini",
   });
@@ -198,7 +198,7 @@ async function main() {
 
   const agent = new Agent({
     name: "xsAI Streaming Agent",
-    description: "Streams text using an OpenAI-compatible API",
+    instructions: "Streams text using an OpenAI-compatible API",
     llm: provider,
     model: "gpt-4o-mini",
   });
@@ -240,7 +240,7 @@ async function main() {
 
   const agent = new Agent({
     name: "xsAI Object Agent",
-    description: "Generates structured objects",
+    instructions: "Generates structured objects",
     llm: provider,
     model: "gpt-4o", // Use a model known for good JSON output
   });
@@ -280,7 +280,7 @@ async function main() {
 
   const agent = new Agent({
     name: "xsAI Object Streaming Agent",
-    description: "Streams structured objects",
+    instructions: "Streams structured objects",
     llm: provider,
     model: "gpt-4o",
   });

--- a/website/docs/tools/overview.md
+++ b/website/docs/tools/overview.md
@@ -41,7 +41,7 @@ const getWeatherTool = createTool({
 
 const agent = new Agent({
   name: "WeatherAgent",
-  description: "An agent that can fetch weather information.",
+  instructions: "An agent that can fetch weather information.",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: [getWeatherTool], // Add the tool to the agent
@@ -98,7 +98,7 @@ import { Agent, createTool, createToolkit, type Toolkit } from "@voltagent/core"
 
 const agent = new Agent({
     name: "MultiToolAgent",
-    description: "An agent with various tools and toolkits.",
+    instructions: "An agent with various tools and toolkits.",
     llm: /* ... */,
     model: /* ... */,
     tools: [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
Previously, the `Agent` class could be defined using a `description` field to provide behavioral guidance. However, this could sometimes create ambiguity with the `description` field. While both `description` and `instructions` might have been usable on the `Agent` class, this wasn't always clear in examples.


## What is the new behavior?

To provide clearer and more specific guidance for `Agent` behavior, the `instructions` field is now the **primary and preferred** way to define an Agent's operational directives and personality.

Consequently, the `description` field on the `Agent` class itself is now considered **deprecated** in favor of `instructions`. Developers should use the `instructions` field for all new `Agent` definitions and are encouraged to migrate existing `Agent` definitions from `description` to `instructions`.

All documentation examples (READMEs, docs, blogs) and relevant package code examples have been updated to:
1.  Use the `instructions` field for `Agent` class definitions.
2.  Mention in the `Agent` overview documentation that the `description` field for `Agent` is deprecated and `instructions` should be used.

This change promotes clearer API usage and ensures that `Agent` behavior is distinctly defined through the `instructions` field.

fixes (issue)
- #88 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
