### PR TITLE
fix(docs): the createTool function example on the agents/overview page is not using the correct option prop 

### DIFF
--- a/website/docs/agents/overview.md
+++ b/website/docs/agents/overview.md
@@ -46,7 +46,7 @@ import { z } from "zod";
 // Example Tool (see Tools section for details)
 const weatherTool = createTool({
   name: "get_weather",
-  instructions: "Get the current weather for a specific location",
+  description: "Get the current weather for a specific location",
   parameters: z.object({ location: z.string().describe("City and state") }),
   execute: async ({ location }) => {
     console.log(`Tool: Getting weather for ${location}`);
@@ -203,7 +203,7 @@ import { z } from "zod";
 // Create a weather tool using the helper function
 const weatherTool = createTool({
   name: "get_weather",
-  instructions: "Get the current weather for a specific location",
+  description: "Get the current weather for a specific location",
   parameters: z.object({
     location: z.string().describe("The city and state, e.g., San Francisco, CA"),
   }),
@@ -367,7 +367,7 @@ const hooks = createHooks({
 
 const loggerTool = createTool({
   name: "context_aware_logger",
-  instructions: "Logs a message using the request ID from context.",
+  description: "Logs a message using the request ID from context.",
   parameters: z.object({ message: z.string() }),
   execute: async (params: { message: string }, options?: ToolExecutionContext) => {
     const requestId = options?.operationContext?.userContext?.get("requestId") || "unknown";


### PR DESCRIPTION

# the `createTool` function example on the agents/overview page is not using the correct option prop 

this PR fixes #120 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
![2025-05-12_23-12](https://github.com/user-attachments/assets/a9836b27-4651-41b9-b09c-e971528616a9)


## What is the new behavior?
![2025-05-12_23-16](https://github.com/user-attachments/assets/40cf632c-a55f-4a27-8d16-147685065345)


fixes (issue)

## Notes for reviewers

I checked throughout all the documentation to see if this issue repeats, but it only appears in agents/overview.md. 

<!-- Add any notes/questions you may have for reviewers -->
