### PR TITLE
chore: update `tsconfig.json`'s `target` to `ES2022`

### DIFF
--- a/.changeset/famous-rivers-cough.md
+++ b/.changeset/famous-rivers-cough.md
@@ -1,0 +1,15 @@
+---
+"create-voltagent-app": patch
+"@voltagent/langfuse-exporter": patch
+"@voltagent/anthropic-ai": patch
+"@voltagent/google-ai": patch
+"@voltagent/vercel-ai": patch
+"@voltagent/supabase": patch
+"@voltagent/groq-ai": patch
+"@voltagent/voice": patch
+"@voltagent/core": patch
+"@voltagent/xsai": patch
+"@voltagent/cli": patch
+---
+
+chore: update `tsconfig.json`'s `target` to `ES2022`

--- a/examples/github-repo-analyzer/tsconfig.json
+++ b/examples/github-repo-analyzer/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "ES2022",
     "module": "commonjs",
     "outDir": "dist",
     "esModuleInterop": true,

--- a/examples/with-composio-mcp/tsconfig.json
+++ b/examples/with-composio-mcp/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/examples/with-google-drive-mcp/client/tsconfig.app.json
+++ b/examples/with-google-drive-mcp/client/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",

--- a/examples/with-mcp/tsconfig.json
+++ b/examples/with-mcp/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/examples/with-nextjs/tsconfig.json
+++ b/examples/with-nextjs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/examples/with-rag-chatbot/tsconfig.json
+++ b/examples/with-rag-chatbot/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/examples/with-retrieval/tsconfig.json
+++ b/examples/with-retrieval/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/examples/with-subagents/tsconfig.json
+++ b/examples/with-subagents/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/examples/with-zapier-mcp/tsconfig.json
+++ b/examples/with-zapier-mcp/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/packages/anthropic-ai/tsconfig.json
+++ b/packages/anthropic-ai/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "ES2022",
     "module": "CommonJS",
     "lib": ["es2020", "dom"],
     "declaration": true,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",

--- a/packages/create-voltagent-app/tsconfig.json
+++ b/packages/create-voltagent-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "ES2022",
     "module": "CommonJS",
     "lib": ["es2020", "dom"],
     "declaration": true,

--- a/packages/google-ai/tsconfig.json
+++ b/packages/google-ai/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/packages/groq-ai/tsconfig.json
+++ b/packages/groq-ai/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/packages/langfuse-exporter/tsconfig.json
+++ b/packages/langfuse-exporter/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/packages/supabase/tsconfig.json
+++ b/packages/supabase/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/packages/vercel-ai/tsconfig.json
+++ b/packages/vercel-ai/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/packages/voice/tsconfig.json
+++ b/packages/voice/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/packages/xsai/tsconfig.json
+++ b/packages/xsai/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -147,7 +147,7 @@ Create a basic TypeScript configuration file (tsconfig.json):
 ```json
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Nothing to change.

## What is the new behavior?

Nothing to change.

## Notes for reviewers

I was evaluating whether we could use `tsdown` as a replacement for `tsup`, and during that process, I noticed that the `tsconfig.json` in this project sometimes specifies an older target such as `ES2015`. As a result, unnecessary polyfills were included in the built assets.

Since voltagent requires Node18, which fully supports `ES2022` syntax, we should be able to change the `tsconfig.json` `target` to `ES2022` to minimize polyfills. Also, since voltagent requires Node18, I believe this change should not be considered a breaking change.