### PR TITLE
chore(cli): switch ESLint to Biome

### DIFF
--- a/packages/cli/biome.json
+++ b/packages/cli/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+  "extends": ["../../biome.json"]
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "lint": "eslint src --ext .ts,.tsx",
+    "lint": "biome check .",
+    "lint:fix": "biome check . --write",
     "start": "node dist/index.js",
     "test": "jest --passWithNoTests"
   },

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,5 +1,5 @@
-import type { Command } from "commander";
 import chalk from "chalk";
+import type { Command } from "commander";
 import { captureError } from "../utils/analytics";
 
 export const registerAddCommand = (program: Command) => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,9 +1,9 @@
-import { Command } from "commander";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import chalk from "chalk";
-import fs from "fs";
-import path from "path";
-import { execSync } from "child_process";
-import { captureInitEvent, captureError } from "../utils/analytics";
+import type { Command } from "commander";
+import { captureError, captureInitEvent } from "../utils/analytics";
 
 export const registerInitCommand = (program: Command): void => {
   program
@@ -39,7 +39,7 @@ export const registerInitCommand = (program: Command): void => {
           } else if (fs.existsSync(path.join(process.cwd(), "yarn.lock"))) {
             packageManager = "yarn";
           }
-        } catch (error) {
+        } catch {
           // Default to npm if detection fails
           packageManager = "npm";
         }
@@ -48,8 +48,8 @@ export const registerInitCommand = (program: Command): void => {
 
         // Add "volt" script to package.json
         let modified = false;
-        if (!scripts["volt"] || scripts["volt"] !== "volt") {
-          scripts["volt"] = "volt";
+        if (!scripts.volt || scripts.volt !== "volt") {
+          scripts.volt = "volt";
           modified = true;
         }
 
@@ -71,7 +71,7 @@ export const registerInitCommand = (program: Command): void => {
             fs.constants.F_OK,
           );
           isPackageInstalled = true;
-        } catch (error) {
+        } catch {
           // Package is not installed
           isPackageInstalled = false;
         }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,11 +1,11 @@
-import { Command } from "commander";
+import fs from "node:fs";
+import path from "node:path";
 import chalk from "chalk";
-import ora from "ora";
-import path from "path";
-import fs from "fs";
-import * as ncuPackage from "npm-check-updates";
+import type { Command } from "commander";
 import inquirer from "inquirer";
-import { captureUpdateEvent, captureError } from "../utils/analytics";
+import * as ncuPackage from "npm-check-updates";
+import ora from "ora";
+import { captureError, captureUpdateEvent } from "../utils/analytics";
 
 // Not directly importing from @voltagent/core due to potential circular dependencies
 // instead, we'll implement a simpler version here
@@ -61,14 +61,13 @@ const checkForUpdates = async (
         count,
         message: `Found ${count} outdated packages:\n${updatesList}`,
       };
-    } else {
-      return {
-        hasUpdates: false,
-        updates: {},
-        count: 0,
-        message: "All packages are up to date",
-      };
     }
+    return {
+      hasUpdates: false,
+      updates: {},
+      count: 0,
+      message: "All packages are up to date",
+    };
   } catch (error) {
     console.error("Error checking for updates:", error);
     return {
@@ -158,7 +157,7 @@ const getCurrentVersion = (packageName: string, packageJsonPath: string): string
     }
 
     return "unknown";
-  } catch (error) {
+  } catch {
     return "unknown";
   }
 };

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -1,8 +1,8 @@
-import { Command } from "commander";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import chalk from "chalk";
-import os from "os";
-import fs from "fs";
-import path from "path";
+import type { Command } from "commander";
 import { captureError, captureWhoamiEvent } from "../utils/analytics";
 
 export const registerWhoamiCommand = (program: Command): void => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-import { Command } from "commander";
 import chalk from "chalk";
+import { Command } from "commander";
 import figlet from "figlet";
+import { registerAddCommand } from "./commands/add";
 import { registerInitCommand } from "./commands/init";
 import { registerUpdateCommand } from "./commands/update";
 import { registerWhoamiCommand } from "./commands/whoami";
-import { registerAddCommand } from "./commands/add";
 import { captureError } from "./utils/analytics";
 import posthogClient from "./utils/analytics";
 

--- a/packages/cli/src/services/announcements.ts
+++ b/packages/cli/src/services/announcements.ts
@@ -1,6 +1,6 @@
-import { Announcement } from "../types";
-import chalk from "chalk";
 import boxen from "boxen";
+import chalk from "chalk";
+import type { Announcement } from "../types";
 
 // Mock announcements - will be fetched from API in the real implementation
 const MOCK_ANNOUNCEMENTS: Announcement[] = [

--- a/packages/cli/src/utils/analytics.ts
+++ b/packages/cli/src/utils/analytics.ts
@@ -1,7 +1,7 @@
+import crypto from "node:crypto";
+import os from "node:os";
 import { PostHog } from "posthog-node";
 import { v4 as uuidv4 } from "uuid";
-import os from "os";
-import crypto from "crypto";
 
 // Check if telemetry is disabled via environment variable
 const isTelemetryDisabled = (): boolean => {
@@ -30,7 +30,7 @@ const getMachineId = (): string => {
 
     const dataToHash = `${hostname}-${cpus}-${platform}-${arch}`;
     return crypto.createHash("sha256").update(dataToHash).digest("hex").substring(0, 32);
-  } catch (error) {
+  } catch {
     // Fallback to a random UUID if machine info isn't accessible
     return uuidv4();
   }
@@ -45,7 +45,7 @@ const getOSInfo = () => {
       os_version: os.version(),
       os_arch: os.arch(),
     };
-  } catch (error) {
+  } catch {
     // Fallback to minimal info if OS info isn't accessible due to security restrictions
     return {
       os_platform: "unknown",
@@ -57,9 +57,7 @@ const getOSInfo = () => {
 };
 
 // Function to capture CLI initialization events
-export const captureInitEvent = (options: {
-  packageManager: string;
-}) => {
+export const captureInitEvent = (options: { packageManager: string }) => {
   // Skip if telemetry is disabled
   if (isTelemetryDisabled()) return;
 
@@ -75,9 +73,7 @@ export const captureInitEvent = (options: {
 };
 
 // Function to capture CLI update check events
-export const captureUpdateEvent = (options: {
-  hadUpdates: boolean;
-}) => {
+export const captureUpdateEvent = (options: { hadUpdates: boolean }) => {
   // Skip if telemetry is disabled
   if (isTelemetryDisabled()) return;
 
@@ -93,10 +89,7 @@ export const captureUpdateEvent = (options: {
 };
 
 // Function to capture error events
-export const captureError = (options: {
-  command: string;
-  errorMessage: string;
-}) => {
+export const captureError = (options: { command: string; errorMessage: string }) => {
   // Skip if telemetry is disabled
   if (isTelemetryDisabled()) return;
 
@@ -113,9 +106,7 @@ export const captureError = (options: {
 };
 
 // Function to capture whoami command events
-export const captureWhoamiEvent = (options: {
-  numVoltPackages: number;
-}) => {
+export const captureWhoamiEvent = (options: { numVoltPackages: number }) => {
   // Skip if telemetry is disabled
   if (isTelemetryDisabled()) return;
 

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,5 +1,5 @@
 import Conf from "conf";
-import { CLIConfig } from "../types";
+import type { CLIConfig } from "../types";
 
 // Default configuration
 const defaultConfig: CLIConfig = {


### PR DESCRIPTION
VoltAgent uses `Biome` but actually some packages use `ESLint`. So I switched it to `Biome` to make it consistent.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

behavior should not change.

## What is the new behavior?

behavior should not change.

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
