### PR TITLE
fix(anthropic): optional chaining `usage` in callback handlers to prevent runtime errors when options are undefined

### DIFF
--- a/.changeset/late-coats-sneeze.md
+++ b/.changeset/late-coats-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/anthropic-ai": patch
+---
+
+fix: optional chaining `usage` in callback handlers to prevent runtime errors when options are undefined

--- a/packages/anthropic-ai/src/index.ts
+++ b/packages/anthropic-ai/src/index.ts
@@ -198,7 +198,7 @@ export class AnthropicProvider implements LLMProvider<string> {
                   const finalResult = {
                     text: currentText,
                     toolCalls: currentToolCalls.map((call) => ({
-                      usage: stopChunk.message.usage,
+                      usage: stopChunk?.message?.usage,
                       ...call,
                     })),
                     toolResults: [],
@@ -302,11 +302,13 @@ export class AnthropicProvider implements LLMProvider<string> {
       return {
         provider: response,
         object: parsedResult.data,
-        usage: {
-          promptTokens: response.usage.input_tokens,
-          completionTokens: response.usage.output_tokens,
-          totalTokens: response.usage.input_tokens + response.usage.output_tokens,
-        },
+        usage: response.usage
+          ? {
+              promptTokens: response.usage.input_tokens,
+              completionTokens: response.usage.output_tokens,
+              totalTokens: response.usage.input_tokens + response.usage.output_tokens,
+            }
+          : undefined,
         finishReason: response.stop_reason as string,
       };
     } catch (error) {


### PR DESCRIPTION
…response usage

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
```
Error during stream iteration: {
  message: 'Error while parsing streamed text response from Anthropic API',
  originalError: TypeError: Cannot read properties of undefined (reading 'usage')
```
## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
