### PR TITLE
Update Nextjs Quickstart with working Bash command

### DIFF
--- a/website/docs/integrations/nextjs.md
+++ b/website/docs/integrations/nextjs.md
@@ -12,7 +12,7 @@ This guide walks you through setting up VoltAgent in a Next.js application. We'l
 If you prefer to start directly with the completed example project, you can create it using the following command:
 
 ```bash
-npm create voltagent-app@latest -- --example with-nextjs
+npm create voltagent-app@latest --example with-nextjs voltagent
 ```
 
 This command will scaffold the entire Next.js example project described in this guide.


### PR DESCRIPTION
The command line prompt does not pull in the Next.js project. It is missing the correct structure for an example flag. Please see a working example below:

$npm create voltagent-app@latest --example with-nextjs voltagent



Related to issue:
https://github.com/VoltAgent/voltagent/issues/135

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
