### PR TITLE
feat: enhance userContext management in Agent operations

### DIFF
--- a/.changeset/crazy-bugs-scream.md
+++ b/.changeset/crazy-bugs-scream.md
@@ -1,0 +1,71 @@
+---
+"@voltagent/core": patch
+---
+
+feat: Enhanced Operation Context (`userContext`) with Initialization and Propagation
+
+We've significantly improved how you can manage and pass custom data through agent operations using `userContext`.
+
+**Key Enhancements:**
+
+1.  **Direct Object & Typed Context:** `userContext` is no longer a `Map`. It's now a direct generic object (`TContext`), defaulting to `Record<string, any>`. This allows for better type safety and a more natural way to work with your context data.
+
+    ```typescript
+    // Old way (Map-based, less type-safe for structure)
+    // context.userContext.set("userId", "user-123");
+    // const userId = context.userContext.get("userId");
+
+    // New way (Direct object, typed)
+    type MyOperationContext = { userId?: string; traceId?: string };
+    // context: OperationContext<MyOperationContext>
+    // context.userContext.userId = "user-123";
+    // const userId = context.userContext.userId;
+    ```
+
+2.  **Initialization with `initialUserContext`:** You can now provide an initial state for an operation's `userContext` directly when calling agent generation methods (e.g., `generateText`, `streamObject`).
+
+    ```typescript
+    type CallSpecificContext = {
+      correlationId: string;
+      userId: string;
+      featureFlags?: Record<string, boolean>;
+    };
+
+    const agent = new Agent({
+      /* ... */
+    });
+
+    const initialDataForOperation: CallSpecificContext = {
+      correlationId: `cid-${Date.now()}`,
+      userId: "user-456",
+      featureFlags: { newUIAvailable: true },
+    };
+
+    // Pass initial context when starting an operation
+    await agent.generateText<CallSpecificContext>("Process this request.", {
+      initialUserContext: initialDataForOperation,
+    });
+    // Inside hooks or tools, operationContext.userContext will be pre-populated
+    // with initialDataForOperation and will be of type CallSpecificContext.
+    ```
+
+3.  **Automatic Propagation to Sub-Agents:** When using a supervisor-subagent hierarchy, the `initialUserContext` provided to the supervisor (or its current `userContext`) is now automatically propagated to sub-agents when tasks are delegated via the `delegate_task` tool.
+
+    - The supervisor's `userContext` is passed as `supervisorUserContext` during handoff.
+    - This becomes the `initialUserContext` for the sub-agent's operation.
+    - This is great for passing down global IDs like `correlationId` or `sessionId` through the entire agent chain.
+
+    ```typescript
+    // Supervisor starts with a correlationId
+    // await supervisor.generateText<MyTraceContext>(
+    //   "Delegate analysis for project X.",
+    //   { initialUserContext: { correlationId: "global-trace-id-123" } }
+    // );
+
+    // SubAgent's onStart hook can access this:
+    // onStart: ({ context }: OnStartHookArgs<MyTraceContext>) => {
+    //   console.log(context.userContext.correlationId); // "global-trace-id-123"
+    // }
+    ```
+
+These changes offer a more robust, type-safe, and developer-friendly way to manage and utilize operation-specific context data across your agent's lifecycle and hierarchies. Check out the updated [`Operation Context`](http://localhost:3000/docs/agents/context/) documentation for detailed examples!

--- a/examples/github-repo-analyzer/src/index.ts
+++ b/examples/github-repo-analyzer/src/index.ts
@@ -1,15 +1,8 @@
-import { VoltAgent, Agent, createHooks } from "@voltagent/core";
-import type { OperationContext } from "@voltagent/core";
+import { VoltAgent, Agent, createTool, createHooks } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 import { openai } from "@ai-sdk/openai";
-import { fetchRepoContributorsTool, fetchRepoStarsTool } from "./tools";
-
-// Define a type for our user context for better type safety
-interface MyUserContext {
-  correlationId?: string;
-  userId?: string;
-  someOtherData?: any;
-}
+import { fetchRepoContributorsTool } from "./tools";
+import { fetchRepoStarsTool } from "./tools";
 
 // Create the stars fetcher agent
 const starsFetcherAgent = new Agent({
@@ -18,23 +11,6 @@ const starsFetcherAgent = new Agent({
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: [fetchRepoStarsTool],
-  hooks: createHooks({
-    onStart: async ({
-      agent,
-      context,
-    }: { agent: Agent<any>; context: OperationContext<MyUserContext> }) => {
-      console.log(`
---- StarsFetcherAgent (${agent.id}) onStart ---`);
-      console.log("  Received userContext:", JSON.stringify(context.userContext, null, 2));
-      if (context.userContext?.correlationId) {
-        console.log("  >>> Correlation ID from supervisor:", context.userContext.correlationId);
-      }
-      if (context.userContext?.userId) {
-        console.log("  >>> User ID from supervisor:", context.userContext.userId);
-      }
-      console.log("---");
-    },
-  }),
 });
 
 // Create the contributors fetcher agent
@@ -44,20 +20,6 @@ const contributorsFetcherAgent = new Agent({
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
   tools: [fetchRepoContributorsTool],
-  hooks: createHooks({
-    onStart: async ({
-      agent,
-      context,
-    }: { agent: Agent<any>; context: OperationContext<MyUserContext> }) => {
-      console.log(`
---- ContributorsFetcherAgent (${agent.id}) onStart ---`);
-      console.log("  Received userContext:", JSON.stringify(context.userContext, null, 2));
-      if (context.userContext?.correlationId) {
-        console.log("  >>> Correlation ID from supervisor:", context.userContext.correlationId);
-      }
-      console.log("---");
-    },
-  }),
 });
 
 // Create the analyzer agent
@@ -66,20 +28,6 @@ const analyzerAgent = new Agent({
   description: "Analyzes repository statistics and provides insights",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o-mini"),
-  hooks: createHooks({
-    onStart: async ({
-      agent,
-      context,
-    }: { agent: Agent<any>; context: OperationContext<MyUserContext> }) => {
-      console.log(`
---- RepoAnalyzerAgent (${agent.id}) onStart ---`);
-      console.log("  Received userContext:", JSON.stringify(context.userContext, null, 2));
-      if (context.userContext?.correlationId) {
-        console.log("  >>> Correlation ID from supervisor:", context.userContext.correlationId);
-      }
-      console.log("---");
-    },
-  }),
 });
 
 // Create the supervisor agent that coordinates all the sub-agents
@@ -103,40 +51,3 @@ new VoltAgent({
     supervisorAgent,
   },
 });
-
-// --- Example Usage of Context Passing ---
-async function main() {
-  console.log("\nStarting GitHub Repo Analyzer example with context passing...");
-
-  const repoUrl = "voltagent/core"; // Example repository
-  const initialContext: MyUserContext = {
-    correlationId: `corr-${Date.now()}`,
-    userId: "user-example-123",
-    someOtherData: { info: "Passed from main execution" },
-  };
-
-  try {
-    console.log(`
-Attempting to analyze repo: ${repoUrl}`);
-    console.log(
-      "Initial context being passed to supervisor:",
-      JSON.stringify(initialContext, null, 2),
-    );
-
-    // Pass the generic type MyUserContext to generateText
-    const response = await supervisorAgent.generateText<MyUserContext>(
-      `Analyze the GitHub repository: ${repoUrl}`,
-      {
-        initialUserContext: initialContext,
-      },
-    );
-
-    console.log("\n--- Supervisor Agent Final Response ---");
-    console.log(response.text);
-    console.log("---");
-  } catch (error) {
-    console.error("\nError during example execution:", error);
-  }
-}
-
-main();

--- a/packages/core/src/agent/subagent/index.spec.ts
+++ b/packages/core/src/agent/subagent/index.spec.ts
@@ -1,6 +1,6 @@
 import { SubAgentManager } from "./index";
 import type { Agent } from "../index";
-import type { AgentHandoffOptions } from "../types";
+import type { AgentHandoffOptions, OperationContext } from "../types";
 
 // Creating a Mock Agent class
 class MockAgent {
@@ -144,47 +144,70 @@ describe("SubAgentManager", () => {
   });
 
   describe("handoffTask", () => {
-    it("should handoff task to target agent", async () => {
-      // Spy on generateText
+    it("should handoff task to target agent and pass supervisorUserContext as initialUserContext", async () => {
+      const generateTextSpy = jest.spyOn(mockAgent1, "generateText");
+      const supervisorContext = { supervisorKey: "supervisorValue" };
+      type SupervisorContextType = typeof supervisorContext;
+
+      const options: AgentHandoffOptions<SupervisorContextType> = {
+        task: "Solve this math problem with supervisor context",
+        targetAgent: mockAgent1,
+        sharedContext: [],
+        supervisorUserContext: supervisorContext,
+      };
+
+      const result = await subAgentManager.handoffTask<SupervisorContextType>(options);
+
+      expect(generateTextSpy).toHaveBeenCalled();
+      const generateTextCallArgs = generateTextSpy.mock.calls[0];
+      const messages = generateTextCallArgs[0] as any[];
+      const genOptions = generateTextCallArgs[1] as any;
+
+      expect(messages[0].role).toBe("system");
+      expect(messages[0].content).toContain("Task handed off from Main Agent to Math Agent");
+      expect(genOptions.initialUserContext).toEqual(supervisorContext);
+      expect(genOptions.initialUserContext?.supervisorKey).toBe("supervisorValue");
+
+      expect(result.result).toBe("Response from Math Agent");
+      expect(result.messages.length).toBe(2);
+    });
+
+    it("should handoff task without supervisorUserContext if not provided", async () => {
       const generateTextSpy = jest.spyOn(mockAgent1, "generateText");
 
       const options: AgentHandoffOptions = {
         task: "Solve this math problem",
         targetAgent: mockAgent1,
-        context: { problem: "2+2" },
         sharedContext: [],
       };
 
-      const result = await subAgentManager.handoffTask(options);
+      await subAgentManager.handoffTask(options);
 
-      // Verify generateText was called with handoff message
       expect(generateTextSpy).toHaveBeenCalled();
-      const messages = generateTextSpy.mock.calls[0][0] as any[];
-      expect(messages[0].role).toBe("system");
-      expect(messages[0].content).toContain("Task handed off from Main Agent to Math Agent");
-
-      // Verify result
-      expect(result.result).toBe("Response from Math Agent");
-      expect(result.messages.length).toBe(2);
+      const genOptions = generateTextSpy.mock.calls[0][1] as any;
+      expect(genOptions.initialUserContext).toBeUndefined();
     });
   });
 
   describe("handoffToMultiple", () => {
-    it("should handoff task to multiple target agents", async () => {
+    it("should handoff task to multiple target agents and pass supervisorUserContext", async () => {
       const handoffTaskSpy = jest.spyOn(subAgentManager, "handoffTask");
+      const supervisorContext = { multiHandoffKey: "multiValue" };
+      type MultiContextType = typeof supervisorContext;
 
       const options = {
-        task: "Process this request",
+        task: "Process this request with context",
         targetAgents: [mockAgent1, mockAgent2],
-        context: { data: "test data" },
+        supervisorUserContext: supervisorContext,
       };
 
-      await subAgentManager.handoffToMultiple(options);
+      await subAgentManager.handoffToMultiple<MultiContextType>(options);
 
-      // Verify handoffTask was called for each agent
       expect(handoffTaskSpy).toHaveBeenCalledTimes(2);
       expect(handoffTaskSpy.mock.calls[0][0].targetAgent).toBe(mockAgent1);
+      expect(handoffTaskSpy.mock.calls[0][0].supervisorUserContext).toEqual(supervisorContext);
       expect(handoffTaskSpy.mock.calls[1][0].targetAgent).toBe(mockAgent2);
+      expect(handoffTaskSpy.mock.calls[1][0].supervisorUserContext).toEqual(supervisorContext);
     });
   });
 
@@ -195,7 +218,6 @@ describe("SubAgentManager", () => {
       expect(tool.name).toBe("delegate_task");
       expect(tool.description).toContain("Delegate a task");
 
-      // Verify parameters
       const params = (tool.parameters as any).shape;
       expect(params.task).toBeDefined();
       expect(params.targetAgents).toBeDefined();
@@ -205,7 +227,6 @@ describe("SubAgentManager", () => {
     it("should throw error when executing with no valid agents", async () => {
       const tool = subAgentManager.createDelegateTool();
 
-      // Attempt to execute with non-existent agents
       await expect(
         tool.execute({
           task: "Test task",
@@ -218,52 +239,161 @@ describe("SubAgentManager", () => {
       });
     });
 
-    it("should execute and return results when valid agents exist", async () => {
+    it("should execute and pass combined context (supervisor's userContext and LLM context) to handoffToMultiple", async () => {
       subAgentManager.addSubAgent(mockAgent1);
       subAgentManager.addSubAgent(mockAgent2);
+
+      const mockSupervisorOperationalContext = {
+        fromSupervisor: "importantData",
+        commonKey: "supervisorValue",
+      };
+      const llmProvidedContext = { fromLLM: "llmData", commonKey: "llmValue" }; // LLM context overwrites commonKey
+      type CombinedContextType = Partial<
+        typeof mockSupervisorOperationalContext & typeof llmProvidedContext
+      >;
+
+      const mockOperationContext: OperationContext<typeof mockSupervisorOperationalContext> = {
+        operationId: "test-op-id",
+        userContext: mockSupervisorOperationalContext,
+        historyEntry: {} as any,
+        eventUpdaters: new Map(),
+        isActive: true,
+      };
 
       const handoffToMultipleSpy = jest
         .spyOn(subAgentManager, "handoffToMultiple")
         .mockResolvedValue([
-          {
-            result: "Result 1",
-            conversationId: "conv1",
-            messages: [],
-            error: undefined,
-            status: "success",
-          },
-          {
-            result: "Result 2",
-            conversationId: "conv2",
-            messages: [],
-            error: undefined,
-            status: "success",
-          },
+          { result: "Result 1", conversationId: "conv1", messages: [], status: "success" },
+          { result: "Result 2", conversationId: "conv2", messages: [], status: "success" },
         ]);
 
-      const tool = subAgentManager.createDelegateTool();
+      const tool = subAgentManager.createDelegateTool({
+        sourceAgent: new MockAgent("supervisorId", "Supervisor"),
+        currentHistoryEntryId: "hist-entry-123",
+        operationContext: mockOperationContext,
+      });
 
       const result = await tool.execute({
-        task: "Test task",
+        task: "Test task with combined context",
         targetAgents: ["Math Agent", "Writing Agent"],
-        context: {},
+        context: llmProvidedContext, // LLM provides its own context via the tool parameter
       });
 
       expect(handoffToMultipleSpy).toHaveBeenCalled();
+      const handoffOptions = handoffToMultipleSpy.mock.calls[0][0];
+
+      const expectedCombinedContext: CombinedContextType = {
+        fromSupervisor: "importantData",
+        fromLLM: "llmData",
+        commonKey: "llmValue", // LLM's value for commonKey should take precedence
+      };
+      expect(handoffOptions.supervisorUserContext).toEqual(expectedCombinedContext);
+
       expect(result).toEqual([
         {
           agentName: "Math Agent",
           response: "Result 1",
           conversationId: "conv1",
-          error: undefined,
           status: "success",
+          error: undefined,
         },
         {
           agentName: "Writing Agent",
           response: "Result 2",
           conversationId: "conv2",
-          error: undefined,
           status: "success",
+          error: undefined,
+        },
+      ]);
+    });
+
+    it("should use only supervisor's userContext if LLM provides no context parameter", async () => {
+      subAgentManager.addSubAgent(mockAgent1);
+      const mockSupervisorOperationalContext = { fromSupervisor: "dataOnly" };
+      const mockOperationContext: OperationContext<typeof mockSupervisorOperationalContext> = {
+        operationId: "test-op-id-2",
+        userContext: mockSupervisorOperationalContext,
+        historyEntry: {} as any,
+        eventUpdaters: new Map(),
+        isActive: true,
+      };
+
+      const handoffToMultipleSpy = jest
+        .spyOn(subAgentManager, "handoffToMultiple")
+        .mockResolvedValue([
+          { result: "Result Math", conversationId: "convM", messages: [], status: "success" },
+        ]);
+
+      const tool = subAgentManager.createDelegateTool({ operationContext: mockOperationContext });
+      await tool.execute({ task: "Test no LLM context", targetAgents: ["Math Agent"] }); // No context from LLM
+
+      expect(handoffToMultipleSpy).toHaveBeenCalled();
+      const handoffOptions = handoffToMultipleSpy.mock.calls[0][0];
+      expect(handoffOptions.supervisorUserContext).toEqual(mockSupervisorOperationalContext);
+    });
+
+    it("should use only LLM context if supervisor has no userContext (or operationContext is not passed to tool)", async () => {
+      subAgentManager.addSubAgent(mockAgent1);
+      const llmProvidedContext = { fromLLMOnly: "llmOnlyData" };
+
+      const handoffToMultipleSpy = jest
+        .spyOn(subAgentManager, "handoffToMultiple")
+        .mockResolvedValue([
+          {
+            result: "Result Math LLM",
+            conversationId: "convMLLM",
+            messages: [],
+            status: "success",
+          },
+        ]);
+
+      // Create tool without operationContext (supervisorUserContext will be an empty object initially)
+      const tool = subAgentManager.createDelegateTool({});
+      await tool.execute({
+        task: "Test only LLM context",
+        targetAgents: ["Math Agent"],
+        context: llmProvidedContext,
+      });
+
+      expect(handoffToMultipleSpy).toHaveBeenCalled();
+      const handoffOptions = handoffToMultipleSpy.mock.calls[0][0];
+      expect(handoffOptions.supervisorUserContext).toEqual(llmProvidedContext);
+    });
+
+    it("should execute delegate_task correctly even if operationContext is not in tool options (legacy or direct tool call)", async () => {
+      subAgentManager.addSubAgent(mockAgent1);
+
+      const handoffToMultipleSpy = jest
+        .spyOn(subAgentManager, "handoffToMultiple")
+        .mockResolvedValue([
+          {
+            result: "Result from Math",
+            conversationId: "conv-math",
+            messages: [],
+            status: "success",
+          },
+        ]);
+
+      const tool = subAgentManager.createDelegateTool({
+        sourceAgent: new MockAgent("supervisorId", "Supervisor"),
+      });
+
+      const result = await tool.execute({
+        task: "Test task no explicit supervisor context in tool options",
+        targetAgents: ["Math Agent"],
+      });
+
+      expect(handoffToMultipleSpy).toHaveBeenCalled();
+      const handoffOptions = handoffToMultipleSpy.mock.calls[0][0];
+      expect(handoffOptions.supervisorUserContext).toEqual({});
+
+      expect(result).toEqual([
+        {
+          agentName: "Math Agent",
+          response: "Result from Math",
+          conversationId: "conv-math",
+          status: "success",
+          error: undefined,
         },
       ]);
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Previously, `userContext` was a `Map<string | symbol, unknown>`, making it less type-safe and requiring manual `get`/`set` operations. There was no built-in way to initialize the context when starting an agent operation or to automatically propagate context down through agent hierarchies during delegation.


## What is the new behavior?

1.  **Type-Safe Object Context:** `userContext` is now a generic object (`TContext` defaulting to `Record<string, any>`), allowing developers to define specific types for their context data, improving type safety and DX.
2.  **Initialization:** Agent generation methods (e.g., `generateText`) now accept an `initialUserContext` option to directly set the initial state of `userContext` for that specific operation.
3.  **Automatic Propagation:** `initialUserContext` provided to a supervisor agent (or its current `userContext`) is automatically propagated down to sub-agents when using the `delegate_task` tool, making it easy to pass tracing IDs, user info, etc., through the hierarchy.

This provides a more robust, type-safe, and developer-friendly mechanism for managing operation-specific state.


fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
