### PR TITLE
chore(core): remove logging via `console.log` in favor of dev logger that won't pollute production logs

### DIFF
--- a/.changeset/all-breads-behave.md
+++ b/.changeset/all-breads-behave.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Remove console based logging in favor of a dev-only logger that will not output logs in production environments by leveraging the NODE_ENV

--- a/packages/core/src/agent/history/index.ts
+++ b/packages/core/src/agent/history/index.ts
@@ -1,15 +1,16 @@
 import { v4 as uuidv4 } from "uuid";
 import { AgentEventEmitter } from "../../events";
-import type { BaseMessage, StepWithContent, UsageInfo } from "../providers/base/types";
-import type { AgentStatus } from "../types";
+import type { NewTimelineEvent } from "../../events/types";
+import devLogger from "../../internal/dev-logger";
 import type { MemoryManager } from "../../memory";
-import type { VoltAgentExporter } from "../../telemetry/exporter";
 import type {
-  ExportAgentHistoryPayload,
   AgentHistoryUpdatableFields,
+  ExportAgentHistoryPayload,
   ExportTimelineEventPayload,
 } from "../../telemetry/client";
-import type { NewTimelineEvent } from "../../events/types";
+import type { VoltAgentExporter } from "../../telemetry/exporter";
+import type { BaseMessage, StepWithContent, UsageInfo } from "../providers/base/types";
+import type { AgentStatus } from "../types";
 
 // Export types
 export type { HistoryStatus } from "./types";
@@ -285,14 +286,13 @@ export class HistoryManager {
         await this.voltAgentExporter.exportHistoryEntry(historyPayload);
       } catch (telemetryError: any) {
         if (telemetryError?.message?.includes("401")) {
-          console.warn(
-            `[HistoryManager] Failed to export history entry to telemetry service for agent ${this.agentId}. Status: 401. Please check your VoltAgentExporter public and secret keys.`,
+          devLogger.warn(
+            `Failed to export history entry to telemetry service for agent ${this.agentId}. Status: 401. Please check your VoltAgentExporter public and secret keys.`,
           );
         } else {
-          console.warn(
-            `[HistoryManager] Failed to export history entry to telemetry service for agent ${this.agentId}. Error:`,
+          devLogger.warn(
+            `Failed to export history entry to telemetry service for agent ${this.agentId}. Error:`,
             telemetryError,
-            "If this issue persists, please open an issue on GitHub: @https://github.com/VoltAgent/voltagent/issues or ask on our Discord server: @https://s.voltagent.dev/discord/",
           );
         }
       }
@@ -463,7 +463,7 @@ export class HistoryManager {
 
       return updatedEntry;
     } catch (error) {
-      console.error("[HistoryManager] Failed to persist timeline event:", error);
+      devLogger.error("Failed to persist timeline event:", error);
       return undefined;
     }
   }

--- a/packages/core/src/agent/history/index.ts
+++ b/packages/core/src/agent/history/index.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import { AgentEventEmitter } from "../../events";
 import type { NewTimelineEvent } from "../../events/types";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import type { MemoryManager } from "../../memory";
 import type {
   AgentHistoryUpdatableFields,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -13,7 +13,7 @@ import type {
   ToolStartEvent,
   ToolSuccessEvent,
 } from "../events/types";
-import devLogger from "../internal/dev-logger";
+import devLogger from "../utils/internal/dev-logger";
 import { MemoryManager } from "../memory";
 import type { BaseRetriever } from "../retriever/retriever";
 import { AgentRegistry } from "../server/registry";

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -13,6 +13,7 @@ import type {
   ToolStartEvent,
   ToolSuccessEvent,
 } from "../events/types";
+import devLogger from "../internal/dev-logger";
 import { MemoryManager } from "../memory";
 import type { BaseRetriever } from "../retriever/retriever";
 import { AgentRegistry } from "../server/registry";
@@ -349,7 +350,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
           event: retrieverErrorEvent,
         });
 
-        console.warn("Failed to retrieve context:", error);
+        devLogger.warn("Failed to retrieve context:", error);
       }
     }
 
@@ -397,7 +398,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
 
       return formattedMemory || "No previous agent interactions found.";
     } catch (error) {
-      console.warn("Error preparing agents memory:", error);
+      devLogger.warn("Error preparing agents memory:", error);
       return "Error retrieving agent history.";
     }
   }
@@ -442,7 +443,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
 
     // Ensure operationContext exists before proceeding
     if (!operationContext) {
-      console.warn(
+      devLogger.warn(
         `[Agent ${this.id}] Missing operationContext in prepareTextOptions. Tool execution context might be incomplete.`,
       );
       // Potentially handle this case more gracefully, e.g., throw an error or create a default context
@@ -477,7 +478,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
               finalExecOptions as ReasoningToolExecuteOptions; // Cast should be safe here
 
             if (!reasoningOptions.historyEntryId || reasoningOptions.historyEntryId === "unknown") {
-              console.warn(
+              devLogger.warn(
                 `Executing reasoning tool '${tool.name}' without a known historyEntryId within the operation context.`,
               );
             }
@@ -664,7 +665,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
 
     if (toolCallId && status === "working") {
       if (context.toolSpans.has(toolCallId)) {
-        console.warn(`[VoltAgentCore] OTEL tool span already exists for toolCallId: ${toolCallId}`);
+        devLogger.warn(`OTEL tool span already exists for toolCallId: ${toolCallId}`);
       } else {
         // Call the helper function
         const toolSpan = startToolSpan({
@@ -699,8 +700,8 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
         data,
       });
     } else {
-      console.warn(
-        `[VoltAgentCore] OpenTelemetry span not found in OperationContext for agent event ${eventName} (Operation ID: ${context.operationId})`,
+      devLogger.warn(
+        `OpenTelemetry span not found in OperationContext for agent event ${eventName} (Operation ID: ${context.operationId})`,
       );
     }
   };
@@ -720,8 +721,8 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
       endToolSpan({ span: toolSpan, resultData });
       context.toolSpans?.delete(toolCallId); // Remove from map after ending
     } else {
-      console.warn(
-        `[VoltAgentCore] OTEL tool span not found for toolCallId: ${toolCallId} in _endOtelToolSpan (Tool: ${toolName})`,
+      devLogger.warn(
+        `OTEL tool span not found for toolCallId: ${toolCallId} in _endOtelToolSpan (Tool: ${toolName})`,
       );
     }
   }
@@ -1497,7 +1498,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
               event: toolErrorEvent,
             });
           } catch (updateError) {
-            console.error(
+            devLogger.error(
               `[Agent ${this.id}] Failed to update tool event to error status for ${toolName} (${toolCallId}):`,
               updateError,
             );

--- a/packages/core/src/agent/open-telemetry/index.ts
+++ b/packages/core/src/agent/open-telemetry/index.ts
@@ -1,12 +1,13 @@
 import {
-  trace,
+  type Attributes,
   type Span,
   SpanKind,
   SpanStatusCode,
-  type Attributes,
   context as apiContext,
+  trace,
 } from "@opentelemetry/api";
 import type { EventStatus, StandardEventData } from "../../events/types";
+import devLogger from "../../internal/dev-logger";
 import type { UsageInfo } from "../providers/base/types";
 
 // Get a tracer instance for this library
@@ -120,12 +121,12 @@ export function endOperationSpan(options: EndOperationSpanOptions): void {
       }
     }
   } catch (e) {
-    console.error("[VoltAgentCore OTEL] Error enriching operation span:", e);
+    devLogger.error("[OTEL] Error enriching operation span:", e);
     try {
       span.setAttribute("otel.enrichment.error", true);
       span.setStatus({ code: SpanStatusCode.ERROR, message: "Span enrichment failed" });
     } catch (safeSetError) {
-      console.error("[VoltAgentCore OTEL] Error setting enrichment error status:", safeSetError);
+      devLogger.error("[OTEL] Error setting enrichment error status:", safeSetError);
     }
   } finally {
     span.end();
@@ -192,15 +193,12 @@ export function endToolSpan(options: EndToolSpanOptions): void {
       span.setStatus({ code: SpanStatusCode.OK });
     }
   } catch (e) {
-    console.error("[VoltAgentCore OTEL] Error enriching tool span:", e);
+    devLogger.error("[OTEL] Error enriching tool span:", e);
     try {
       span.setAttribute("otel.enrichment.error", true);
       span.setStatus({ code: SpanStatusCode.ERROR, message: "Tool span enrichment failed" });
     } catch (safeSetError) {
-      console.error(
-        "[VoltAgentCore OTEL] Error setting tool enrichment error status:",
-        safeSetError,
-      );
+      devLogger.error("[OTEL] Error setting tool enrichment error status:", safeSetError);
     }
   } finally {
     span.end();

--- a/packages/core/src/agent/open-telemetry/index.ts
+++ b/packages/core/src/agent/open-telemetry/index.ts
@@ -7,7 +7,7 @@ import {
   trace,
 } from "@opentelemetry/api";
 import type { EventStatus, StandardEventData } from "../../events/types";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import type { UsageInfo } from "../providers/base/types";
 
 // Get a tracer instance for this library

--- a/packages/core/src/agent/subagent/index.ts
+++ b/packages/core/src/agent/subagent/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import devLogger from "../../internal/dev-logger";
 import { AgentRegistry } from "../../server/registry";
 import { createTool } from "../../tool";
 import type { Agent } from "../index";
@@ -192,7 +193,7 @@ Context: ${JSON.stringify(context)}`,
         status: "success",
       };
     } catch (error) {
-      console.error(`Error in handoffTask to ${targetAgent.name}:`, error);
+      devLogger.error(`Error in handoffTask to ${targetAgent.name}:`, error);
 
       // Get error message safely whether error is Error object or string
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -247,7 +248,7 @@ Context: ${JSON.stringify(context)}`,
             userContext,
           });
         } catch (error) {
-          console.error(`Error in handoffToMultiple for agent ${agent.name}:`, error);
+          devLogger.error(`Error in handoffToMultiple for agent ${agent.name}:`, error);
 
           // Get error message safely whether error is Error object or string
           const errorMessage = error instanceof Error ? error.message : String(error);
@@ -301,7 +302,7 @@ Context: ${JSON.stringify(context)}`,
             .map((name: string) => {
               const agent = this.subAgents.find((a: Agent<any>) => a.name === name);
               if (!agent) {
-                console.warn(
+                devLogger.warn(
                   `Agent "${name}" not found. Available agents: ${this.subAgents.map((a) => a.name).join(", ")}`,
                 );
               }
@@ -358,7 +359,7 @@ Context: ${JSON.stringify(context)}`,
             };
           });
         } catch (error) {
-          console.error("Error in delegate_task tool execution:", error);
+          devLogger.error("Error in delegate_task tool execution:", error);
 
           // Return structured error to the LLM
           return {

--- a/packages/core/src/agent/subagent/index.ts
+++ b/packages/core/src/agent/subagent/index.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import { AgentRegistry } from "../../server/registry";
 import { createTool } from "../../tool";
 import type { Agent } from "../index";

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import type { AgentHistoryEntry } from "../agent/history";
 import type { AgentStatus } from "../agent/types";
 import type { BaseMessage } from "../index";
-import devLogger from "../internal/dev-logger";
+import devLogger from "../utils/internal/dev-logger";
 import { AgentRegistry } from "../server/registry";
 import type { NewTimelineEvent } from "./types";
 

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,11 +1,12 @@
+import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
+import { v4 as uuidv4 } from "uuid";
 import type { AgentHistoryEntry } from "../agent/history";
 import type { AgentStatus } from "../agent/types";
+import type { BaseMessage } from "../index";
+import devLogger from "../internal/dev-logger";
 import { AgentRegistry } from "../server/registry";
-import { v4 as uuidv4 } from "uuid";
 import type { NewTimelineEvent } from "./types";
-import crypto from "node:crypto";
-import type { BaseMessage } from "..";
 
 // New type exports
 export type EventStatus = AgentStatus;
@@ -113,7 +114,7 @@ export class AgentEventEmitter extends EventEmitter {
 
     const agent = AgentRegistry.getInstance().getAgent(agentId);
     if (!agent) {
-      console.warn("[AgentEventEmitter.publishTimelineEvent] Agent not found: ", agentId);
+      devLogger.warn("Agent not found: ", agentId);
       return undefined;
     }
 
@@ -133,13 +134,10 @@ export class AgentEventEmitter extends EventEmitter {
 
         return updatedEntry;
       }
-      console.warn(
-        "[AgentEventEmitter.publishTimelineEvent] Failed to persist event for history: ",
-        historyId,
-      );
+      devLogger.warn("Failed to persist event for history: ", historyId);
       return undefined;
     } catch (error) {
-      console.error("[AgentEventEmitter.publishTimelineEvent] Error persisting event:", error);
+      devLogger.error("Error persisting event:", error);
       return undefined;
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,12 +1,13 @@
 import type { Agent } from "./agent";
 import { startServer } from "./server";
-import { AgentRegistry } from "./server/registry";
-import { checkForUpdates } from "./utils/update";
 import { registerCustomEndpoint, registerCustomEndpoints } from "./server/api";
 import type { CustomEndpointDefinition } from "./server/custom-endpoints";
+import { AgentRegistry } from "./server/registry";
+import { checkForUpdates } from "./utils/update";
 
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { BatchSpanProcessor, type SpanExporter } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import devLogger from "./internal/dev-logger";
 import type { VoltAgentExporter } from "./telemetry/exporter";
 
 export * from "./agent";
@@ -121,7 +122,7 @@ export class VoltAgent {
     // Auto-start server if enabled
     if (options.autoStart !== false) {
       this.startServer().catch((err) => {
-        console.error("[VoltAgent] Failed to start server:", err);
+        devLogger.error("Failed to start server:", err);
         process.exit(1);
       });
     }
@@ -137,14 +138,14 @@ export class VoltAgent {
       });
 
       if (result.hasUpdates) {
-        console.log("\n");
-        console.log(`[VoltAgent] ${result.message}`);
-        console.log("[VoltAgent] Run 'volt update' to update VoltAgent packages");
+        devLogger.info("\n");
+        devLogger.info(result.message);
+        devLogger.info("Run 'volt update' to update VoltAgent packages");
       } else {
-        console.log(`[VoltAgent] ${result.message}`);
+        devLogger.info(result.message);
       }
     } catch (error) {
-      console.error("[VoltAgent] Error checking dependencies:", error);
+      devLogger.error("Error checking dependencies:", error);
     }
   }
 
@@ -174,7 +175,7 @@ export class VoltAgent {
    */
   public async startServer(): Promise<void> {
     if (this.serverStarted) {
-      console.log("[VoltAgent] Server is already running");
+      devLogger.info("Server is already running");
       return;
     }
 
@@ -187,8 +188,8 @@ export class VoltAgent {
       await startServer();
       this.serverStarted = true;
     } catch (error) {
-      console.error(
-        `[VoltAgent] Failed to start server: ${error instanceof Error ? error.message : String(error)}`,
+      devLogger.error(
+        `Failed to start server: ${error instanceof Error ? error.message : String(error)}`,
       );
       throw error;
     }
@@ -209,7 +210,7 @@ export class VoltAgent {
         registerCustomEndpoint(endpoint);
       }
     } catch (error) {
-      console.error(
+      devLogger.error(
         `Failed to register custom endpoint: ${error instanceof Error ? error.message : String(error)}`,
       );
       throw error;
@@ -235,7 +236,7 @@ export class VoltAgent {
         registerCustomEndpoints(endpoints);
       }
     } catch (error) {
-      console.error(
+      devLogger.error(
         `Failed to register custom endpoints: ${error instanceof Error ? error.message : String(error)}`,
       );
       throw error;
@@ -267,8 +268,8 @@ export class VoltAgent {
     exporterOrExporters: (SpanExporter | VoltAgentExporter) | (SpanExporter | VoltAgentExporter)[],
   ): void {
     if (isTelemetryInitializedByVoltAgent) {
-      console.warn(
-        "[VoltAgent] Telemetry seems to be already initialized by a VoltAgent instance. Skipping re-initialization.",
+      devLogger.warn(
+        "Telemetry seems to be already initialized by a VoltAgent instance. Skipping re-initialization.",
       );
       return;
     }
@@ -310,11 +311,11 @@ export class VoltAgent {
       // Add automatic shutdown on SIGTERM
       process.on("SIGTERM", () => {
         this.shutdownTelemetry().catch((err) =>
-          console.error("[VoltAgent] Error during SIGTERM telemetry shutdown:", err),
+          devLogger.error("Error during SIGTERM telemetry shutdown:", err),
         );
       });
     } catch (error) {
-      console.error("[VoltAgent] Failed to initialize OpenTelemetry:", error);
+      devLogger.error("Failed to initialize OpenTelemetry:", error);
     }
   }
 
@@ -325,11 +326,11 @@ export class VoltAgent {
         isTelemetryInitializedByVoltAgent = false;
         registeredProvider = null;
       } catch (error) {
-        console.error("[VoltAgent] Error shutting down OpenTelemetry provider:", error);
+        devLogger.error("Error shutting down OpenTelemetry provider:", error);
       }
     } else {
-      console.log(
-        "[VoltAgent] Telemetry provider was not initialized by this VoltAgent instance or already shut down.",
+      devLogger.info(
+        "Telemetry provider was not initialized by this VoltAgent instance or already shut down.",
       );
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ import { checkForUpdates } from "./utils/update";
 
 import { BatchSpanProcessor, type SpanExporter } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import devLogger from "./internal/dev-logger";
+import devLogger from "./utils/internal/dev-logger";
 import type { VoltAgentExporter } from "./telemetry/exporter";
 
 export * from "./agent";

--- a/packages/core/src/internal/dev-logger.ts
+++ b/packages/core/src/internal/dev-logger.ts
@@ -1,0 +1,76 @@
+/**
+ * A logger for development purposes, that will not pollute the production logs (aka if process.env.NODE_ENV is not "development").
+ *
+ * @example
+ * ```typescript
+ * devLogger.info("Hello, world!");
+ * ```
+ */
+export default {
+  /**
+   * Log a message to the console if the environment is development. This will NOT be logged if process.env.NODE_ENV is not "development".
+   *
+   * @example
+   * ```typescript
+   * devLogger.info("Hello, world!");
+   *
+   * // output: [VoltAgent] [2021-01-01T00:00:00.000Z] INFO: Hello, world!
+   * ```
+   *
+   * @param message - The message to log.
+   * @param args - The arguments to log.
+   */
+  info: (message?: any, ...args: any[]) => {
+    if (isDev()) {
+      console.info(formatLogPrefix("INFO"), message, ...args);
+    }
+  },
+  /**
+   * Log a warning message to the console if the environment is development. This will NOT be logged if process.env.NODE_ENV is not "development".
+   *
+   * @example
+   * ```typescript
+   * devLogger.warn("Hello, world!");
+   *
+   * // output: [VoltAgent] [2021-01-01T00:00:00.000Z] WARN: Hello, world!
+   * ```
+   *
+   * @param message - The message to log.
+   * @param args - The arguments to log.
+   */
+  warn: (message?: any, ...args: any[]) => {
+    if (isDev()) {
+      console.warn(formatLogPrefix("WARN"), message, ...args);
+    }
+  },
+  /**
+   * Log a warning message to the console if the environment is development.
+   *
+   * @example
+   * ```typescript
+   * devLogger.error("Hello, world!");
+   *
+   * // output: [VoltAgent] [2021-01-01T00:00:00.000Z] ERROR: Hello, world!
+   * ```
+   *
+   * @param message - The message to log.
+   * @param args - The arguments to log.
+   */
+  error: (message?: any, ...args: any[]) => {
+    if (isDev()) {
+      console.error(formatLogPrefix("ERROR"), message, ...args);
+    }
+  },
+};
+
+function isDev(): boolean {
+  return process.env.NODE_ENV === "development";
+}
+
+function formatLogPrefix(level: "INFO" | "WARN" | "ERROR"): string {
+  return `[VoltAgent] [${timestamp()}] ${level}: `;
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace("T", " ").slice(0, -1);
+}

--- a/packages/core/src/mcp/client/index.ts
+++ b/packages/core/src/mcp/client/index.ts
@@ -11,7 +11,10 @@ import {
   CallToolResultSchema,
   ListResourcesResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import type * as z from "zod";
 import { convertJsonSchemaToZod } from "zod-from-json-schema";
+import devLogger from "../../internal/dev-logger";
+import { type Tool, createTool } from "../../tool";
 import type {
   ClientInfo,
   HTTPServerConfig,
@@ -22,8 +25,6 @@ import type {
   MCPToolResult,
   StdioServerConfig,
 } from "../types";
-import { createTool, type Tool } from "../../tool";
-import type * as z from "zod";
 
 /**
  * Client for interacting with Model Context Protocol (MCP) servers.
@@ -209,7 +210,7 @@ export class MCPClient extends EventEmitter {
                 });
                 return result.content;
               } catch (execError) {
-                console.error(`Error executing remote tool '${toolDef.name}':`, execError);
+                devLogger.error(`Error executing remote tool '${toolDef.name}':`, execError);
                 throw execError;
               }
             },
@@ -217,7 +218,7 @@ export class MCPClient extends EventEmitter {
 
           executableTools[namespacedToolName] = agentTool;
         } catch (toolCreationError) {
-          console.error(
+          devLogger.error(
             `Failed to create executable tool wrapper for '${toolDef.name}':`,
             toolCreationError,
           );

--- a/packages/core/src/mcp/client/index.ts
+++ b/packages/core/src/mcp/client/index.ts
@@ -13,7 +13,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import type * as z from "zod";
 import { convertJsonSchemaToZod } from "zod-from-json-schema";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import { type Tool, createTool } from "../../tool";
 import type {
   ClientInfo,

--- a/packages/core/src/mcp/registry/index.ts
+++ b/packages/core/src/mcp/registry/index.ts
@@ -1,4 +1,3 @@
-import devLogger from "../../internal/dev-logger";
 import type { Tool } from "../../tool";
 import { MCPClient } from "../client/index";
 import type { AnyToolConfig, MCPServerConfig, ToolsetWithTools } from "../types";
@@ -66,7 +65,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
             break;
           }
         }
-        devLogger.error(`Error disconnecting client ${serverName}:`, error);
+        console.error(`Error disconnecting client ${serverName}:`, error);
       }),
     );
 
@@ -87,7 +86,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
         const agentTools = await client.getAgentTools();
         return Object.values(agentTools);
       } catch (error) {
-        devLogger.error(`Error fetching agent tools from server ${serverName}:`, error);
+        console.error(`Error fetching agent tools from server ${serverName}:`, error);
         return []; // Return empty array for this server on error
       }
     });
@@ -111,7 +110,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
         const rawToolsResult: unknown = await client.listTools();
         return { serverName, rawToolsResult };
       } catch (error) {
-        devLogger.error(`Error fetching raw tools from server ${serverName}:`, error);
+        console.error(`Error fetching raw tools from server ${serverName}:`, error);
         return null;
       }
     });
@@ -125,7 +124,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
           if (this.isAnyToolConfigStructure(toolConfig)) {
             allRawTools[`${result.serverName}.${toolName}`] = toolConfig;
           } else {
-            devLogger.warn(
+            console.warn(
               `Tool '${toolName}' from server '${result.serverName}' has unexpected structure, skipping.`,
             );
           }
@@ -157,7 +156,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
           return { serverName, toolset };
         }
       } catch (error) {
-        devLogger.error(`Error fetching agent toolset for server ${serverName}:`, error);
+        console.error(`Error fetching agent toolset for server ${serverName}:`, error);
       }
       return null; // Indicate failure or no tools for this server
     });
@@ -204,13 +203,13 @@ export class MCPConfiguration<TServerKeys extends string = string> {
               rawToolsResult: rawToolsResult as Record<string, AnyToolConfig>,
             };
           } else {
-            devLogger.warn(
+            console.warn(
               `Not all tools from server '${serverName}' have the expected structure, skipping toolset.`,
             );
           }
         }
       } catch (error) {
-        devLogger.error(`Error fetching raw toolset for server ${serverName}:`, error);
+        console.error(`Error fetching raw toolset for server ${serverName}:`, error);
       }
       return null;
     });
@@ -233,7 +232,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
   public async getClient(serverName: TServerKeys): Promise<MCPClient | undefined> {
     const serverConfig = this.serverConfigs[serverName];
     if (!serverConfig) {
-      devLogger.warn(`No configuration found for server: ${serverName}`);
+      console.warn(`No configuration found for server: ${serverName}`);
       return undefined;
     }
     try {
@@ -289,7 +288,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
         await cachedClient.connect();
         return cachedClient;
       } catch (connectionError) {
-        devLogger.warn(
+        console.warn(
           `Reconnection check failed for client ${serverName}, attempting recreation:`,
           connectionError instanceof Error ? connectionError.message : String(connectionError),
         );
@@ -297,7 +296,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
       }
     }
 
-    devLogger.info(`Creating new MCP connection for server: ${serverName as string}`);
+    console.debug(`Creating new MCP connection for server: ${serverName as string}`);
     const newClient = new MCPClient({
       clientInfo: {
         name: serverName as string,
@@ -309,11 +308,11 @@ export class MCPConfiguration<TServerKeys extends string = string> {
     try {
       await newClient.connect();
       this.mcpClientsById.set(serverName, newClient);
-      devLogger.info(`Successfully connected to MCP server: ${serverName as string}`);
+      console.debug(`Successfully connected to MCP server: ${serverName as string}`);
       return newClient;
     } catch (initialConnectionError) {
       this.mcpClientsById.delete(serverName);
-      devLogger.error(`Failed to connect to MCP server ${serverName}:`, initialConnectionError);
+      console.error(`Failed to connect to MCP server ${serverName}:`, initialConnectionError);
       throw new Error(
         `Connection failure for server ${serverName}: ${initialConnectionError instanceof Error ? initialConnectionError.message : String(initialConnectionError)}`,
       );

--- a/packages/core/src/mcp/registry/index.ts
+++ b/packages/core/src/mcp/registry/index.ts
@@ -1,6 +1,7 @@
+import devLogger from "../../internal/dev-logger";
+import type { Tool } from "../../tool";
 import { MCPClient } from "../client/index";
 import type { AnyToolConfig, MCPServerConfig, ToolsetWithTools } from "../types";
-import type { Tool } from "../../tool";
 
 // Removed global configurationRegistry Map
 
@@ -65,7 +66,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
             break;
           }
         }
-        console.error(`Error disconnecting client ${serverName}:`, error);
+        devLogger.error(`Error disconnecting client ${serverName}:`, error);
       }),
     );
 
@@ -86,7 +87,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
         const agentTools = await client.getAgentTools();
         return Object.values(agentTools);
       } catch (error) {
-        console.error(`Error fetching agent tools from server ${serverName}:`, error);
+        devLogger.error(`Error fetching agent tools from server ${serverName}:`, error);
         return []; // Return empty array for this server on error
       }
     });
@@ -110,7 +111,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
         const rawToolsResult: unknown = await client.listTools();
         return { serverName, rawToolsResult };
       } catch (error) {
-        console.error(`Error fetching raw tools from server ${serverName}:`, error);
+        devLogger.error(`Error fetching raw tools from server ${serverName}:`, error);
         return null;
       }
     });
@@ -124,7 +125,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
           if (this.isAnyToolConfigStructure(toolConfig)) {
             allRawTools[`${result.serverName}.${toolName}`] = toolConfig;
           } else {
-            console.warn(
+            devLogger.warn(
               `Tool '${toolName}' from server '${result.serverName}' has unexpected structure, skipping.`,
             );
           }
@@ -156,7 +157,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
           return { serverName, toolset };
         }
       } catch (error) {
-        console.error(`Error fetching agent toolset for server ${serverName}:`, error);
+        devLogger.error(`Error fetching agent toolset for server ${serverName}:`, error);
       }
       return null; // Indicate failure or no tools for this server
     });
@@ -203,13 +204,13 @@ export class MCPConfiguration<TServerKeys extends string = string> {
               rawToolsResult: rawToolsResult as Record<string, AnyToolConfig>,
             };
           } else {
-            console.warn(
+            devLogger.warn(
               `Not all tools from server '${serverName}' have the expected structure, skipping toolset.`,
             );
           }
         }
       } catch (error) {
-        console.error(`Error fetching raw toolset for server ${serverName}:`, error);
+        devLogger.error(`Error fetching raw toolset for server ${serverName}:`, error);
       }
       return null;
     });
@@ -232,7 +233,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
   public async getClient(serverName: TServerKeys): Promise<MCPClient | undefined> {
     const serverConfig = this.serverConfigs[serverName];
     if (!serverConfig) {
-      console.warn(`No configuration found for server: ${serverName}`);
+      devLogger.warn(`No configuration found for server: ${serverName}`);
       return undefined;
     }
     try {
@@ -288,7 +289,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
         await cachedClient.connect();
         return cachedClient;
       } catch (connectionError) {
-        console.warn(
+        devLogger.warn(
           `Reconnection check failed for client ${serverName}, attempting recreation:`,
           connectionError instanceof Error ? connectionError.message : String(connectionError),
         );
@@ -296,7 +297,7 @@ export class MCPConfiguration<TServerKeys extends string = string> {
       }
     }
 
-    console.debug(`Creating new MCP connection for server: ${serverName as string}`);
+    devLogger.info(`Creating new MCP connection for server: ${serverName as string}`);
     const newClient = new MCPClient({
       clientInfo: {
         name: serverName as string,
@@ -308,11 +309,11 @@ export class MCPConfiguration<TServerKeys extends string = string> {
     try {
       await newClient.connect();
       this.mcpClientsById.set(serverName, newClient);
-      console.debug(`Successfully connected to MCP server: ${serverName as string}`);
+      devLogger.info(`Successfully connected to MCP server: ${serverName as string}`);
       return newClient;
     } catch (initialConnectionError) {
       this.mcpClientsById.delete(serverName);
-      console.error(`Failed to connect to MCP server ${serverName}:`, initialConnectionError);
+      devLogger.error(`Failed to connect to MCP server ${serverName}:`, initialConnectionError);
       throw new Error(
         `Connection failure for server ${serverName}: ${initialConnectionError instanceof Error ? initialConnectionError.message : String(initialConnectionError)}`,
       );

--- a/packages/core/src/memory/in-memory/index.spec.ts
+++ b/packages/core/src/memory/in-memory/index.spec.ts
@@ -1,6 +1,17 @@
 import { InMemoryStorage } from ".";
 import type { Conversation, MemoryMessage } from "../types";
 import type { NewTimelineEvent } from "../../events/types";
+import devLogger from "../../utils/internal/dev-logger";
+
+// Mock devLogger
+jest.mock("../../utils/internal/dev-logger", () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
 
 // Mock Math.random for generateId
 const mockRandomValues = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6];
@@ -53,6 +64,10 @@ describe("InMemoryStorage", () => {
   beforeEach(() => {
     // Reset the mock random index for each test
     mockRandomIndex = 0;
+    // Reset devLogger mocks
+    (devLogger.info as jest.Mock).mockClear();
+    (devLogger.warn as jest.Mock).mockClear();
+    (devLogger.error as jest.Mock).mockClear();
     // Create a fresh storage instance for each test
     storage = new InMemoryStorage({ debug: false });
   });
@@ -729,7 +744,6 @@ describe("InMemoryStorage", () => {
 
     it("should enable debug logging when configured", () => {
       // Arrange
-      const consoleSpy = jest.spyOn(console, "log").mockImplementation();
       const debugStorage = new InMemoryStorage({ debug: true });
 
       // Act
@@ -737,10 +751,7 @@ describe("InMemoryStorage", () => {
       debugStorage.debug("Test debug message");
 
       // Assert
-      expect(consoleSpy).toHaveBeenCalledWith("[InMemoryStorage] Test debug message", "");
-
-      // Cleanup
-      consoleSpy.mockRestore();
+      expect(devLogger.info).toHaveBeenCalledWith("[InMemoryStorage] Test debug message", "");
     });
   });
 

--- a/packages/core/src/memory/in-memory/index.ts
+++ b/packages/core/src/memory/in-memory/index.ts
@@ -1,5 +1,5 @@
 import type { NewTimelineEvent } from "../../events/types";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import type {
   Conversation,
   CreateConversationInput,

--- a/packages/core/src/memory/in-memory/index.ts
+++ b/packages/core/src/memory/in-memory/index.ts
@@ -1,4 +1,5 @@
 import type { NewTimelineEvent } from "../../events/types";
+import devLogger from "../../internal/dev-logger";
 import type {
   Conversation,
   CreateConversationInput,
@@ -275,7 +276,7 @@ export class InMemoryStorage implements Memory {
    */
   private debug(message: string, data?: unknown): void {
     if (this.options.debug) {
-      console.log(`[InMemoryStorage] ${message}`, data || "");
+      devLogger.info(`[InMemoryStorage] ${message}`, data || "");
     }
   }
 

--- a/packages/core/src/memory/libsql/index.ts
+++ b/packages/core/src/memory/libsql/index.ts
@@ -5,7 +5,7 @@ import type { Client, Row } from "@libsql/client";
 import { createClient } from "@libsql/client";
 import type { BaseMessage } from "../../agent/providers/base/types";
 import type { NewTimelineEvent } from "../../events/types";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import { safeJsonParse } from "../../utils";
 import type {
   Conversation,

--- a/packages/core/src/memory/libsql/index.ts
+++ b/packages/core/src/memory/libsql/index.ts
@@ -1,10 +1,11 @@
 import { existsSync } from "node:fs";
+import fs from "node:fs";
 import { join } from "node:path";
 import type { Client, Row } from "@libsql/client";
 import { createClient } from "@libsql/client";
-import fs from "node:fs";
 import type { BaseMessage } from "../../agent/providers/base/types";
 import type { NewTimelineEvent } from "../../events/types";
+import devLogger from "../../internal/dev-logger";
 import { safeJsonParse } from "../../utils";
 import type {
   Conversation,
@@ -143,7 +144,7 @@ export class LibSQLStorage implements Memory {
    */
   private debug(message: string, data?: unknown): void {
     if (this.options?.debug) {
-      console.log(`[LibSQLStorage] ${message}`, data || "");
+      devLogger.info(`[LibSQLStorage] ${message}`, data || "");
     }
   }
 
@@ -302,16 +303,16 @@ export class LibSQLStorage implements Memory {
 
       if (result.success) {
         if ((result.migratedCount || 0) > 0) {
-          console.log(`${result.migratedCount} records successfully migrated`);
+          devLogger.info(`${result.migratedCount} records successfully migrated`);
         }
       } else {
-        console.error("Migration error:", result.error);
+        devLogger.error("Migration error:", result.error);
 
         // Restore from backup in case of error
         const restoreResult = await this.migrateAgentHistoryData({});
 
         if (restoreResult.success) {
-          console.log("Successfully restored from backup");
+          devLogger.info("Successfully restored from backup");
         }
       }
     } catch (error) {

--- a/packages/core/src/memory/manager/index.ts
+++ b/packages/core/src/memory/manager/index.ts
@@ -10,7 +10,7 @@ import type {
   MemoryWriteSuccessEvent,
   NewTimelineEvent,
 } from "../../events/types";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import { NodeType, createNodeId } from "../../utils/node-utils";
 import { LibSQLStorage } from "../index";
 import type { Memory, MemoryMessage, MemoryOptions } from "../types";

--- a/packages/core/src/memory/manager/index.ts
+++ b/packages/core/src/memory/manager/index.ts
@@ -1,18 +1,19 @@
 import type { StepWithContent } from "../../agent/providers";
 import type { BaseMessage } from "../../agent/providers/base/types";
-import { AgentEventEmitter } from "../../events";
-import { LibSQLStorage } from "../index";
-import type { Memory, MemoryMessage, MemoryOptions } from "../types";
-import { NodeType, createNodeId } from "../../utils/node-utils";
 import type { OperationContext } from "../../agent/types";
+import { AgentEventEmitter } from "../../events";
 import type {
-  NewTimelineEvent,
   MemoryReadStartEvent,
   MemoryReadSuccessEvent,
+  MemoryWriteErrorEvent,
   MemoryWriteStartEvent,
   MemoryWriteSuccessEvent,
-  MemoryWriteErrorEvent,
+  NewTimelineEvent,
 } from "../../events/types";
+import devLogger from "../../internal/dev-logger";
+import { NodeType, createNodeId } from "../../utils/node-utils";
+import { LibSQLStorage } from "../index";
+import type { Memory, MemoryMessage, MemoryOptions } from "../types";
 
 /**
  * Convert BaseMessage to MemoryMessage for memory storage
@@ -94,7 +95,7 @@ export class MemoryManager {
         event: event,
       });
     } catch (error) {
-      console.error("[Memory] Failed to publish timeline event:", error);
+      devLogger.error("Failed to publish timeline event:", error);
     }
   }
 
@@ -193,7 +194,7 @@ export class MemoryManager {
       // Publish the memory write error event
       await this.publishTimelineEvent(context, memoryWriteErrorEvent);
 
-      console.error("[Memory] Failed to save message:", error);
+      devLogger.error("Failed to save message:", error);
     }
   }
 
@@ -324,7 +325,7 @@ export class MemoryManager {
         await this.publishTimelineEvent(context, memoryReadSuccessEvent);
       } catch (error) {
         // TODO: add new event for getMessages
-        console.error("[Memory] Failed to get messages:", error);
+        devLogger.error("Failed to get messages:", error);
       }
     }
 
@@ -429,7 +430,7 @@ export class MemoryManager {
         await this.addStepsToHistoryEntry(agentId, entry.id, entry.steps);
       }
     } catch (error) {
-      console.error("[Memory] Failed to store history entry:", error);
+      devLogger.error("Failed to store history entry:", error);
     }
   }
 
@@ -453,7 +454,7 @@ export class MemoryManager {
       }
       return undefined;
     } catch (error) {
-      console.error("[Memory] Failed to get history entry:", error);
+      devLogger.error("Failed to get history entry:", error);
       return undefined;
     }
   }
@@ -472,7 +473,7 @@ export class MemoryManager {
       const agentEntries = await this.memory.getAllHistoryEntriesByAgent(agentId);
       return agentEntries;
     } catch (error) {
-      console.error("[Memory] Failed to get all history entries:", error);
+      devLogger.error("Failed to get all history entries:", error);
       return [];
     }
   }
@@ -520,7 +521,7 @@ export class MemoryManager {
       // Return the updated record with all relationships
       return await this.getHistoryEntryById(agentId, entryId);
     } catch (error) {
-      console.error("[Memory] Failed to update history entry:", error);
+      devLogger.error("Failed to update history entry:", error);
       return undefined;
     }
   }
@@ -569,7 +570,7 @@ export class MemoryManager {
       // Return the updated record with all relationships
       return await this.getHistoryEntryById(agentId, entryId);
     } catch (error) {
-      console.error("[Memory] Failed to add steps to history entry:", error);
+      devLogger.error("Failed to add steps to history entry:", error);
       return undefined;
     }
   }
@@ -601,7 +602,7 @@ export class MemoryManager {
 
       return await this.getHistoryEntryById(agentId, historyId);
     } catch (error) {
-      console.error("Memory: Failed to add timeline event to history entry:", error);
+      devLogger.error("Failed to add timeline event to history entry:", error);
       return undefined;
     }
   }

--- a/packages/core/src/telemetry/client/index.ts
+++ b/packages/core/src/telemetry/client/index.ts
@@ -2,7 +2,7 @@ import type { AgentHistoryEntry, HistoryStep } from "../../agent/history";
 import type { UsageInfo } from "../../agent/providers";
 import type { AgentStatus } from "../../agent/types";
 import type { NewTimelineEvent } from "../../events/types";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import type { VoltAgentExporterOptions } from "../exporter";
 
 export interface ExportAgentHistoryPayload {

--- a/packages/core/src/telemetry/client/index.ts
+++ b/packages/core/src/telemetry/client/index.ts
@@ -1,8 +1,9 @@
-import type { VoltAgentExporterOptions } from "../exporter";
 import type { AgentHistoryEntry, HistoryStep } from "../../agent/history";
-import type { AgentStatus } from "../../agent/types";
 import type { UsageInfo } from "../../agent/providers";
+import type { AgentStatus } from "../../agent/types";
 import type { NewTimelineEvent } from "../../events/types";
+import devLogger from "../../internal/dev-logger";
+import type { VoltAgentExporterOptions } from "../exporter";
 
 export interface ExportAgentHistoryPayload {
   agent_id: string;
@@ -101,7 +102,7 @@ export class TelemetryServiceApiClient {
 
       return await response.json();
     } catch (error) {
-      console.error("API request error:", error);
+      devLogger.error("API request error:", error);
       throw error;
     }
   }
@@ -137,7 +138,7 @@ export class TelemetryServiceApiClient {
   public async exportTimelineEvent(
     timelineEventData: ExportTimelineEventPayload,
   ): Promise<{ id: string }> {
-    // Timeline eventlerini history-events endpoint'ine taşıyoruz
+    // NOTE: We are moving timeline events to the history-events endpoint
     const { event, history_id, event_id, agent_id } = timelineEventData;
 
     const payload = {
@@ -165,7 +166,7 @@ export class TelemetryServiceApiClient {
   }
 
   public async exportHistorySteps(history_id: string, steps: HistoryStep[]): Promise<void> {
-    // History güncelleyerek steps bilgisini metadata'ya ekle
+    // NOTE: We are updating the history by adding the steps information to the metadata
     const payload = {
       metadata: {
         steps,
@@ -179,7 +180,7 @@ export class TelemetryServiceApiClient {
     history_id: string,
     updates: AgentHistoryUpdatableFields,
   ): Promise<void> {
-    // Güncellemeleri history endpoint'ine gönder
+    // NOTE: We are updating the history by adding the steps information to the metadata
     const payload: Record<string, unknown> = {};
 
     if (updates.input) payload.input = updates.input;
@@ -188,7 +189,7 @@ export class TelemetryServiceApiClient {
     if (updates.usage) payload.usage = updates.usage;
     if (updates.endTime) payload.endTime = updates.endTime;
 
-    // agent_snapshot'ı metadata olarak ekle
+    // NOTE: We are adding the agent_snapshot to the metadata
     if (updates.metadata) {
       payload.metadata = {
         ...updates.metadata,

--- a/packages/core/src/tool/index.ts
+++ b/packages/core/src/tool/index.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import type { z } from "zod";
 import type { BaseTool, ToolExecuteOptions, ToolSchema } from "../agent/providers/base/types";
-import devLogger from "../internal/dev-logger";
+import devLogger from "../utils/internal/dev-logger";
 
 // Export ToolManager and related types
 export { ToolManager, ToolStatus, ToolStatusInfo } from "./manager";

--- a/packages/core/src/tool/index.ts
+++ b/packages/core/src/tool/index.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
-import type { BaseTool, ToolExecuteOptions, ToolSchema } from "../agent/providers/base/types";
 import type { z } from "zod";
+import type { BaseTool, ToolExecuteOptions, ToolSchema } from "../agent/providers/base/types";
+import devLogger from "../internal/dev-logger";
 
 // Export ToolManager and related types
 export { ToolManager, ToolStatus, ToolStatusInfo } from "./manager";
@@ -79,7 +80,7 @@ export class Tool<T extends ToolSchema = ToolSchema> /* implements BaseTool<z.in
       throw new Error("Tool name is required");
     }
     if (!options.description) {
-      console.warn(`Tool '${options.name}' created without a description.`);
+      devLogger.warn(`Tool '${options.name}' created without a description.`);
     }
     if (!options.parameters) {
       throw new Error(`Tool '${options.name}' parameters schema is required`);

--- a/packages/core/src/tool/manager/index.ts
+++ b/packages/core/src/tool/manager/index.ts
@@ -1,6 +1,7 @@
 import type { BaseTool, ToolExecuteOptions } from "../../agent/providers/base/types";
+import devLogger from "../../internal/dev-logger";
 import { zodSchemaToJsonUI } from "../../utils/toolParser";
-import { createTool, type AgentTool } from "../index";
+import { type AgentTool, createTool } from "../index";
 import type { Toolkit } from "../toolkit";
 
 /**
@@ -100,7 +101,7 @@ export class ToolManager {
       toolkit.tools.some((t) => t.name === tool.name),
     );
     if (conflictsWithToolkitTool) {
-      console.warn(
+      devLogger.warn(
         `[ToolManager] Warning: Standalone tool name '${tool.name}' conflicts with a tool inside an existing toolkit.`,
       );
     }
@@ -156,7 +157,7 @@ export class ToolManager {
           .filter((tk) => tk.name !== toolkit.name)
           .some((tk) => tk.tools.some((t) => t.name === tool.name))
       ) {
-        console.warn(
+        devLogger.warn(
           `[ToolManager] Warning: Tool '${tool.name}' in toolkit '${toolkit.name}' conflicts with an existing tool. Toolkit not added/replaced.`,
         );
         return false;
@@ -168,10 +169,10 @@ export class ToolManager {
       // Before replacing, ensure no name conflicts are introduced by the *new* toolkit's tools
       // (This check is already done above, but double-checking can be safer depending on logic complexity)
       this.toolkits[existingIndex] = toolkit;
-      console.log(`[ToolManager] Replaced toolkit: ${toolkit.name}`);
+      devLogger.info(`Replaced toolkit: ${toolkit.name}`);
     } else {
       this.toolkits.push(toolkit);
-      console.log(`[ToolManager] Added toolkit: ${toolkit.name}`);
+      devLogger.info(`Added toolkit: ${toolkit.name}`);
     }
     return true;
   }
@@ -184,7 +185,7 @@ export class ToolManager {
     for (const item of items) {
       // Basic validation of item
       if (!item || !("name" in item)) {
-        console.warn("[ToolManager] Skipping invalid item in addItems:", item);
+        devLogger.warn("Skipping invalid item in addItems:", item);
         continue;
       }
 
@@ -193,7 +194,7 @@ export class ToolManager {
         if (item.tools && Array.isArray(item.tools)) {
           this.addToolkit(item);
         } else {
-          console.warn(
+          devLogger.warn(
             `[ToolManager] Skipping toolkit '${item.name}' due to missing or invalid 'tools' array.`,
           );
         }
@@ -202,7 +203,7 @@ export class ToolManager {
         if (typeof item.execute === "function") {
           this.addTool(item);
         } else {
-          console.warn(
+          devLogger.warn(
             `[ToolManager] Skipping tool '${item.name}' due to missing or invalid 'execute' function.`,
           );
         }
@@ -219,7 +220,7 @@ export class ToolManager {
     this.tools = this.tools.filter((t) => t.name !== toolName);
     const removed = this.tools.length < initialLength;
     if (removed) {
-      console.log(`[ToolManager] Removed standalone tool: ${toolName}`);
+      devLogger.info(`Removed standalone tool: ${toolName}`);
     }
     return removed;
   }
@@ -233,7 +234,7 @@ export class ToolManager {
     this.toolkits = this.toolkits.filter((tk) => tk.name !== toolkitName);
     const removed = this.toolkits.length < initialLength;
     if (removed) {
-      console.log(`[ToolManager] Removed toolkit: ${toolkitName}`);
+      devLogger.info(`Removed toolkit: ${toolkitName}`);
     }
     return removed;
   }
@@ -249,7 +250,7 @@ export class ToolManager {
         (dt) => dt?.name && dt?.parameters && typeof dt?.execute === "function", // Apply optional chaining
       );
       if (validDynamicTools.length !== dynamicTools.length) {
-        console.warn(
+        devLogger.warn(
           "[ToolManager] Some dynamic tools provided to prepareToolsForGeneration were invalid and ignored.",
         );
       }
@@ -337,7 +338,7 @@ export class ToolManager {
       return await tool.execute(args, options);
     } catch (error) {
       // Log the specific error for better debugging
-      console.error(`[ToolManager] Error executing tool '${toolName}':`, error);
+      devLogger.error(`Error executing tool '${toolName}':`, error);
       // Re-throw a more informative error
       const errorMessage = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to execute tool ${toolName}: ${errorMessage}`);

--- a/packages/core/src/tool/manager/index.ts
+++ b/packages/core/src/tool/manager/index.ts
@@ -1,5 +1,5 @@
 import type { BaseTool, ToolExecuteOptions } from "../../agent/providers/base/types";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import { zodSchemaToJsonUI } from "../../utils/toolParser";
 import { type AgentTool, createTool } from "../index";
 import type { Toolkit } from "../toolkit";

--- a/packages/core/src/tool/reasoning/tools.ts
+++ b/packages/core/src/tool/reasoning/tools.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 import { createTool } from "..";
 import type { ToolExecuteOptions } from "../../agent/providers/base/types";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../../utils/internal/dev-logger";
 import {
   NextAction,
   type ReasoningStep,

--- a/packages/core/src/tool/reasoning/tools.ts
+++ b/packages/core/src/tool/reasoning/tools.ts
@@ -1,7 +1,8 @@
-import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
 import { createTool } from "..";
 import type { ToolExecuteOptions } from "../../agent/providers/base/types";
+import devLogger from "../../internal/dev-logger";
 import {
   NextAction,
   type ReasoningStep,
@@ -36,7 +37,7 @@ export const thinkTool = createTool({
     const { agentId, historyEntryId } = reasoningOptions || {};
 
     if (!agentId || !historyEntryId) {
-      console.error("Think tool requires agentId and historyEntryId in options.");
+      devLogger.error("Think tool requires agentId and historyEntryId in options.");
       return "Error: Missing required agentId or historyEntryId in execution options.";
     }
 
@@ -58,7 +59,7 @@ export const thinkTool = createTool({
 
       return `Thought step "${title}" recorded successfully.`;
     } catch (error) {
-      console.error("Error processing or emitting thought step:", error);
+      devLogger.error("Error processing or emitting thought step:", error);
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       return `Error recording thought step: ${errorMessage}`;
     }
@@ -98,7 +99,7 @@ export const analyzeTool = createTool({
     const { agentId, historyEntryId } = reasoningOptions || {};
 
     if (!agentId || !historyEntryId) {
-      console.error("Analyze tool requires agentId and historyEntryId in options.");
+      devLogger.error("Analyze tool requires agentId and historyEntryId in options.");
       return "Error: Missing required agentId or historyEntryId in execution options.";
     }
 
@@ -121,7 +122,7 @@ export const analyzeTool = createTool({
 
       return `Analysis step "${title}" recorded successfully. Next action: ${next_action}.`;
     } catch (error) {
-      console.error("Error processing or emitting analysis step:", error);
+      devLogger.error("Error processing or emitting analysis step:", error);
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       return `Error recording analysis step: ${errorMessage}`;
     }

--- a/packages/core/src/tool/toolkit.ts
+++ b/packages/core/src/tool/toolkit.ts
@@ -1,5 +1,5 @@
 import type { ToolSchema } from "../agent/providers/base/types";
-import devLogger from "../internal/dev-logger";
+import devLogger from "../utils/internal/dev-logger";
 import type { Tool } from "./index";
 
 /**

--- a/packages/core/src/tool/toolkit.ts
+++ b/packages/core/src/tool/toolkit.ts
@@ -1,4 +1,5 @@
 import type { ToolSchema } from "../agent/providers/base/types";
+import devLogger from "../internal/dev-logger";
 import type { Tool } from "./index";
 
 /**
@@ -49,7 +50,7 @@ export const createToolkit = (options: Toolkit): Toolkit => {
     throw new Error("Toolkit name is required");
   }
   if (!options.tools || options.tools.length === 0) {
-    console.warn(`Toolkit '${options.name}' created without any tools.`);
+    devLogger.warn(`Toolkit '${options.name}' created without any tools.`);
   }
 
   return {

--- a/packages/core/src/utils/internal/dev-logger/index.spec.ts
+++ b/packages/core/src/utils/internal/dev-logger/index.spec.ts
@@ -1,0 +1,261 @@
+import devLogger from "./index";
+
+describe("devLogger", () => {
+  let consoleSpy: {
+    info: jest.SpyInstance;
+    warn: jest.SpyInstance;
+    error: jest.SpyInstance;
+  };
+
+  beforeEach(() => {
+    consoleSpy = {
+      info: jest.spyOn(console, "info").mockImplementation(() => {}),
+      warn: jest.spyOn(console, "warn").mockImplementation(() => {}),
+      error: jest.spyOn(console, "error").mockImplementation(() => {}),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env.NODE_ENV = undefined;
+  });
+
+  describe("when NODE_ENV is development", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+    });
+
+    describe("info", () => {
+      it("should log info message to console", () => {
+        const message = "Test info message";
+        const args = ["arg1", "arg2"];
+
+        devLogger.info(message, ...args);
+
+        expect(consoleSpy.info).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.info).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] INFO: $/,
+          ),
+          message,
+          ...args,
+        );
+      });
+
+      it("should log without additional arguments", () => {
+        const message = "Test info message";
+
+        devLogger.info(message);
+
+        expect(consoleSpy.info).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.info).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] INFO: $/,
+          ),
+          message,
+        );
+      });
+
+      it("should log without any arguments", () => {
+        devLogger.info();
+
+        expect(consoleSpy.info).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.info).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] INFO: $/,
+          ),
+          undefined,
+        );
+      });
+    });
+
+    describe("warn", () => {
+      it("should log warning message to console", () => {
+        const message = "Test warning message";
+        const args = ["arg1", "arg2"];
+
+        devLogger.warn(message, ...args);
+
+        expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.warn).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] WARN: $/,
+          ),
+          message,
+          ...args,
+        );
+      });
+
+      it("should log without additional arguments", () => {
+        const message = "Test warning message";
+
+        devLogger.warn(message);
+
+        expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.warn).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] WARN: $/,
+          ),
+          message,
+        );
+      });
+    });
+
+    describe("error", () => {
+      it("should log error message to console", () => {
+        const message = "Test error message";
+        const args = ["arg1", "arg2"];
+
+        devLogger.error(message, ...args);
+
+        expect(consoleSpy.error).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.error).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: $/,
+          ),
+          message,
+          ...args,
+        );
+      });
+
+      it("should log without additional arguments", () => {
+        const message = "Test error message";
+
+        devLogger.error(message);
+
+        expect(consoleSpy.error).toHaveBeenCalledTimes(1);
+        expect(consoleSpy.error).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] ERROR: $/,
+          ),
+          message,
+        );
+      });
+    });
+
+    describe("log format", () => {
+      it("should format log prefix correctly", () => {
+        const fixedDate = new Date("2023-01-01T12:00:00.000Z");
+        jest.spyOn(global, "Date").mockImplementation(() => fixedDate as any);
+
+        devLogger.info("test message");
+
+        expect(consoleSpy.info).toHaveBeenCalledWith(
+          "[VoltAgent] [2023-01-01 12:00:00.000] INFO: ",
+          "test message",
+        );
+
+        jest.restoreAllMocks();
+      });
+    });
+  });
+
+  describe("when NODE_ENV is not development", () => {
+    const testCases = [
+      { env: "production", description: "production" },
+      { env: "test", description: "test" },
+      { env: undefined, description: "undefined" },
+      { env: "", description: "empty string" },
+    ];
+
+    testCases.forEach(({ env, description }) => {
+      describe(`when NODE_ENV is ${description}`, () => {
+        beforeEach(() => {
+          if (env === undefined) {
+            process.env.NODE_ENV = undefined;
+          } else {
+            process.env.NODE_ENV = env;
+          }
+        });
+
+        it("should not log info messages", () => {
+          devLogger.info("Test message");
+          expect(consoleSpy.info).not.toHaveBeenCalled();
+        });
+
+        it("should not log warning messages", () => {
+          devLogger.warn("Test message");
+          expect(consoleSpy.warn).not.toHaveBeenCalled();
+        });
+
+        it("should not log error messages", () => {
+          devLogger.error("Test message");
+          expect(consoleSpy.error).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("multiple log calls", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+    });
+
+    it("should handle multiple consecutive log calls", () => {
+      devLogger.info("First message");
+      devLogger.warn("Second message");
+      devLogger.error("Third message");
+
+      expect(consoleSpy.info).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.warn).toHaveBeenCalledTimes(1);
+      expect(consoleSpy.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("should maintain separate timestamps for each call", () => {
+      devLogger.info("First message");
+      devLogger.info("Second message");
+
+      expect(consoleSpy.info).toHaveBeenCalledTimes(2);
+
+      const firstCall = consoleSpy.info.mock.calls[0][0];
+      const secondCall = consoleSpy.info.mock.calls[1][0];
+
+      // Both should have valid timestamp format but might be different
+      expect(firstCall).toMatch(
+        /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] INFO: $/,
+      );
+      expect(secondCall).toMatch(
+        /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] INFO: $/,
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+    });
+
+    it("should handle null message", () => {
+      devLogger.info(null);
+      expect(consoleSpy.info).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] INFO: $/,
+        ),
+        null,
+      );
+    });
+
+    it("should handle object messages", () => {
+      const obj = { key: "value", number: 123 };
+      devLogger.info(obj);
+      expect(consoleSpy.info).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] INFO: $/,
+        ),
+        obj,
+      );
+    });
+
+    it("should handle mixed argument types", () => {
+      const args = ["string", 123, { obj: true }, null, undefined];
+      devLogger.warn("Mixed args:", ...args);
+      expect(consoleSpy.warn).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^\[VoltAgent\] \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] WARN: $/,
+        ),
+        "Mixed args:",
+        ...args,
+      );
+    });
+  });
+});

--- a/packages/core/src/utils/internal/dev-logger/index.ts
+++ b/packages/core/src/utils/internal/dev-logger/index.ts
@@ -63,14 +63,14 @@ export default {
   },
 };
 
-function isDev(): boolean {
+const isDev = (): boolean => {
   return process.env.NODE_ENV === "development";
-}
+};
 
-function formatLogPrefix(level: "INFO" | "WARN" | "ERROR"): string {
+const formatLogPrefix = (level: "INFO" | "WARN" | "ERROR"): string => {
   return `[VoltAgent] [${timestamp()}] ${level}: `;
-}
+};
 
-function timestamp(): string {
+const timestamp = (): string => {
   return new Date().toISOString().replace("T", " ").slice(0, -1);
-}
+};

--- a/packages/core/src/utils/update/index.ts
+++ b/packages/core/src/utils/update/index.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import * as ncuPackage from "npm-check-updates";
-import devLogger from "../../internal/dev-logger";
+import devLogger from "../internal/dev-logger";
 
 type UpdateOptions = {
   filter?: string;

--- a/packages/core/src/utils/update/index.ts
+++ b/packages/core/src/utils/update/index.ts
@@ -1,7 +1,7 @@
-import path from "node:path";
-/* import fs from "fs"; */
-import * as ncuPackage from "npm-check-updates";
 import fs from "node:fs";
+import path from "node:path";
+import * as ncuPackage from "npm-check-updates";
+import devLogger from "../../internal/dev-logger";
 
 type UpdateOptions = {
   filter?: string;
@@ -144,7 +144,7 @@ export const checkForUpdates = async (
       message: "All packages are up to date",
     };
   } catch (error) {
-    console.error("Error checking for updates:", error);
+    devLogger.error("Error checking for updates:", error);
     return {
       hasUpdates: false,
       updates: [],
@@ -207,7 +207,7 @@ export const updateAllPackages = async (
     // 3. Prepare the package list for security
     const packagesToUpdate = updateCheckResult.updates.map((pkg) => pkg.name);
 
-    console.log(`Updating ${packagesToUpdate.length} packages in ${rootDir}`);
+    devLogger.info(`Updating ${packagesToUpdate.length} packages in ${rootDir}`);
 
     // Use npm-check-updates API to perform the update
     // Use the filter parameter to only update our packages
@@ -238,7 +238,7 @@ export const updateAllPackages = async (
       updatedPackages,
     };
   } catch (error) {
-    console.error("Error updating packages:", error);
+    devLogger.error("Error updating packages:", error);
     return {
       success: false,
       message: `Failed to update packages: ${error instanceof Error ? error.message : String(error)}`,
@@ -287,7 +287,7 @@ export const updateSinglePackage = async (
     const rootDir = packagePath ? path.dirname(packagePath) : process.cwd();
     const packageJsonPath = packagePath || path.join(rootDir, "package.json");
 
-    console.log(`Updating package ${packageName} in ${rootDir}`);
+    devLogger.info(`Updating package ${packageName} in ${rootDir}`);
 
     // Use npm-check-updates API to update only the specified package
     const ncuResult = await ncuPackage.run({
@@ -315,7 +315,7 @@ export const updateSinglePackage = async (
       packageName,
     };
   } catch (error) {
-    console.error(`Error updating package ${packageName}:`, error);
+    devLogger.error(`Error updating package ${packageName}:`, error);
     return {
       success: false,
       message: `Failed to update ${packageName}: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`console.<func>` are polluting server logs when using VoltAgent

## What is the new behavior?

replaced with a logger that omits logs when `NODE_ENV` is NOT `development`

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
