### PR TITLE
chore: remove `jsx` option from root `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "jsx": "react",
     "target": "ES2020",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Notes for reviewers

I understand that this project is not fundamentally a React project. Therefore, I believe the `jsx` option in the root `tsconfig.json` is unnecessary. Having this option might lead visitors to mistakenly think the project is intended for React, so I have removed it.