### PR TITLE
feat: enhance userContext functionality across agent operations

### DIFF
--- a/.changeset/new-otters-turn.md
+++ b/.changeset/new-otters-turn.md
@@ -1,0 +1,37 @@
+---
+"@voltagent/core": patch
+---
+
+Enabled `userContext` to be passed from supervisor agents to their sub-agents, allowing for consistent contextual data across delegated tasks. This ensures that sub-agents can operate with the necessary shared information provided by their parent agent.
+
+```typescript
+// Supervisor Agent initiates an operation with userContext:
+const supervisorContext = new Map<string | symbol, unknown>();
+supervisorContext.set("globalTransactionId", "tx-supervisor-12345");
+
+await supervisorAgent.generateText(
+  "Delegate analysis of transaction tx-supervisor-12345 to the financial sub-agent.",
+  { userContext: supervisorContext }
+);
+
+// In your sub-agent's hook definition (e.g., within createHooks):
+onStart: ({ agent, context }: OnStartHookArgs) => {
+  const inheritedUserContext = context.userContext; // Access the OperationContext's userContext
+  const transactionId = inheritedUserContext.get("globalTransactionId");
+  console.log(`[${agent.name}] Hook: Operating with Transaction ID: ${transactionId}`);
+  // Expected log: [FinancialSubAgent] Hook: Operating with Transaction ID: tx-supervisor-12345
+};
+
+// Example: Inside a Tool executed by the Sub-Agent
+// In your sub-agent tool's execute function:
+execute: async (params: { someParam: string }, options?: ToolExecutionContext) => {
+  if (options?.operationContext?.userContext) {
+    const inheritedUserContext = options.operationContext.userContext;
+    const transactionId = inheritedUserContext.get("globalTransactionId");
+    console.log(`[SubAgentTool] Tool: Processing with Transaction ID: ${transactionId}`);
+    // Expected log: [SubAgentTool] Tool: Processing with Transaction ID: tx-supervisor-12345
+    return `Processed ${params.someParam} for transaction ${transactionId}`;
+  }
+  return "Error: OperationContext not available for tool";
+};
+```

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -438,6 +438,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       parentAgentId?: string;
       parentHistoryEntryId?: string;
       operationName: string;
+      userContext?: Map<string | symbol, unknown>;
     } = {
       operationName: "unknown",
     },
@@ -459,7 +460,9 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
     // Create operation context
     const opContext: OperationContext = {
       operationId: historyEntry.id,
-      userContext: new Map<string | symbol, unknown>(),
+      userContext: options.userContext
+        ? new Map(options.userContext)
+        : new Map<string | symbol, unknown>(),
       historyEntry,
       eventUpdaters: new Map<string, EventUpdater>(),
       isActive: true,
@@ -810,12 +813,14 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       parentAgentId,
       parentHistoryEntryId,
       contextLimit = 10,
+      userContext,
     } = internalOptions;
 
     const operationContext = await this.initializeHistory(input, "working", {
       parentAgentId,
       parentHistoryEntryId,
       operationName: "generateText",
+      userContext,
     });
 
     const { messages: contextMessages, conversationId: finalConversationId } =
@@ -1020,12 +1025,14 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       parentAgentId,
       parentHistoryEntryId,
       contextLimit = 10,
+      userContext,
     } = internalOptions;
 
     const operationContext = await this.initializeHistory(input, "working", {
       parentAgentId,
       parentHistoryEntryId,
       operationName: "streamText",
+      userContext,
     });
 
     const { messages: contextMessages, conversationId: finalConversationId } =
@@ -1277,12 +1284,14 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       parentAgentId,
       parentHistoryEntryId,
       contextLimit = 10,
+      userContext,
     } = internalOptions;
 
     const operationContext = await this.initializeHistory(input, "working", {
       parentAgentId,
       parentHistoryEntryId,
       operationName: "generateObject",
+      userContext,
     });
 
     const { messages: contextMessages, conversationId: finalConversationId } =
@@ -1427,12 +1436,14 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       parentHistoryEntryId,
       provider,
       contextLimit = 10,
+      userContext,
     } = internalOptions;
 
     const operationContext = await this.initializeHistory(input, "working", {
       parentAgentId,
       parentHistoryEntryId,
       operationName: "streamObject",
+      userContext,
     });
 
     const { messages: contextMessages, conversationId: finalConversationId } =

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -81,6 +81,11 @@ export type AgentOptions = {
    * Sub-agents that this agent can delegate tasks to
    */
   subAgents?: any[]; // Using any to avoid circular dependency
+
+  /**
+   * Optional user-defined context to be passed around
+   */
+  userContext?: Map<string | symbol, unknown>;
 } & (
   | {
       /**
@@ -180,6 +185,9 @@ export interface CommonGenerateOptions {
 
   // The OperationContext associated with this specific generation call
   operationContext?: OperationContext;
+
+  // Optional user-defined context to be passed from a parent operation
+  userContext?: Map<string | symbol, unknown>;
 }
 
 /**
@@ -306,6 +314,11 @@ export type AgentHandoffOptions = {
    * Parent history entry ID
    */
   parentHistoryEntryId?: string;
+
+  /**
+   * Optional user-defined context to be passed from the supervisor agent
+   */
+  userContext?: Map<string | symbol, unknown>;
 };
 
 /**

--- a/website/docs/agents/context.md
+++ b/website/docs/agents/context.md
@@ -4,42 +4,154 @@ slug: /agents/context
 description: Pass custom data through agent operations using userContext.
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Operation Context (`userContext`)
 
-VoltAgent provides a powerful mechanism called `userContext` to pass custom data through the lifecycle of a single agent operation (like a `generateText` or `streamObject` call). This context is isolated to each individual _main_ agent operation, ensuring that data doesn't inadvertently leak between concurrent or subsequent requests. Importantly, `userContext` can also be intentionally propagated from a supervisor agent to its sub-agents, allowing for consistent contextual data across delegated tasks.
+`userContext` allows you to pass custom data throughout a single agent operation. Think of it as a temporary, isolated bag of information specific to one task your agent is performing. It becomes especially powerful when coordinating tasks between supervisor and sub-agents.
 
-## What is `userContext`?
+**Quick Examples: Initializing `userContext`**
 
-`userContext` is a property within the `OperationContext` object. `OperationContext` itself encapsulates information about a specific agent task, including its unique ID (`operationId`), the associated history entry, and event tracking details.
+There are two primary ways to initialize or populate `userContext` for an operation:
 
-`userContext` is specifically a `Map<string | symbol, unknown>`.
+<Tabs groupId="usercontext-initialization">
+  <TabItem value="hooks" label="Managed by Hooks">
 
-- **Map**: It allows you to store key-value pairs.
-- **Keys**: Can be strings or symbols, providing flexibility in how you identify your context data.
-- **Values**: Can be of `unknown` type, meaning you can store virtually any kind of data – strings, numbers, objects, custom class instances, etc.
+```typescript
+// Filename: agentHooksContext.ts
+import {
+  Agent,
+  createHooks,
+  VercelAIProvider,
+  type OnStartHookArgs,
+  type OnEndHookArgs,
+} from "@voltagent/core";
+import { openai } from "@ai-sdk/openai";
 
-## Why Use `userContext`?
+// Agent populates userContext internally via hooks
+const agentManagingInternally = new Agent({
+  name: "InternalContextAgent",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
+  hooks: createHooks({
+    onStart: ({ agent, context }: OnStartHookArgs) => {
+      const operationSpecificId = `op-${agent.name}-${Date.now()}`;
+      context.userContext.set("internalOpId", operationSpecificId);
+      console.log(
+        `[${agent.name}] HOOK: Operation started. OpID set internally: ${operationSpecificId}`
+      );
+    },
+    onEnd: ({ agent, context }: OnEndHookArgs) => {
+      const opId = context.userContext.get("internalOpId");
+      console.log(`[${agent.name}] HOOK: Operation ended. Retrieved internal OpID: ${opId}`);
+    },
+  }),
+});
 
-`userContext` solves the problem of needing to maintain and access request-specific state or data across different parts of an agent's execution flow, particularly between lifecycle hooks and tool executions.
+async function runInternalContextTask() {
+  console.log("\n--- Running Task: Context Managed by Hooks ---");
+  await agentManagingInternally.generateText("Tell me a story about a brave otter.");
+}
+// runInternalContextTask();
+```
 
-Common use cases include:
+In this approach, the `userContext` starts empty for the operation, and hooks (like `onStart`) are responsible for populating it with relevant data.
 
-1.  **Tracing & Logging**: Propagate unique request IDs or trace IDs generated at the start (`onStart`) into tool executions and across sub-agent operations for distributed tracing or detailed logging.
-2.  **Request-Specific Configuration**: Pass configuration details relevant only to the current operation (e.g., user preferences, tenant IDs) from `onStart` to tools, and potentially to sub-agents if they require this shared configuration.
-3.  **Metrics & Analytics**: Store timing information or other metrics in `onStart` and finalize/report them in `onEnd`. This can span across operations delegated to sub-agents if the metric is relevant to the entire supervised task.
-4.  **Resource Management**: Store references to resources allocated in `onStart` (like database connections specific to the request) and release them in `onEnd`. For complex delegated tasks, sub-agents might also need access to these resources via the propagated `userContext`.
-5.  **Passing Data Between Hooks**: Set a value in `onStart` and retrieve it in `onEnd` for the same operation.
-6.  **Delegated Task Context**: When a supervisor agent delegates parts of a task to sub-agents, the `userContext` can carry overarching information (e.g., a global session ID, the original user query, or shared parameters) that all sub-agents need to perform their part of the task coherently.
+  </TabItem>
+  <TabItem value="options" label="Passed via Options">
+
+```typescript
+// Filename: agentOptionsContext.ts
+import {
+  Agent,
+  createHooks,
+  VercelAIProvider,
+  type OnStartHookArgs,
+  type OnEndHookArgs,
+} from "@voltagent/core";
+import { openai } from "@ai-sdk/openai";
+
+// Agent receives userContext via generateText options
+const agentReceivingContext = new Agent({
+  name: "OptionsContextAgent",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
+  hooks: createHooks({
+    onStart: ({ agent, context }: OnStartHookArgs) => {
+      // Reads data passed in via options
+      const externalTraceId = context.userContext.get("traceId");
+      console.log(
+        `[${agent.name}] HOOK: Operation started. Received traceId from options: ${externalTraceId}`
+      );
+      // Can also add more context if needed
+      context.userContext.set("hookProcessed", true);
+    },
+    onEnd: ({ agent, context }: OnEndHookArgs) => {
+      const externalTraceId = context.userContext.get("traceId");
+      const processed = context.userContext.get("hookProcessed");
+      console.log(
+        `[${agent.name}] HOOK: Operation ended. TraceId: ${externalTraceId}, Processed by hook: ${processed}`
+      );
+    },
+  }),
+});
+
+async function runOptionsContextTask() {
+  console.log("\n--- Running Task: Context Passed via Options ---");
+  const initialContext = new Map<string | symbol, unknown>();
+  initialContext.set("traceId", `trace-${Date.now()}`);
+  initialContext.set("userId", "user123");
+
+  await agentReceivingContext.generateText("Analyze this user feedback.", {
+    userContext: initialContext,
+  });
+}
+// runOptionsContextTask();
+```
+
+Here, you provide an initial `userContext` map directly when calling the agent's generation method. The agent's `OperationContext` is then initialized with a _clone_ of this map. Hooks and tools can then access and potentially add to this context.
+
+  </TabItem>
+</Tabs>
+
+## Key Concepts & Usage
+
+`userContext` is a `Map<string | symbol, unknown>` within an `OperationContext`. It lets you store and retrieve data relevant to the current agent task.
+
+**When to Use `userContext`:**
+
+- **Carry Request-Specific Data:** Pass unique IDs (trace, session, request IDs) or configurations that apply only to the current operation.
+  - _Example:_ Set a `correlationId` in `onStart` and use it in tools for logging.
+- **Share State Between Hooks & Tools:** Data set by an `onStart` hook can be read by tools called during that operation, or by the `onEnd` hook.
+  - _Example:_ The "Quick Example" above shows setting an ID in `onStart` and reading it in `onEnd`.
+- **Coordinate Supervisor & Sub-Agents:** A supervisor agent can pass down common information (like a `globalSessionId`) to sub-agents.
+  - _Example:_ See the "`userContext` in Sub-Agent Scenarios" section below.
+- **Manage Operation-Scoped Resources:** Handle resources like a Playwright page that should live only for the duration of one operation.
+  - _Example:_ See the "Advanced Use Case: Managing Playwright Browser Instances" section.
+
+**Core Principles (How to Think About It):**
+
+1.  **Accessibility:**
+    - In **Hooks** (`onStart`, `onEnd`): Access via `context.userContext`.
+    - In **Tools** (`execute` function): Access via `options.operationContext.userContext`.
+2.  **Initialization & Propagation:**
+    - For a new top-level agent operation, `userContext` starts empty.
+    - If an agent call includes `userContext` in its options (e.g., `agent.generateText("...", { userContext: myDataMap })`), the operation starts with a clone of `myDataMap`.
+    - When a **supervisor agent delegates to a sub-agent** (e.g., via `delegate_task`), the supervisor's current `userContext` is automatically cloned and passed to the sub-agent. The sub-agent's operation then begins with this inherited context.
+3.  **Isolation:**
+    - Each top-level agent operation (e.g., two separate calls to `agent.generateText(...)`) has its own completely independent `userContext`.
+    - When context is passed to a sub-agent, it's a _clone_. Modifications by the sub-agent don't affect the supervisor's original `userContext` or other sub-agents.
 
 ### Advanced Use Case: Managing Playwright Browser Instances
 
-Another powerful use case for `userContext` is managing stateful resources that should be isolated per operation, such as a Playwright `Browser` or `Page` instance. This avoids the complexity of passing the instance explicitly between hooks and tools.
+Another powerful illustration of `userContext` is managing operation-scoped resources, like a Playwright `Browser` or `Page` instance. This avoids manually passing instances between hooks and tools.
 
-**Scenario:** You want an agent to perform browser automation tasks using Playwright. Each agent operation should have its own isolated browser session.
+**Scenario:** An agent needs to perform browser automation. Each agent operation (e.g., a `generateText` call) requires its own isolated browser session.
 
-1.  **Initialization (in Tools or Hooks):** Instead of initializing the browser directly in `onStart`, you can create a helper function (e.g., `ensureBrowser`) that tools call. This function checks `userContext` first. If a `Page` instance for the current `operationId` doesn't exist, it launches Playwright, creates a `Page`, and stores it in `userContext` using a unique key (like a `Symbol`).
-2.  **Tool Access:** Tools needing browser access (e.g., `clickElement`, `navigateToUrl`) call the `ensureBrowser` helper, passing their `options.operationContext`. The helper retrieves the correct `Page` instance from `userContext`.
-3.  **Cleanup (`onEnd` Hook):** An `onEnd` hook retrieves the `Browser` instance from `userContext` using the operation's context and calls `browser.close()` to ensure resources are released when the operation finishes.
+1.  **Lazy Initialization & Context Storage:** A helper function (e.g., `ensurePage`) checks `userContext` for an existing `Page`. If not found (or closed), it launches Playwright, creates a new `Page`, and stores both the `Page` and `Browser` instances in `userContext` using unique symbols as keys.
+2.  **Tool Access:** Tools needing browser access call this helper, passing their `operationContext`. The helper ensures they get the correct `Page` instance for the current operation from `userContext`.
+3.  **Scoped Cleanup via `onEnd` Hook:** An `onEnd` hook retrieves the `Browser` instance from the operation's `userContext` and closes it, ensuring resources are released when the specific operation concludes.
 
 ```typescript
 import {
@@ -50,224 +162,206 @@ import {
   type OperationContext,
   type ToolExecutionContext,
 } from "@voltagent/core";
+import { z } from "zod"; // Make sure z is imported if not already
 import { chromium, type Browser, type Page } from "playwright";
+// Assume VercelAIProvider and openai are configured as in the first example
 
 const PAGE_KEY = Symbol("playwrightPage");
 const BROWSER_KEY = Symbol("playwrightBrowser");
 
-// Helper to get/create page within the context
 async function ensurePage(context: OperationContext): Promise<Page> {
   let page = context.userContext.get(PAGE_KEY) as Page | undefined;
   if (!page || page.isClosed()) {
-    console.log(`[${context.operationId}] Creating new browser/page for context...`);
+    console.log(`[${context.operationId}] LAZY: Creating new browser/page for operation...`);
     const browser = await chromium.launch();
     page = await browser.newPage();
-    context.userContext.set(BROWSER_KEY, browser); // Store browser for cleanup
+    context.userContext.set(BROWSER_KEY, browser);
     context.userContext.set(PAGE_KEY, page);
   }
   return page;
 }
 
-// Hook for cleanup
-const hooks = createHooks({
+const playwrightHooks = createHooks({
   onEnd: async ({ context }: OnEndHookArgs) => {
     const browser = context.userContext.get(BROWSER_KEY) as Browser | undefined;
     if (browser) {
-      console.log(`[${context.operationId}] Closing browser for context...`);
+      console.log(`[${context.operationId}] CLEANUP: Closing browser for operation...`);
       await browser.close();
     }
   },
 });
 
-// Example Tool
 const navigateTool = createTool({
-  name: "navigate",
+  name: "navigate_url",
+  description: "Navigates to a specified URL.", // Added description
   parameters: z.object({ url: z.string().url() }),
   execute: async ({ url }, options?: ToolExecutionContext) => {
-    if (!options?.operationContext) throw new Error("Context required");
-    const page = await ensurePage(options.operationContext); // Get page via context
+    if (!options?.operationContext) throw new Error("OperationContext is required for this tool.");
+    const page = await ensurePage(options.operationContext);
     await page.goto(url);
-    return `Navigated to ${url}`;
+    console.log(`[${options.operationContext.operationId}] ACTION: Navigated to ${url}`);
+    return `Successfully navigated to ${url}`;
   },
 });
 
-// Agent setup (LLM/Model details omitted)
-const browserAgent = new Agent({
-  name: "Browser Agent",
-  // ... llm, model ...
-  hooks: hooks,
+const browserAutomationAgent = new Agent({
+  name: "BrowserAutomationAgent",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
+  hooks: playwrightHooks,
   tools: [navigateTool],
+  instructions: "You are an agent that can browse the web. Use the navigate_url tool.",
 });
 
-// Usage:
-// await browserAgent.generateText("Navigate to https://example.com");
-// await browserAgent.generateText("Navigate to https://google.com"); // Uses a *different* browser instance
+async function runBrowserTasks() {
+  console.log("--- Starting Browser Task 1 ---");
+  await browserAutomationAgent.generateText("Navigate to https://example.com using the tool.");
+  console.log("--- Browser Task 1 Finished ---");
+
+  console.log("\n--- Starting Browser Task 2 (separate browser instance) ---");
+  await browserAutomationAgent.generateText("Navigate to https://google.com using the tool.");
+  console.log("--- Browser Task 2 Finished ---");
+}
+
+// runBrowserTasks();
 ```
 
-This pattern ensures each `generateText` call gets its own clean browser environment managed via the isolated `userContext`.
+This pattern ensures each call to `browserAutomationAgent.generateText` gets its own, clean browser environment, managed entirely through the operation-specific `userContext`.
 
 For a full implementation of this pattern, see the [VoltAgent Playwright Example](https://github.com/voltagent/voltagent/tree/main/examples/with-playwright).
 
-## How it Works
+## Illustrating Core Access Patterns
 
-1.  **Initialization**: When an agent operation (e.g., `agent.generateText(...)`) begins, VoltAgent creates a unique `OperationContext`.
-2.  **Empty Map or Propagated Context**:
-    - For a new top-level operation, `userContext` within this `OperationContext` is initialized as an empty `Map`.
-    - If the operation is initiated by a sub-agent that had `userContext` passed to it from a supervisor (via `PublicGenerateOptions`), the sub-agent's `OperationContext` will be initialized with a _clone_ of the supervisor's `userContext`. This ensures the sub-agent starts with the supervisor's context data but modifications within the sub-agent do not affect the supervisor's original context map.
-3.  **Access via Hooks**: The `OperationContext` (including `userContext`) is passed as an argument to the `onStart` and `onEnd` agent lifecycle hooks of the current agent (be it a supervisor or a sub-agent).
-4.  **Access via Tools**: The `OperationContext` is also accessible within a tool's `execute` function via the optional `options` parameter (specifically `options.operationContext`). This applies to tools executed by both supervisor and sub-agents.
-5.  **Propagation to Sub-Agents**: When a supervisor agent uses a tool like `delegate_task` (typically created by `SubAgentManager`), the supervisor's current `userContext` (from its `operationContext`) is automatically included in the options passed to the sub-agent's generation method (e.g., `generateText`). The sub-agent then starts its own operation with this context, as described in point 2.
-6.  **Isolation with Intentional Propagation**:
-    - Each direct call to an agent's generation method (e.g., `supervisorAgent.generateText(...)`) gets its own independent `OperationContext` and, initially, an empty `userContext` (unless it's a sub-agent receiving context).
-    - Data stored in one top-level operation's `userContext` is not visible to other concurrent or subsequent top-level operations.
-    - However, as detailed above, a supervisor agent _can_ and _does_ intentionally pass its `userContext` (as a clone) to its sub-agents when delegating tasks. This allows sub-agents to operate with the necessary shared context while maintaining the integrity of the supervisor's original context due to the cloning mechanism.
-
-## Usage Example
-
-This example demonstrates how to set context data in the `onStart` hook and access it in both the `onEnd` hook and within a tool's `execute` function.
+Let's solidify how to access `userContext` with a direct example focusing on hooks and tools. This expands on the "Quick Example" by showing tool interaction.
 
 ```typescript
-import {
-  Agent,
-  createHooks,
-  createTool,
-  type OnStartHookArgs,
-  type OnEndHookArgs,
-  type OperationContext,
-  type ToolExecutionContext,
-} from "@voltagent/core";
-import { z } from "zod";
-import { VercelAIProvider } from "@voltagent/vercel-ai";
-import { openai } from "@ai-sdk/openai";
-
-// Define hooks that set and retrieve data
-const hooks = createHooks({
-  onStart: ({ agent, context }: OnStartHookArgs) => {
-    // Set a unique request ID for this operation
-    const requestId = `req-${Date.now()}`;
-    context.userContext.set("requestId", requestId);
-    console.log(`[${agent.name}] Operation started. RequestID: ${requestId}`);
-  },
-  onEnd: ({ agent, context }: OnEndHookArgs) => {
-    // Retrieve the request ID at the end of the operation
-    const requestId = context.userContext.get("requestId");
-    console.log(`[${agent.name}] Operation finished. RequestID: ${requestId}`);
-    // Use this ID for logging, metrics, cleanup, etc.
-  },
-});
-
-// Define a tool that uses the context data set in onStart
-const loggerTool = createTool({
-  name: "context_aware_logger",
-  description: "Logs a message using the request ID from context.",
+// Logger tool using context
+const simpleContextTool = createTool({
+  name: "log_with_context",
+  description: "Logs a message using an ID from userContext.",
   parameters: z.object({ message: z.string() }),
   execute: async (params: { message: string }, options?: ToolExecutionContext) => {
-    // Access userContext via options.operationContext
-    const requestId = options?.operationContext?.userContext?.get("requestId") || "unknown-request";
-    const logMessage = `[RequestID: ${requestId}] Tool Log: ${params.message}`;
+    const operationIdFromContext = options?.operationContext?.userContext?.get("myOperationId");
+    const logMessage = `[Tool Log][OpID: ${operationIdFromContext || "N/A"}] Message: ${params.message}`;
     console.log(logMessage);
-    // In a real scenario, you might interact with external systems using this ID
-    return `Logged message with RequestID: ${requestId}`;
+    return `Logged: ${params.message} (OpID: ${operationIdFromContext || "N/A"})`;
   },
 });
 
-const agent = new Agent({
-  name: "MyCombinedAgent",
+const agentWithToolContext = new Agent({
+  name: "ToolContextAgent",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
-  tools: [loggerTool],
-  hooks: hooks,
+  tools: [simpleContextTool],
+  hooks: createHooks({
+    // Using hooks from the first "Quick Example"
+    onStart: ({ agent, context }: OnStartHookArgs) => {
+      const operationSpecificId = `op-${agent.name}-${Date.now()}`;
+      context.userContext.set("myOperationId", operationSpecificId);
+      console.log(`[${agent.name}] HOOK: Operation started. OpID set to: ${operationSpecificId}`);
+    },
+    onEnd: ({ agent, context }: OnEndHookArgs) => {
+      const opId = context.userContext.get("myOperationId");
+      console.log(`[${agent.name}] HOOK: Operation finished. Retrieved OpID: ${opId}`);
+    },
+  }),
+  instructions: "Use the log_with_context tool to log your thoughts.",
 });
 
-// Trigger the agent.
-await agent.generateText(
-  "Log the following information using the custom logger: 'User feedback received.'"
-);
-
-// Console output will show logs from onStart, the tool (if called), and onEnd,
+async function runToolContextTask() {
+  await agentWithToolContext.generateText(
+    "Log this message: 'Hello from the tool, using context!'"
+  );
+}
+// runToolContextTask();
 ```
+
+This example explicitly shows:
+
+- `onStart` hook setting a value in `userContext`.
+- A tool (`log_with_context`) accessing this value via `options.operationContext.userContext`.
+- `onEnd` hook also accessing the same value.
 
 ## `userContext` in Sub-Agent Scenarios
 
-The `userContext` is particularly useful in scenarios involving supervisor agents and sub-agents. A supervisor agent can establish a context that is then passed down to any sub-agents it delegates tasks to. This allows for a consistent flow of information, like a global `transactionId` or shared configuration, across the entire hierarchy of an operation.
+As highlighted in the "Core Principles", `userContext` is automatically cloned and passed from a supervisor agent to its sub-agents during delegation. This allows sub-agents to access shared information seamlessly.
 
-**How Propagation Works:**
+**Example: Propagating a Session ID to a Sub-Agent**
 
-1.  **Supervisor Initiates with Context**: When a supervisor agent starts an operation (e.g., `supervisor.generateText("Delegate this work", { userContext: mySupervisorContext })`), its `userContext` is initialized.
-2.  **Delegation**: If the supervisor uses a tool like `delegate_task` (managed by `SubAgentManager`), its current `operationContext.userContext` is automatically picked up.
-3.  **Sub-Agent Receives Context**: This `userContext` is passed as part of the `PublicGenerateOptions` to the sub-agent's generation method (e.g., `subAgent.generateText(..., { /* other options */, userContext: supervisorContextClone })`).
-4.  **Sub-Agent Initialization**: The sub-agent's `OperationContext` is then initialized with a _clone_ of the supervisor's `userContext`. This means the sub-agent gets all the data but cannot accidentally modify the supervisor's original context map.
-5.  **Sub-Agent Access**: The sub-agent can access this inherited context in its own hooks (`onStart`, `onEnd`) and tools, just like a regular `userContext`.
-
-**Example:**
-
-Let's consider a supervisor agent that wants to pass a `sessionId` to its sub-agents.
+Let's see a supervisor agent passing a `sessionId` to its sub-agent. The sub-agent then uses this ID in its hooks and tools.
 
 ```typescript
-// Assume VercelAIProvider and openai are configured as in the previous example.
+// Assume VercelAIProvider, openai, createTool, z, Agent, createHooks,
+// OnStartHookArgs, ToolExecutionContext are imported as in previous examples.
 
 // Sub-Agent that will use the context
-const subAgentTool = createTool({
-  name: "sub_task_processor",
-  description: "Processes a sub-task using session ID from context.",
+const subAgentProcessingTool = createTool({
+  name: "sub_task_processor_with_session",
+  description: "Processes a sub-task using an inherited session ID from context.",
   parameters: z.object({ task_details: z.string() }),
   execute: async (params, options?: ToolExecutionContext) => {
     const sessionId = options?.operationContext?.userContext?.get("sessionId") || "unknown-session";
-    const logMessage = `[Sub-Agent Task][SessionID: ${sessionId}] Processing: ${params.task_details}`;
+    const logMessage = `[Sub-Agent TOOL][SessionID: ${sessionId}] Processing: ${params.task_details}`;
     console.log(logMessage);
-    return `Sub-task processed with SessionID: ${sessionId}`;
+    return `Sub-task for session ${sessionId} processed successfully.`;
   },
 });
 
-const subAgent = new Agent({
-  name: "WorkerAgent",
+const workerAgentWithContext = new Agent({
+  name: "WorkerAgentWithContext",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
-  tools: [subAgentTool],
+  tools: [subAgentProcessingTool],
   hooks: createHooks({
-    onStart: ({ agent, context }) => {
+    onStart: ({ agent, context }: OnStartHookArgs) => {
       const sessionId = context.userContext.get("sessionId");
-      console.log(`[${agent.name}] Operation started. Inherited SessionID: ${sessionId}`);
+      console.log(`[${agent.name} HOOK] Operation started. Inherited SessionID: ${sessionId}`);
     },
+    onEnd: ({ agent, context }: OnStartHookArgs) => {
+      const sessionId = context.userContext.get("sessionId");
+      console.log(`[${agent.name} HOOK] Operation finished for SessionID: ${sessionId}`);
+    }
   }),
+  instructions: "You are a worker agent. Use your tools to process tasks based on session ID."
 });
 
 // Supervisor Agent
-const supervisorHooks = createHooks({
-  onStart: ({ agent, context }: OnStartHookArgs) => {
-    const sessionId = context.userContext.get("sessionId"); // Will be set from generateText options
-    console.log(`[${agent.name}] Supervisor Operation started. SessionID: ${sessionId}`);
-  },
-});
-
-const supervisorAgent = new Agent({
-  name: "SupervisorAgent",
+const supervisorAgentWithDelegation = new Agent({
+  name: "SupervisorAgentWithDelegation",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
-  hooks: supervisorHooks,
-  subAgents: [subAgent],
+  hooks: createHooks({
+    onStart: ({ agent, context }: OnStartHookArgs) => {
+      const sessionId = context.userContext.get("sessionId");
+      console.log(`[${agent.name} HOOK] Supervisor Operation started. SessionID set to: ${sessionId}`);
+    },
+  }),
+  subAgents: [workerAgentWithContext], // This makes delegate_task available
+  instructions: "You are a supervisor. Delegate tasks to WorkerAgentWithContext."
 });
 
-async function runDelegation() {
-  const supervisorSessionContext = new Map<string | symbol, unknown>();
-  supervisorSessionContext.set("sessionId", `session-${Date.now()}`);
+async function runDelegationWithContext() {
+  const supervisorSessionMap = new Map<string | symbol, unknown>();
+  const newSessionId = `session-${Date.now()}`;
+  supervisorSessionMap.set("sessionId", newSessionId);
 
-  console.log("--- Starting Supervisor Operation with User Context ---");
-  // The supervisor's generateText call includes the userContext.
-  // If it calls delegate_task, this context will be passed to WorkerAgent.
-  await supervisorAgent.generateText("Delegate processing of 'important data' to WorkerAgent.", {
-    userContext: supervisorSessionContext,
-  });
-  console.log("--- Supervisor Operation Finished ---");
+  console.log(`\n--- Supervisor starting operation with SessionID: ${newSessionId} ---\`);
+  // Supervisor's generateText call includes the userContext.
+  // If it calls delegate_task for WorkerAgentWithContext, this context will be passed.
+  await supervisorAgentWithDelegation.generateText(
+    `Delegate processing of 'important financial data' to WorkerAgentWithContext for session ${newSessionId}.`,
+    { userContext: supervisorSessionMap }
+  );
+  console.log("--- Supervisor operation finished ---");
 }
 
-// runDelegation();
+// runDelegationWithContext();
 ```
 
 In this example:
 
-- When `supervisorAgent.generateText` is called with `userContext` containing a `sessionId`, this context is set for the supervisor's operation.
-- If the supervisor LLM decides to use the `delegate_task` tool to delegate to `WorkerAgent`, the `SubAgentManager` ensures that the `supervisorSessionContext` (as a clone) is passed to `WorkerAgent`.
-- `WorkerAgent`'s `onStart` hook and its `subAgentTool` can then access this `sessionId`.
+- When `supervisorAgentWithDelegation.generateText` is called with a `userContext` containing a `sessionId`, this context is established for the supervisor's operation.
+- If the supervisor LLM uses the `delegate_task` tool (automatically available due to `subAgents` configuration) to delegate to `WorkerAgentWithContext`, the `SubAgentManager` ensures the `supervisorSessionMap` (as a clone) is passed to the worker.
+- `WorkerAgentWithContext`'s `onStart` hook and its `subAgentProcessingTool` can then access this `sessionId` from their own `userContext`.
 
 This pattern is crucial for maintaining contextual coherence when tasks are broken down and distributed across multiple specialized agents.

--- a/website/docs/agents/context.md
+++ b/website/docs/agents/context.md
@@ -6,7 +6,7 @@ description: Pass custom data through agent operations using userContext.
 
 # Operation Context (`userContext`)
 
-VoltAgent provides a powerful mechanism called `userContext` to pass custom data through the lifecycle of a single agent operation (like a `generateText` or `streamObject` call). This context is isolated to each individual operation, ensuring that data doesn't leak between concurrent or subsequent requests.
+VoltAgent provides a powerful mechanism called `userContext` to pass custom data through the lifecycle of a single agent operation (like a `generateText` or `streamObject` call). This context is isolated to each individual _main_ agent operation, ensuring that data doesn't inadvertently leak between concurrent or subsequent requests. Importantly, `userContext` can also be intentionally propagated from a supervisor agent to its sub-agents, allowing for consistent contextual data across delegated tasks.
 
 ## What is `userContext`?
 
@@ -24,11 +24,12 @@ VoltAgent provides a powerful mechanism called `userContext` to pass custom data
 
 Common use cases include:
 
-1.  **Tracing & Logging**: Propagate unique request IDs or trace IDs generated at the start (`onStart`) into tool executions for distributed tracing or detailed logging.
-2.  **Request-Specific Configuration**: Pass configuration details relevant only to the current operation (e.g., user preferences, tenant IDs) from `onStart` to tools.
-3.  **Metrics & Analytics**: Store timing information or other metrics in `onStart` and finalize/report them in `onEnd`.
-4.  **Resource Management**: Store references to resources allocated in `onStart` (like database connections specific to the request) and release them in `onEnd`.
+1.  **Tracing & Logging**: Propagate unique request IDs or trace IDs generated at the start (`onStart`) into tool executions and across sub-agent operations for distributed tracing or detailed logging.
+2.  **Request-Specific Configuration**: Pass configuration details relevant only to the current operation (e.g., user preferences, tenant IDs) from `onStart` to tools, and potentially to sub-agents if they require this shared configuration.
+3.  **Metrics & Analytics**: Store timing information or other metrics in `onStart` and finalize/report them in `onEnd`. This can span across operations delegated to sub-agents if the metric is relevant to the entire supervised task.
+4.  **Resource Management**: Store references to resources allocated in `onStart` (like database connections specific to the request) and release them in `onEnd`. For complex delegated tasks, sub-agents might also need access to these resources via the propagated `userContext`.
 5.  **Passing Data Between Hooks**: Set a value in `onStart` and retrieve it in `onEnd` for the same operation.
+6.  **Delegated Task Context**: When a supervisor agent delegates parts of a task to sub-agents, the `userContext` can carry overarching information (e.g., a global session ID, the original user query, or shared parameters) that all sub-agents need to perform their part of the task coherently.
 
 ### Advanced Use Case: Managing Playwright Browser Instances
 
@@ -110,10 +111,16 @@ For a full implementation of this pattern, see the [VoltAgent Playwright Example
 ## How it Works
 
 1.  **Initialization**: When an agent operation (e.g., `agent.generateText(...)`) begins, VoltAgent creates a unique `OperationContext`.
-2.  **Empty Map**: Within this context, `userContext` is initialized as an empty `Map`.
-3.  **Access via Hooks**: The `OperationContext` (including `userContext`) is passed as an argument to the `onStart` and `onEnd` agent lifecycle hooks.
-4.  **Access via Tools**: The `OperationContext` is also accessible within a tool's `execute` function via the optional `options` parameter (specifically `options.operationContext`).
-5.  **Isolation**: Each call to an agent generation method (`generateText`, `streamText`, etc.) gets its own independent `OperationContext` and `userContext`. Data stored in one operation's `userContext` is not visible to others.
+2.  **Empty Map or Propagated Context**:
+    - For a new top-level operation, `userContext` within this `OperationContext` is initialized as an empty `Map`.
+    - If the operation is initiated by a sub-agent that had `userContext` passed to it from a supervisor (via `PublicGenerateOptions`), the sub-agent's `OperationContext` will be initialized with a _clone_ of the supervisor's `userContext`. This ensures the sub-agent starts with the supervisor's context data but modifications within the sub-agent do not affect the supervisor's original context map.
+3.  **Access via Hooks**: The `OperationContext` (including `userContext`) is passed as an argument to the `onStart` and `onEnd` agent lifecycle hooks of the current agent (be it a supervisor or a sub-agent).
+4.  **Access via Tools**: The `OperationContext` is also accessible within a tool's `execute` function via the optional `options` parameter (specifically `options.operationContext`). This applies to tools executed by both supervisor and sub-agents.
+5.  **Propagation to Sub-Agents**: When a supervisor agent uses a tool like `delegate_task` (typically created by `SubAgentManager`), the supervisor's current `userContext` (from its `operationContext`) is automatically included in the options passed to the sub-agent's generation method (e.g., `generateText`). The sub-agent then starts its own operation with this context, as described in point 2.
+6.  **Isolation with Intentional Propagation**:
+    - Each direct call to an agent's generation method (e.g., `supervisorAgent.generateText(...)`) gets its own independent `OperationContext` and, initially, an empty `userContext` (unless it's a sub-agent receiving context).
+    - Data stored in one top-level operation's `userContext` is not visible to other concurrent or subsequent top-level operations.
+    - However, as detailed above, a supervisor agent _can_ and _does_ intentionally pass its `userContext` (as a clone) to its sub-agents when delegating tasks. This allows sub-agents to operate with the necessary shared context while maintaining the integrity of the supervisor's original context due to the cloning mechanism.
 
 ## Usage Example
 
@@ -179,3 +186,88 @@ await agent.generateText(
 
 // Console output will show logs from onStart, the tool (if called), and onEnd,
 ```
+
+## `userContext` in Sub-Agent Scenarios
+
+The `userContext` is particularly useful in scenarios involving supervisor agents and sub-agents. A supervisor agent can establish a context that is then passed down to any sub-agents it delegates tasks to. This allows for a consistent flow of information, like a global `transactionId` or shared configuration, across the entire hierarchy of an operation.
+
+**How Propagation Works:**
+
+1.  **Supervisor Initiates with Context**: When a supervisor agent starts an operation (e.g., `supervisor.generateText("Delegate this work", { userContext: mySupervisorContext })`), its `userContext` is initialized.
+2.  **Delegation**: If the supervisor uses a tool like `delegate_task` (managed by `SubAgentManager`), its current `operationContext.userContext` is automatically picked up.
+3.  **Sub-Agent Receives Context**: This `userContext` is passed as part of the `PublicGenerateOptions` to the sub-agent's generation method (e.g., `subAgent.generateText(..., { /* other options */, userContext: supervisorContextClone })`).
+4.  **Sub-Agent Initialization**: The sub-agent's `OperationContext` is then initialized with a _clone_ of the supervisor's `userContext`. This means the sub-agent gets all the data but cannot accidentally modify the supervisor's original context map.
+5.  **Sub-Agent Access**: The sub-agent can access this inherited context in its own hooks (`onStart`, `onEnd`) and tools, just like a regular `userContext`.
+
+**Example:**
+
+Let's consider a supervisor agent that wants to pass a `sessionId` to its sub-agents.
+
+```typescript
+// Assume VercelAIProvider and openai are configured as in the previous example.
+
+// Sub-Agent that will use the context
+const subAgentTool = createTool({
+  name: "sub_task_processor",
+  description: "Processes a sub-task using session ID from context.",
+  parameters: z.object({ task_details: z.string() }),
+  execute: async (params, options?: ToolExecutionContext) => {
+    const sessionId = options?.operationContext?.userContext?.get("sessionId") || "unknown-session";
+    const logMessage = `[Sub-Agent Task][SessionID: ${sessionId}] Processing: ${params.task_details}`;
+    console.log(logMessage);
+    return `Sub-task processed with SessionID: ${sessionId}`;
+  },
+});
+
+const subAgent = new Agent({
+  name: "WorkerAgent",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
+  tools: [subAgentTool],
+  hooks: createHooks({
+    onStart: ({ agent, context }) => {
+      const sessionId = context.userContext.get("sessionId");
+      console.log(`[${agent.name}] Operation started. Inherited SessionID: ${sessionId}`);
+    },
+  }),
+});
+
+// Supervisor Agent
+const supervisorHooks = createHooks({
+  onStart: ({ agent, context }: OnStartHookArgs) => {
+    const sessionId = context.userContext.get("sessionId"); // Will be set from generateText options
+    console.log(`[${agent.name}] Supervisor Operation started. SessionID: ${sessionId}`);
+  },
+});
+
+const supervisorAgent = new Agent({
+  name: "SupervisorAgent",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
+  hooks: supervisorHooks,
+  subAgents: [subAgent],
+});
+
+async function runDelegation() {
+  const supervisorSessionContext = new Map<string | symbol, unknown>();
+  supervisorSessionContext.set("sessionId", `session-${Date.now()}`);
+
+  console.log("--- Starting Supervisor Operation with User Context ---");
+  // The supervisor's generateText call includes the userContext.
+  // If it calls delegate_task, this context will be passed to WorkerAgent.
+  await supervisorAgent.generateText("Delegate processing of 'important data' to WorkerAgent.", {
+    userContext: supervisorSessionContext,
+  });
+  console.log("--- Supervisor Operation Finished ---");
+}
+
+// runDelegation();
+```
+
+In this example:
+
+- When `supervisorAgent.generateText` is called with `userContext` containing a `sessionId`, this context is set for the supervisor's operation.
+- If the supervisor LLM decides to use the `delegate_task` tool to delegate to `WorkerAgent`, the `SubAgentManager` ensures that the `supervisorSessionContext` (as a clone) is passed to `WorkerAgent`.
+- `WorkerAgent`'s `onStart` hook and its `subAgentTool` can then access this `sessionId`.
+
+This pattern is crucial for maintaining contextual coherence when tasks are broken down and distributed across multiple specialized agents.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
Currently, the `userContext` within an agent's `OperationContext` is primarily isolated to that specific agent's operation. There is no direct mechanism for a supervisor agent to automatically pass its `userContext` to sub-agents when delegating tasks. Sub-agents operate with their own fresh `userContext` unless context is manually passed through tool arguments, which can be cumbersome.

## What is the new behavior?

This PR introduces the capability for `userContext` to be seamlessly propagated from a supervisor agent to its sub-agents. 

Key changes include:
- `AgentOptions`, `PublicGenerateOptions`, and `InternalGenerateOptions` now accept an optional `userContext` (Map).
- When a sub-agent operation is initiated (e.g., via `delegate_task`), the supervisor's `userContext` (if provided in the supervisor's generate call options or already present in its `OperationContext`) is cloned and passed to the sub-agent.
- The sub-agent's `OperationContext` is then initialized with this cloned `userContext`.
- This allows sub-agents to access contextual information (e.g., global transaction IDs, session data, request-specific configurations) set by the supervisor, ensuring consistency across delegated tasks.
- The cloning mechanism ensures that modifications to `userContext` within a sub-agent do not affect the supervisor's original context or the context of sibling sub-agents.
- Updated documentation (`context.md`) to reflect this new capability, including how it works and example use cases.
- Added comprehensive unit tests for both `Agent` and `SubAgentManager` to cover `userContext` initialization, propagation to hooks, tools, and sub-agents, and isolation.


fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
