### PR TITLE
[FEAT] Get Conversations and history by user

### DIFF
--- a/.changeset/new-sides-wave.md
+++ b/.changeset/new-sides-wave.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/postgres": minor
+"@voltagent/supabase": minor
+"@voltagent/core": minor
+---
+
+[FEAT] Get Conversations and history by user
+
+Resolves [#146](https://github.com/VoltAgent/voltagent/issues/146)

--- a/packages/core/src/agent/index.spec.ts
+++ b/packages/core/src/agent/index.spec.ts
@@ -125,6 +125,11 @@ const mockMemory = {
       },
     ),
 
+  // Add missing user-centric conversation methods
+  getConversationsByUserId: jest.fn().mockImplementation(async () => []),
+  queryConversations: jest.fn().mockImplementation(async () => []),
+  getConversationMessages: jest.fn().mockImplementation(async () => []),
+
   // Special test requirements
   getHistoryEntries: jest.fn().mockImplementation(async () => {
     return [createMockHistoryEntry("Test input")];

--- a/packages/core/src/memory/in-memory/index.spec.ts
+++ b/packages/core/src/memory/in-memory/index.spec.ts
@@ -52,6 +52,7 @@ describe("InMemoryStorage", () => {
   const createConversation = (overrides: Partial<Conversation> = {}): Conversation => ({
     id: `conv-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`,
     resourceId: "resource-test",
+    userId: "test-user",
     title: "Test Conversation",
     metadata: {},
     createdAt: new Date().toISOString(),
@@ -470,6 +471,7 @@ describe("InMemoryStorage", () => {
         const conversation = await storage.createConversation({
           id: testData.id,
           resourceId: testData.resourceId,
+          userId: "test-user",
           title: testData.title,
           metadata: testData.metadata,
         });
@@ -478,6 +480,7 @@ describe("InMemoryStorage", () => {
         expect(conversation).toEqual({
           id: testData.id,
           resourceId: testData.resourceId,
+          userId: "test-user",
           title: testData.title,
           metadata: testData.metadata,
           createdAt: expect.any(String),
@@ -499,6 +502,7 @@ describe("InMemoryStorage", () => {
         const conversation = await storage.createConversation({
           id: testData.id,
           resourceId: testData.resourceId,
+          userId: "test-user",
           title: testData.title,
           metadata: testData.metadata,
         });
@@ -507,6 +511,7 @@ describe("InMemoryStorage", () => {
         expect(conversation).toEqual({
           id: customId,
           resourceId: testData.resourceId,
+          userId: "test-user",
           title: testData.title,
           metadata: testData.metadata,
           createdAt: expect.any(String),
@@ -519,6 +524,7 @@ describe("InMemoryStorage", () => {
         const conversation = await storage.createConversation({
           id: "test-conversation-2",
           resourceId: "resource-minimal",
+          userId: "test-user",
           title: "",
           metadata: {},
         });
@@ -527,6 +533,7 @@ describe("InMemoryStorage", () => {
         expect(conversation).toEqual({
           id: "test-conversation-2",
           resourceId: "resource-minimal",
+          userId: "test-user",
           title: "",
           metadata: {},
           createdAt: expect.any(String),
@@ -541,6 +548,7 @@ describe("InMemoryStorage", () => {
         const created = await storage.createConversation({
           id: "test-conversation-3",
           resourceId: "resource-1",
+          userId: "test-user",
           title: "Test Conversation",
           metadata: { isTest: true },
         });
@@ -569,6 +577,7 @@ describe("InMemoryStorage", () => {
         await storage.createConversation({
           id: "test-conversation-4",
           resourceId: "resource-1",
+          userId: "test-user",
           title: "First Conversation",
           metadata: { order: 1 },
         });
@@ -577,6 +586,7 @@ describe("InMemoryStorage", () => {
         await storage.createConversation({
           id: "test-conversation-5",
           resourceId: "resource-1",
+          userId: "test-user",
           title: "Second Conversation",
           metadata: { order: 2 },
         });
@@ -585,6 +595,7 @@ describe("InMemoryStorage", () => {
         await storage.createConversation({
           id: "test-conversation-6",
           resourceId: "resource-2",
+          userId: "test-user",
           title: "Different Resource",
           metadata: { order: 3 },
         });
@@ -621,6 +632,7 @@ describe("InMemoryStorage", () => {
         existingConversation = await storage.createConversation({
           id: "test-conversation-7",
           resourceId: "resource-1",
+          userId: "test-user",
           title: "Original Title",
           metadata: { originalKey: "value" },
         });
@@ -674,7 +686,8 @@ describe("InMemoryStorage", () => {
         existingConversation = await storage.createConversation({
           id: "test-conversation-8",
           resourceId: "resource-1",
-          title: "To Be Deleted",
+          userId: "test-user",
+          title: "Original Title",
           metadata: {},
         });
 

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -4,6 +4,6 @@
  */
 
 export { InMemoryStorage } from "./in-memory";
-export { LibSQLStorage } from "./libsql";
+export { LibSQLStorage, ExtendedLibSQLStorage } from "./libsql";
 export { MemoryManager } from "./manager";
 export * from "./types";

--- a/packages/core/src/memory/libsql/README.md
+++ b/packages/core/src/memory/libsql/README.md
@@ -1,0 +1,262 @@
+# Enhanced LibSQL Storage - User-Centric Conversations
+
+This document describes the enhanced LibSQL storage implementation that adds user-centric conversation management to VoltAgent, similar to ChatGPT's conversation sidebar.
+
+## Key Features
+
+- **User-specific conversations**: Each conversation is now associated with a user ID
+- **Automatic migration**: Seamlessly upgrades existing databases to the new schema
+- **Query builder pattern**: Fluent interface for building complex queries
+- **Pagination support**: Built-in pagination for large conversation lists
+- **Backward compatibility**: Existing code continues to work with minimal changes
+
+## Schema Changes
+
+### Before (Old Schema)
+
+```sql
+-- Conversations table
+CREATE TABLE conversations (
+  id TEXT PRIMARY KEY,
+  resource_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  metadata TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- Messages table
+CREATE TABLE messages (
+  user_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  type TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (user_id, conversation_id, message_id)
+);
+```
+
+### After (New Schema)
+
+```sql
+-- Conversations table (with user_id added)
+CREATE TABLE conversations (
+  id TEXT PRIMARY KEY,
+  resource_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,        -- NEW: Associates conversation with user
+  title TEXT NOT NULL,
+  metadata TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- Messages table (user_id removed, simpler primary key)
+CREATE TABLE messages (
+  conversation_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  type TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (conversation_id, message_id)  -- Simplified primary key
+);
+```
+
+## Usage Examples
+
+### Basic Setup
+
+```typescript
+import { ExtendedLibSQLStorage } from "@voltagent/core/memory";
+
+const memoryStorage = new ExtendedLibSQLStorage({
+  url: process.env.DATABASE_URL || "file:.voltagent/memory.db",
+  authToken: process.env.DATABASE_AUTH_TOKEN,
+});
+```
+
+### Get User Conversations (ChatGPT-style sidebar)
+
+```typescript
+// Get all conversations for a user
+const conversations = await memoryStorage.getConversationsByUserId("user123");
+
+// Get recent conversations with limit
+const recentConversations = await memoryStorage.getConversationsByUserId("user123", {
+  limit: 20,
+  orderBy: "updated_at",
+  orderDirection: "DESC",
+});
+
+// Get conversations for specific agent/resource
+const agentConversations = await memoryStorage.getConversationsByUserId("user123", {
+  resourceId: "agent-456",
+  limit: 50,
+});
+```
+
+### Get Conversation Messages
+
+```typescript
+// Get all messages for a conversation
+const messages = await memoryStorage.getConversationMessages("conversation-id");
+
+// Get recent messages with pagination
+const recentMessages = await memoryStorage.getConversationMessages("conversation-id", {
+  limit: 50,
+  offset: 0,
+});
+```
+
+### Query Builder Pattern (Fluent Interface)
+
+```typescript
+// Simple query
+const conversations = await memoryStorage.getUserConversations("user123").limit(10).execute();
+
+// Complex query with ordering
+const orderedConversations = await memoryStorage
+  .getUserConversations("user123")
+  .orderBy("updated_at", "DESC")
+  .limit(25)
+  .execute();
+
+// Default query (no chaining)
+const allConversations = await memoryStorage.getUserConversations("user123").execute();
+```
+
+### Pagination
+
+```typescript
+// Get first page of conversations
+const page1 = await memoryStorage.getPaginatedUserConversations("user123", 1, 10);
+
+console.log(page1.conversations); // Array of 10 conversations
+console.log(page1.hasMore); // true if more pages exist
+console.log(page1.page); // 1
+console.log(page1.pageSize); // 10
+
+// Get next page
+if (page1.hasMore) {
+  const page2 = await memoryStorage.getPaginatedUserConversations("user123", 2, 10);
+}
+```
+
+### Advanced Queries
+
+```typescript
+// Query conversations with multiple filters
+const filteredConversations = await memoryStorage.queryConversations({
+  userId: "user123",
+  resourceId: "agent-456",
+  limit: 20,
+  orderBy: "created_at",
+  orderDirection: "ASC",
+});
+
+// Get user-specific conversation (with ownership validation)
+const conversation = await memoryStorage.getUserConversation("conv-123", "user123");
+// Returns null if conversation doesn't exist or doesn't belong to user
+```
+
+### Creating Conversations
+
+```typescript
+// Create a new conversation
+const conversation = await memoryStorage.createConversation({
+  id: "conv-" + Date.now(),
+  resourceId: "agent-456",
+  userId: "user123",
+  title: "New Chat Session",
+  metadata: {
+    source: "web",
+    theme: "dark",
+    language: "en",
+  },
+});
+```
+
+### Adding Messages
+
+```typescript
+// Add message to conversation (userId no longer needed in messages table)
+await memoryStorage.addMessage(
+  {
+    id: "msg-" + Date.now(),
+    role: "user",
+    content: "Hello, how can you help me?",
+    type: "text",
+    createdAt: new Date().toISOString(),
+  },
+  "user123",
+  "conversation-id"
+);
+```
+
+## Migration
+
+The storage automatically handles migration when initialized. The migration process:
+
+1. **Creates backups** of existing tables
+2. **Checks current schema** to determine if migration is needed
+3. **Migrates data** while preserving all existing records
+4. **Updates indexes** for optimal performance
+5. **Validates migration** and can rollback if needed
+
+### Manual Migration Control
+
+```typescript
+// Initialize without automatic migration
+const storage = new ExtendedLibSQLStorage({
+  url: "file:memory.db",
+  // Migration happens automatically in initializeDatabase()
+});
+
+// Manual migration control (if needed for custom scenarios)
+const migrationResult = await storage.migrateConversationSchema({
+  createBackup: true,
+  restoreFromBackup: false, // Set to true to restore from backup
+  deleteBackupAfterSuccess: false,
+});
+
+console.log(migrationResult.success); // true/false
+console.log(migrationResult.migratedCount); // Number of records migrated
+console.log(migrationResult.backupCreated); // Whether backup was created
+```
+
+## Error Handling
+
+```typescript
+try {
+  const conversations = await memoryStorage.getConversationsByUserId("user123");
+} catch (error) {
+  console.error("Failed to fetch conversations:", error);
+  // Handle error appropriately
+}
+```
+
+## Performance Considerations
+
+- **Indexes**: The new schema includes optimized indexes for user_id and conversation_id lookups
+- **Pagination**: Use pagination for large conversation lists to improve performance
+- **Limits**: Set reasonable limits on query results to avoid memory issues
+- **Connection pooling**: Consider connection pooling for high-traffic applications
+
+## Backward Compatibility
+
+Existing code using the old API continues to work:
+
+```typescript
+// This still works
+const conversations = await memoryStorage.getConversations("resource-id");
+
+// This still works
+const messages = await memoryStorage.getMessages({
+  userId: "user123",
+  conversationId: "conv-123",
+});
+```
+
+The main difference is that new conversations must include a `userId` field when created.

--- a/packages/core/src/memory/manager/index.ts
+++ b/packages/core/src/memory/manager/index.ts
@@ -257,6 +257,7 @@ export class MemoryManager {
         await this.memory.createConversation({
           id: conversationId,
           resourceId: this.resourceId,
+          userId: userId,
           title: `New Chat ${new Date().toISOString()}`,
           metadata: {},
         });

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -53,6 +53,7 @@ export type MessageFilterOptions = {
 export type Conversation = {
   id: string;
   resourceId: string;
+  userId: string;
   title: string;
   metadata: Record<string, unknown>;
   createdAt: string;
@@ -65,8 +66,21 @@ export type Conversation = {
 export type CreateConversationInput = {
   id: string;
   resourceId: string;
+  userId: string;
   title: string;
   metadata: Record<string, unknown>;
+};
+
+/**
+ * Query builder options for conversations
+ */
+export type ConversationQueryOptions = {
+  userId?: string;
+  resourceId?: string;
+  limit?: number;
+  offset?: number;
+  orderBy?: "created_at" | "updated_at" | "title";
+  orderDirection?: "ASC" | "DESC";
 };
 
 /**
@@ -86,10 +100,7 @@ export type Memory = {
   /**
    * Clear messages from memory
    */
-  clearMessages(options: {
-    userId: string;
-    conversationId?: string;
-  }): Promise<void>;
+  clearMessages(options: { userId: string; conversationId?: string }): Promise<void>;
 
   /**
    * Create a new conversation
@@ -105,6 +116,27 @@ export type Memory = {
    * Get conversations for a resource
    */
   getConversations(resourceId: string): Promise<Conversation[]>;
+
+  /**
+   * Get conversations by user ID with query options
+   */
+  getConversationsByUserId(
+    userId: string,
+    options?: Omit<ConversationQueryOptions, "userId">,
+  ): Promise<Conversation[]>;
+
+  /**
+   * Get conversations with advanced query options
+   */
+  queryConversations(options: ConversationQueryOptions): Promise<Conversation[]>;
+
+  /**
+   * Get all messages for a specific conversation
+   */
+  getConversationMessages(
+    conversationId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<MemoryMessage[]>;
 
   /**
    * Update a conversation

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -188,3 +188,337 @@ Your stars help us reach more developers! If you find VoltAgent useful, please c
 ## License
 
 Licensed under the MIT License, Copyright © 2025-present VoltAgent.
+
+# VoltAgent PostgreSQL Memory Storage
+
+A high-performance PostgreSQL storage implementation for VoltAgent's memory system with enhanced user-centric conversation management.
+
+## Features
+
+- **User-Centric Conversations**: Associate conversations with specific users for multi-tenant applications
+- **Automatic Schema Migration**: Seamlessly migrate from old schema to new user-based schema
+- **Query Builder Pattern**: Fluent interface for complex conversation queries
+- **Pagination Support**: Built-in pagination for large conversation lists
+- **PostgreSQL Optimized**: Takes advantage of PostgreSQL's advanced features and indexing
+- **Transaction Safety**: All operations are wrapped in transactions for data consistency
+- **Backup & Restore**: Built-in backup functionality during migrations
+
+## Installation
+
+```bash
+npm install @voltagent/postgres
+```
+
+## Basic Usage
+
+```typescript
+import { PostgresStorage } from "@voltagent/postgres";
+
+// Initialize with connection details
+const storage = new PostgresStorage({
+  connection: {
+    host: "localhost",
+    port: 5432,
+    database: "voltagent",
+    user: "postgres",
+    password: "password",
+  },
+  storageLimit: 100,
+  debug: true,
+});
+
+// Add a message to a conversation
+await storage.addMessage(
+  {
+    id: "msg-123",
+    role: "user",
+    content: "Hello!",
+    type: "text",
+    createdAt: new Date().toISOString(),
+  },
+  "user-123",
+  "conversation-456"
+);
+
+// Create a conversation
+const conversation = await storage.createConversation({
+  id: "conv-123",
+  resourceId: "agent-456",
+  userId: "user-123",
+  title: "Customer Support Chat",
+  metadata: { priority: "high" },
+});
+```
+
+## User-Centric Conversation Management
+
+### Get User's Conversations (ChatGPT-style)
+
+```typescript
+// Get recent conversations for a user
+const conversations = await storage.getConversationsByUserId("user-123", {
+  limit: 50,
+  orderBy: "updated_at",
+  orderDirection: "DESC",
+});
+
+// Display in sidebar like ChatGPT
+conversations.forEach((conv) => {
+  console.log(`${conv.title} - ${conv.updatedAt}`);
+});
+```
+
+### Advanced Query Builder
+
+```typescript
+import { ExtendedPostgresStorage } from "@voltagent/postgres";
+
+const storage = new ExtendedPostgresStorage({
+  connection: process.env.DATABASE_URL,
+});
+
+// Fluent query interface
+const recentChats = await storage
+  .getUserConversations("user-123")
+  .limit(20)
+  .orderBy("updated_at", "DESC")
+  .execute();
+
+// Get paginated conversations
+const page1 = await storage.getPaginatedUserConversations("user-123", 1, 10);
+console.log(`Page 1 of ${page1.hasMore ? "many" : page1.conversations.length}`);
+```
+
+### Complex Queries
+
+```typescript
+// Query with multiple filters
+const workConversations = await storage.queryConversations({
+  userId: "user-123",
+  resourceId: "work-agent",
+  limit: 25,
+  offset: 0,
+  orderBy: "created_at",
+  orderDirection: "DESC",
+});
+
+// Get all messages for a conversation
+const messages = await storage.getConversationMessages("conversation-456", {
+  limit: 100,
+  offset: 0,
+});
+```
+
+## Schema Migration
+
+The storage automatically handles migration from the old schema to the new user-centric schema:
+
+### Automatic Migration
+
+```typescript
+// Migration happens automatically on initialization
+const storage = new PostgresStorage({
+  connection: process.env.DATABASE_URL,
+});
+
+// Check migration status
+const result = await storage.migrateConversationSchema({
+  createBackup: true,
+  deleteBackupAfterSuccess: false,
+});
+
+if (result.success) {
+  console.log(`Migrated ${result.migratedCount} conversations`);
+} else {
+  console.error("Migration failed:", result.error);
+}
+```
+
+### Manual Migration Control
+
+```typescript
+// Restore from backup if needed
+await storage.migrateConversationSchema({
+  restoreFromBackup: true,
+});
+
+// Migration with custom options
+await storage.migrateConversationSchema({
+  createBackup: true,
+  deleteBackupAfterSuccess: true,
+});
+```
+
+## Schema Changes
+
+### New Schema (After Migration)
+
+**Conversations Table:**
+
+```sql
+CREATE TABLE voltagent_memory_conversations (
+  id TEXT PRIMARY KEY,
+  resource_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,  -- NEW: Associates conversation with user
+  title TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+**Messages Table:**
+
+```sql
+CREATE TABLE voltagent_memory_messages (
+  conversation_id TEXT NOT NULL REFERENCES voltagent_memory_conversations(id) ON DELETE CASCADE,
+  message_id TEXT NOT NULL,
+  -- user_id REMOVED: Now derived through conversation relationship
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  type TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (conversation_id, message_id)
+);
+```
+
+### Indexes
+
+```sql
+-- Optimized indexes for user-centric queries
+CREATE INDEX idx_conversations_user ON voltagent_memory_conversations(user_id);
+CREATE INDEX idx_conversations_resource ON voltagent_memory_conversations(resource_id);
+CREATE INDEX idx_messages_lookup ON voltagent_memory_messages(conversation_id, created_at);
+```
+
+## Configuration Options
+
+```typescript
+interface PostgresStorageOptions {
+  connection:
+    | string
+    | {
+        host: string;
+        port: number;
+        database: string;
+        user: string;
+        password: string;
+        ssl?: boolean;
+      };
+  maxConnections?: number; // Default: 10
+  tablePrefix?: string; // Default: "voltagent_memory"
+  debug?: boolean; // Default: false
+  storageLimit?: number; // Default: 100
+}
+```
+
+## Examples
+
+### Multi-Tenant Application
+
+```typescript
+// Different users can have separate conversation histories
+const userAConversations = await storage.getConversationsByUserId("user-a");
+const userBConversations = await storage.getConversationsByUserId("user-b");
+
+// Each user only sees their own conversations
+assert(userAConversations.every((c) => c.userId === "user-a"));
+assert(userBConversations.every((c) => c.userId === "user-b"));
+```
+
+### Conversation Management UI
+
+```typescript
+// Build a ChatGPT-style conversation list
+async function getConversationList(userId: string, page: number = 1) {
+  const result = await storage.getPaginatedUserConversations(userId, page, 20);
+
+  return {
+    conversations: result.conversations.map((conv) => ({
+      id: conv.id,
+      title: conv.title || "Untitled Conversation",
+      lastMessage: conv.updatedAt,
+      preview: conv.metadata?.preview || "",
+    })),
+    hasMore: result.hasMore,
+    currentPage: page,
+  };
+}
+
+// Get conversation details when user clicks
+async function openConversation(conversationId: string, userId: string) {
+  // Verify user owns this conversation
+  const conversation = await storage.getUserConversation(conversationId, userId);
+  if (!conversation) {
+    throw new Error("Conversation not found or access denied");
+  }
+
+  // Load conversation messages
+  const messages = await storage.getConversationMessages(conversationId);
+
+  return { conversation, messages };
+}
+```
+
+### Analytics and Reporting
+
+```typescript
+// Get conversation statistics per user
+async function getUserStats(userId: string) {
+  const conversations = await storage.getConversationsByUserId(userId);
+
+  const stats = {
+    totalConversations: conversations.length,
+    thisWeek: conversations.filter(
+      (c) => new Date(c.createdAt) > new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    ).length,
+    averageMessagesPerConversation: 0,
+  };
+
+  // Calculate average messages per conversation
+  let totalMessages = 0;
+  for (const conv of conversations) {
+    const messages = await storage.getConversationMessages(conv.id);
+    totalMessages += messages.length;
+  }
+
+  stats.averageMessagesPerConversation = totalMessages / conversations.length || 0;
+  return stats;
+}
+```
+
+## Performance Considerations
+
+- **Indexing**: The storage creates optimized indexes for user-based queries
+- **Connection Pooling**: Uses PostgreSQL connection pooling for better performance
+- **Pagination**: Always use pagination for large conversation lists
+- **Transactions**: All write operations are wrapped in transactions
+
+## Error Handling
+
+```typescript
+try {
+  await storage.addMessage(message, userId, conversationId);
+} catch (error) {
+  if (error.message.includes("foreign key constraint")) {
+    console.error("Conversation does not exist");
+  } else {
+    console.error("Database error:", error);
+  }
+}
+```
+
+## Migration Notes
+
+1. **Backup Recommended**: Always backup your database before running migrations
+2. **Downtime**: Migration may require brief downtime for large datasets
+3. **Default User**: Existing conversations are assigned `userId = "default"` during migration
+4. **Reversible**: Migration includes backup/restore functionality for rollback
+
+## Contributing
+
+This storage implementation is part of the VoltAgent project. See the main repository for contribution guidelines.
+
+## License
+
+Same as the main VoltAgent project.

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -1,14 +1,60 @@
-import { Pool } from "pg";
 import {
-  safeJsonParse,
   type Conversation,
+  type ConversationQueryOptions,
   type CreateConversationInput,
   type Memory,
   type MemoryMessage,
   type MemoryOptions,
   type MessageFilterOptions,
   type NewTimelineEvent,
+  safeJsonParse,
 } from "@voltagent/core";
+import { Pool } from "pg";
+
+/**
+ * Enhanced PostgreSQL Storage for VoltAgent with User-Centric Conversation Management
+ *
+ * This implementation provides:
+ * - User-specific conversation management
+ * - Automatic migration from old schema to new schema
+ * - Query builder pattern for flexible data retrieval
+ * - Pagination support
+ * - PostgreSQL-optimized queries with proper indexing
+ *
+ * ## Schema Changes
+ *
+ * ### Conversations Table:
+ * - Added `user_id` column (REQUIRED)
+ * - Updated indexes for user-based queries
+ *
+ * ### Messages Table:
+ * - Removed `user_id` column (now derived through conversation relationship)
+ * - Updated foreign key constraints
+ *
+ * ## Usage Examples
+ *
+ * ```typescript
+ * const storage = new PostgresStorage({
+ *   connection: {
+ *     host: "localhost",
+ *     port: 5432,
+ *     database: "voltagent",
+ *     user: "postgres",
+ *     password: "password",
+ *   },
+ * });
+ *
+ * // Get user conversations (ChatGPT-style)
+ * const conversations = await storage.getConversationsByUserId("user123", {
+ *   limit: 50,
+ *   orderBy: "updated_at",
+ *   orderDirection: "DESC",
+ * });
+ *
+ * // Get conversation messages
+ * const messages = await storage.getConversationMessages("conversation-id");
+ * ```
+ */
 
 /**
  * Options for configuring the PostgresStorage
@@ -191,11 +237,12 @@ export class PostgresStorage implements Memory {
     try {
       await client.query("BEGIN");
 
-      // Create conversations table
+      // Create conversations table with user_id
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.options.tablePrefix}_conversations (
           id TEXT PRIMARY KEY,
           resource_id TEXT NOT NULL,
+          user_id TEXT NOT NULL,
           title TEXT,
           metadata JSONB,
           created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
@@ -203,17 +250,16 @@ export class PostgresStorage implements Memory {
         )
       `);
 
-      // Create messages table
+      // Create messages table without user_id
       await client.query(`
         CREATE TABLE IF NOT EXISTS ${this.options.tablePrefix}_messages (
-          user_id TEXT NOT NULL,
           conversation_id TEXT NOT NULL REFERENCES ${this.options.tablePrefix}_conversations(id) ON DELETE CASCADE,
           message_id TEXT NOT NULL,
           role TEXT NOT NULL,
           content TEXT NOT NULL,
           type TEXT NOT NULL,
           created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
-          PRIMARY KEY (user_id, conversation_id, message_id)
+          PRIMARY KEY (conversation_id, message_id)
         )
       `);
 
@@ -253,7 +299,7 @@ export class PostgresStorage implements Memory {
           end_time TIMESTAMPTZ,
           status TEXT,
           status_message TEXT,
-          level TEXT DEFAULT 'INFO',
+          level TEXT DEFAULT "INFO",
           version TEXT,
           parent_event_id TEXT,
           tags JSONB,
@@ -270,9 +316,15 @@ export class PostgresStorage implements Memory {
         ON ${this.options.tablePrefix}_conversations(resource_id)
       `);
 
+      // Create index for conversations by user_id
+      await client.query(`
+        CREATE INDEX IF NOT EXISTS idx_${this.options.tablePrefix}_conversations_user
+        ON ${this.options.tablePrefix}_conversations(user_id)
+      `);
+
       await client.query(`
         CREATE INDEX IF NOT EXISTS idx_${this.options.tablePrefix}_messages_lookup
-        ON ${this.options.tablePrefix}_messages(user_id, conversation_id, created_at)
+        ON ${this.options.tablePrefix}_messages(conversation_id, created_at)
       `);
 
       await client.query(`
@@ -323,6 +375,25 @@ export class PostgresStorage implements Memory {
 
       await client.query("COMMIT");
       this.debug("Database initialized successfully");
+
+      // Run conversation schema migration
+      try {
+        const migrationResult = await this.migrateConversationSchema({
+          createBackup: true,
+        });
+
+        if (migrationResult.success) {
+          if ((migrationResult.migratedCount || 0) > 0) {
+            console.log(
+              `${migrationResult.migratedCount} conversation records successfully migrated`,
+            );
+          }
+        } else {
+          console.error("Conversation migration error:", migrationResult.error);
+        }
+      } catch (error) {
+        this.debug("Error migrating conversation schema:", error);
+      }
     } catch (error) {
       await client.query("ROLLBACK");
       this.debug("Error initializing database:", error);
@@ -343,6 +414,280 @@ export class PostgresStorage implements Memory {
   }
 
   /**
+   * Migrate conversation schema to add user_id and update messages table
+   * @param options Migration options
+   * @returns Migration result
+   */
+  async migrateConversationSchema(
+    options: {
+      createBackup?: boolean;
+      restoreFromBackup?: boolean;
+      deleteBackupAfterSuccess?: boolean;
+    } = {},
+  ): Promise<{
+    success: boolean;
+    migratedCount?: number;
+    error?: Error;
+    backupCreated?: boolean;
+  }> {
+    const {
+      createBackup = true,
+      restoreFromBackup = false,
+      deleteBackupAfterSuccess = false,
+    } = options;
+
+    const conversationsTableName = `${this.options.tablePrefix}_conversations`;
+    const messagesTableName = `${this.options.tablePrefix}_messages`;
+    const conversationsBackupName = `${conversationsTableName}_backup`;
+    const messagesBackupName = `${messagesTableName}_backup`;
+
+    const client = await this.pool.connect();
+    try {
+      this.debug("Starting conversation schema migration...");
+
+      // If restoreFromBackup option is active, restore from backup
+      if (restoreFromBackup) {
+        this.debug("Starting restoration from backup...");
+
+        await client.query("BEGIN");
+
+        // Check if backup tables exist
+        const convBackupCheck = await client.query(
+          "SELECT tablename FROM pg_tables WHERE tablename = $1",
+          [conversationsBackupName],
+        );
+
+        const msgBackupCheck = await client.query(
+          "SELECT tablename FROM pg_tables WHERE tablename = $1",
+          [messagesBackupName],
+        );
+
+        if (convBackupCheck.rows.length === 0 || msgBackupCheck.rows.length === 0) {
+          throw new Error("No backup found to restore");
+        }
+
+        // Restore tables from backup
+        await client.query(`DROP TABLE IF EXISTS ${conversationsTableName} CASCADE`);
+        await client.query(`DROP TABLE IF EXISTS ${messagesTableName} CASCADE`);
+        await client.query(
+          `ALTER TABLE ${conversationsBackupName} RENAME TO ${conversationsTableName}`,
+        );
+        await client.query(`ALTER TABLE ${messagesBackupName} RENAME TO ${messagesTableName}`);
+
+        await client.query("COMMIT");
+
+        this.debug("Restoration from backup completed successfully");
+        return { success: true, backupCreated: false };
+      }
+
+      // Check current table structures
+      const convColumnCheck = await client.query(
+        `
+        SELECT column_name 
+        FROM information_schema.columns 
+        WHERE table_name = $1 AND column_name = "user_id"
+      `,
+        [conversationsTableName],
+      );
+
+      const msgColumnCheck = await client.query(
+        `
+        SELECT column_name 
+        FROM information_schema.columns 
+        WHERE table_name = $1 AND column_name = "user_id"
+      `,
+        [messagesTableName],
+      );
+
+      const hasUserIdInConversations = convColumnCheck.rows.length > 0;
+      const hasUserIdInMessages = msgColumnCheck.rows.length > 0;
+
+      // If conversations already has user_id and messages doesn't have user_id, migration not needed
+      if (hasUserIdInConversations && !hasUserIdInMessages) {
+        this.debug("Tables are already in new format, migration not needed");
+        return { success: true, migratedCount: 0 };
+      }
+
+      // Check if tables exist at all
+      const convTableCheck = await client.query(
+        "SELECT tablename FROM pg_tables WHERE tablename = $1",
+        [conversationsTableName],
+      );
+
+      const msgTableCheck = await client.query(
+        "SELECT tablename FROM pg_tables WHERE tablename = $1",
+        [messagesTableName],
+      );
+
+      // If neither table exists, no migration needed
+      if (convTableCheck.rows.length === 0 && msgTableCheck.rows.length === 0) {
+        this.debug("Tables don't exist, migration not needed");
+        return { success: true, migratedCount: 0 };
+      }
+
+      // Create backups if requested
+      if (createBackup) {
+        this.debug("Creating backups...");
+
+        // Remove existing backups
+        await client.query(`DROP TABLE IF EXISTS ${conversationsBackupName} CASCADE`);
+        await client.query(`DROP TABLE IF EXISTS ${messagesBackupName} CASCADE`);
+
+        // Create backups
+        if (convTableCheck.rows.length > 0) {
+          await client.query(
+            `CREATE TABLE ${conversationsBackupName} AS SELECT * FROM ${conversationsTableName}`,
+          );
+        }
+
+        if (msgTableCheck.rows.length > 0) {
+          await client.query(
+            `CREATE TABLE ${messagesBackupName} AS SELECT * FROM ${messagesTableName}`,
+          );
+        }
+
+        this.debug("Backups created successfully");
+      }
+
+      // Get existing data
+      let conversationData: any[] = [];
+      let messageData: any[] = [];
+
+      if (convTableCheck.rows.length > 0) {
+        const convResult = await client.query(`SELECT * FROM ${conversationsTableName}`);
+        conversationData = convResult.rows;
+      }
+
+      if (msgTableCheck.rows.length > 0) {
+        const msgResult = await client.query(`SELECT * FROM ${messagesTableName}`);
+        messageData = msgResult.rows;
+      }
+
+      // Start transaction for migration
+      await client.query("BEGIN");
+
+      // Create temporary tables with new schemas
+      const tempConversationsTable = `${conversationsTableName}_temp`;
+      const tempMessagesTable = `${messagesTableName}_temp`;
+
+      await client.query(`
+        CREATE TABLE ${tempConversationsTable} (
+          id TEXT PRIMARY KEY,
+          resource_id TEXT NOT NULL,
+          user_id TEXT NOT NULL,
+          title TEXT,
+          metadata JSONB,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now())
+        )
+      `);
+
+      await client.query(`
+        CREATE TABLE ${tempMessagesTable} (
+          conversation_id TEXT NOT NULL,
+          message_id TEXT NOT NULL,
+          role TEXT NOT NULL,
+          content TEXT NOT NULL,
+          type TEXT NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
+          PRIMARY KEY (conversation_id, message_id)
+        )
+      `);
+
+      let migratedCount = 0;
+
+      // Migrate conversations data
+      for (const row of conversationData) {
+        let userId = "default"; // Default user_id for existing conversations
+
+        // If the table already has user_id, use it
+        if (hasUserIdInConversations && row.user_id) {
+          userId = row.user_id;
+        }
+
+        await client.query(
+          `INSERT INTO ${tempConversationsTable} 
+           (id, resource_id, user_id, title, metadata, created_at, updated_at) 
+           VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+          [
+            row.id,
+            row.resource_id,
+            userId,
+            row.title,
+            row.metadata,
+            row.created_at,
+            row.updated_at,
+          ],
+        );
+        migratedCount++;
+      }
+
+      // Migrate messages data
+      for (const row of messageData) {
+        await client.query(
+          `INSERT INTO ${tempMessagesTable} 
+           (conversation_id, message_id, role, content, type, created_at) 
+           VALUES ($1, $2, $3, $4, $5, $6)`,
+          [row.conversation_id, row.message_id, row.role, row.content, row.type, row.created_at],
+        );
+      }
+
+      // Replace old tables with new ones
+      await client.query(`DROP TABLE IF EXISTS ${conversationsTableName} CASCADE`);
+      await client.query(`DROP TABLE IF EXISTS ${messagesTableName} CASCADE`);
+      await client.query(
+        `ALTER TABLE ${tempConversationsTable} RENAME TO ${conversationsTableName}`,
+      );
+      await client.query(`ALTER TABLE ${tempMessagesTable} RENAME TO ${messagesTableName}`);
+
+      // Recreate foreign key constraint
+      await client.query(`
+        ALTER TABLE ${messagesTableName} 
+        ADD CONSTRAINT ${messagesTableName}_conversation_id_fkey 
+        FOREIGN KEY (conversation_id) 
+        REFERENCES ${conversationsTableName}(id) 
+        ON DELETE CASCADE
+      `);
+
+      // Commit transaction
+      await client.query("COMMIT");
+
+      // Delete backups if requested
+      if (deleteBackupAfterSuccess) {
+        await client.query(`DROP TABLE IF EXISTS ${conversationsBackupName} CASCADE`);
+        await client.query(`DROP TABLE IF EXISTS ${messagesBackupName} CASCADE`);
+      }
+
+      this.debug(
+        `Conversation schema migration completed successfully. Migrated ${migratedCount} conversations.`,
+      );
+
+      return {
+        success: true,
+        migratedCount,
+        backupCreated: createBackup,
+      };
+    } catch (error) {
+      this.debug("Error during conversation schema migration:", error);
+
+      // Rollback transaction if still active
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackError) {
+        this.debug("Error rolling back transaction:", rollbackError);
+      }
+
+      return {
+        success: false,
+        error: error as Error,
+        backupCreated: createBackup,
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
    * Add a message to the conversation history
    */
   async addMessage(
@@ -356,48 +701,60 @@ export class PostgresStorage implements Memory {
     try {
       await client.query("BEGIN");
 
-      // Insert the message
+      // Insert the message without user_id (userId parameter is kept for compatibility but not used)
       await client.query(
         `
         INSERT INTO ${this.options.tablePrefix}_messages 
-        (user_id, conversation_id, message_id, role, content, type, created_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        (conversation_id, message_id, role, content, type, created_at)
+        VALUES ($1, $2, $3, $4, $5, $6)
         `,
         [
-          userId,
           conversationId,
           message.id || this.generateId(),
           message.role,
-          typeof message.content === "string" ? message.content : JSON.stringify(message.content),
+          message.content,
           message.type,
-          message.createdAt || new Date().toISOString(),
+          message.createdAt,
         ],
       );
 
-      // If we have a storage limit, clean up old messages
+      // Apply storage limit if specified
       if (this.options.storageLimit && this.options.storageLimit > 0) {
-        await client.query(
+        // Get the count of messages for this conversation
+        const countResult = await client.query(
           `
-          DELETE FROM ${this.options.tablePrefix}_messages
-          WHERE user_id = $1 AND conversation_id = $2
-          AND message_id IN (
-            SELECT message_id
-            FROM ${this.options.tablePrefix}_messages
-            WHERE user_id = $1 AND conversation_id = $2
-            ORDER BY created_at ASC
-            LIMIT (
-              SELECT GREATEST(0, COUNT(*) - $3)
-              FROM ${this.options.tablePrefix}_messages
-              WHERE user_id = $1 AND conversation_id = $2
-            )
-          )
+          SELECT COUNT(*) as count 
+          FROM ${this.options.tablePrefix}_messages 
+          WHERE conversation_id = $1
           `,
-          [userId, conversationId, this.options.storageLimit],
+          [conversationId],
         );
+
+        const count = Number.parseInt(countResult.rows[0].count);
+
+        // If we have more messages than the limit, delete the oldest ones
+        if (count > this.options.storageLimit) {
+          await client.query(
+            `
+            DELETE FROM ${this.options.tablePrefix}_messages 
+            WHERE conversation_id = $1 
+            AND message_id IN (
+              SELECT message_id 
+              FROM ${this.options.tablePrefix}_messages 
+              WHERE conversation_id = $1 
+              ORDER BY created_at ASC 
+              LIMIT $2
+            )
+            `,
+            [conversationId, count - this.options.storageLimit],
+          );
+        }
       }
 
       await client.query("COMMIT");
-      this.debug(`Added message for user ${userId} and conversation ${conversationId}`);
+      this.debug(
+        `Added message for conversation ${conversationId}. UserId parameter: ${userId} (compatibility only)`,
+      );
     } catch (error) {
       await client.query("ROLLBACK");
       this.debug("Error adding message:", error);
@@ -424,36 +781,62 @@ export class PostgresStorage implements Memory {
 
     const client = await this.pool.connect();
     try {
-      const queryParams: any[] = [userId, conversationId];
-      let query = `
-        SELECT message_id, role, content, type, created_at
-        FROM ${this.options.tablePrefix}_messages
-        WHERE user_id = $1 AND conversation_id = $2
+      let sql = `
+        SELECT m.message_id, m.role, m.content, m.type, m.created_at
+        FROM ${this.options.tablePrefix}_messages m
       `;
+      const params: any[] = [];
+      const conditions: string[] = [];
+      let paramCount = 1;
 
-      if (role) {
-        queryParams.push(role);
-        query += ` AND role = $${queryParams.length}`;
+      // If userId is specified, we need to join with conversations table
+      if (userId !== "default") {
+        sql += ` INNER JOIN ${this.options.tablePrefix}_conversations c ON m.conversation_id = c.id`;
+        conditions.push(`c.user_id = $${paramCount}`);
+        params.push(userId);
+        paramCount++;
       }
 
+      // Add conversation_id filter
+      if (conversationId !== "default") {
+        conditions.push(`m.conversation_id = $${paramCount}`);
+        params.push(conversationId);
+        paramCount++;
+      }
+
+      // Add time-based filters
       if (before) {
-        queryParams.push(before);
-        query += ` AND created_at < $${queryParams.length}`;
+        conditions.push(`m.created_at < $${paramCount}`);
+        params.push(new Date(before).toISOString());
+        paramCount++;
       }
 
       if (after) {
-        queryParams.push(after);
-        query += ` AND created_at > $${queryParams.length}`;
+        conditions.push(`m.created_at > $${paramCount}`);
+        params.push(new Date(after).toISOString());
+        paramCount++;
       }
 
-      query += " ORDER BY created_at ASC";
+      // Add role filter
+      if (role) {
+        conditions.push(`m.role = $${paramCount}`);
+        params.push(role);
+        paramCount++;
+      }
 
+      // Add WHERE clause if we have conditions
+      if (conditions.length > 0) {
+        sql += ` WHERE ${conditions.join(" AND ")}`;
+      }
+
+      // Add ordering and limit
+      sql += " ORDER BY m.created_at ASC";
       if (limit && limit > 0) {
-        queryParams.push(limit);
-        query += ` LIMIT $${queryParams.length}`;
+        sql += ` LIMIT $${paramCount}`;
+        params.push(limit);
       }
 
-      const result = await client.query(query, queryParams);
+      const result = await client.query(sql, params);
 
       return result.rows.map((row: any) => ({
         id: row.message_id,
@@ -463,8 +846,8 @@ export class PostgresStorage implements Memory {
         createdAt: row.created_at,
       }));
     } catch (error) {
-      this.debug("Error fetching messages:", error);
-      throw new Error("Failed to fetch messages from PostgreSQL database");
+      this.debug("Error getting messages:", error);
+      throw new Error("Failed to get messages from PostgreSQL database");
     } finally {
       client.release();
     }
@@ -476,18 +859,42 @@ export class PostgresStorage implements Memory {
   async clearMessages(options: { userId: string; conversationId?: string }): Promise<void> {
     await this.initialized;
 
-    const { userId, conversationId = "default" } = options;
+    const { userId, conversationId } = options;
     const client = await this.pool.connect();
+
     try {
-      await client.query(
-        `
-        DELETE FROM ${this.options.tablePrefix}_messages
-        WHERE user_id = $1 AND conversation_id = $2
-        `,
-        [userId, conversationId],
-      );
-      this.debug(`Cleared messages for user ${userId} and conversation ${conversationId}`);
+      await client.query("BEGIN");
+
+      if (conversationId) {
+        // Clear messages for a specific conversation (with user validation)
+        await client.query(
+          `
+          DELETE FROM ${this.options.tablePrefix}_messages 
+          WHERE conversation_id = $1 
+          AND conversation_id IN (
+            SELECT id FROM ${this.options.tablePrefix}_conversations WHERE user_id = $2
+          )
+          `,
+          [conversationId, userId],
+        );
+        this.debug(`Cleared messages for conversation ${conversationId} for user ${userId}`);
+      } else {
+        // Clear all messages for the user across all their conversations
+        await client.query(
+          `
+          DELETE FROM ${this.options.tablePrefix}_messages 
+          WHERE conversation_id IN (
+            SELECT id FROM ${this.options.tablePrefix}_conversations WHERE user_id = $1
+          )
+          `,
+          [userId],
+        );
+        this.debug(`Cleared all messages for user ${userId}`);
+      }
+
+      await client.query("COMMIT");
     } catch (error) {
+      await client.query("ROLLBACK");
       this.debug("Error clearing messages:", error);
       throw new Error("Failed to clear messages from PostgreSQL database");
     } finally {
@@ -506,13 +913,14 @@ export class PostgresStorage implements Memory {
       const result = await client.query(
         `
         INSERT INTO ${this.options.tablePrefix}_conversations
-        (id, resource_id, title, metadata)
-        VALUES ($1, $2, $3, $4)
-        RETURNING id, resource_id, title, metadata, created_at, updated_at
+        (id, resource_id, user_id, title, metadata)
+        VALUES ($1, $2, $3, $4, $5)
+        RETURNING id, resource_id, user_id, title, metadata, created_at, updated_at
         `,
         [
           conversation.id || this.generateId(),
           conversation.resourceId,
+          conversation.userId,
           conversation.title,
           JSON.stringify(conversation.metadata || {}),
         ],
@@ -522,6 +930,7 @@ export class PostgresStorage implements Memory {
       return {
         id: row.id,
         resourceId: row.resource_id,
+        userId: row.user_id,
         title: row.title,
         metadata: row.metadata,
         createdAt: row.created_at,
@@ -545,7 +954,7 @@ export class PostgresStorage implements Memory {
     try {
       const result = await client.query(
         `
-        SELECT id, resource_id, title, metadata, created_at, updated_at
+        SELECT id, resource_id, user_id, title, metadata, created_at, updated_at
         FROM ${this.options.tablePrefix}_conversations
         WHERE id = $1
         `,
@@ -560,6 +969,7 @@ export class PostgresStorage implements Memory {
       return {
         id: row.id,
         resourceId: row.resource_id,
+        userId: row.user_id,
         title: row.title,
         metadata: row.metadata,
         createdAt: row.created_at,
@@ -583,7 +993,7 @@ export class PostgresStorage implements Memory {
     try {
       const result = await client.query(
         `
-        SELECT id, resource_id, title, metadata, created_at, updated_at
+        SELECT id, resource_id, user_id, title, metadata, created_at, updated_at
         FROM ${this.options.tablePrefix}_conversations
         WHERE resource_id = $1
         ORDER BY created_at DESC
@@ -594,6 +1004,7 @@ export class PostgresStorage implements Memory {
       return result.rows.map((row: any) => ({
         id: row.id,
         resourceId: row.resource_id,
+        userId: row.user_id,
         title: row.title,
         metadata: row.metadata,
         createdAt: row.created_at,
@@ -602,6 +1013,175 @@ export class PostgresStorage implements Memory {
     } catch (error) {
       this.debug("Error getting conversations:", error);
       throw new Error("Failed to get conversations from PostgreSQL database");
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Get conversations by user ID with query options
+   */
+  async getConversationsByUserId(
+    userId: string,
+    options: Omit<ConversationQueryOptions, "userId"> = {},
+  ): Promise<Conversation[]> {
+    await this.initialized;
+
+    const {
+      resourceId,
+      limit = 50,
+      offset = 0,
+      orderBy = "updated_at",
+      orderDirection = "DESC",
+    } = options;
+
+    const client = await this.pool.connect();
+    try {
+      let sql = `
+        SELECT id, resource_id, user_id, title, metadata, created_at, updated_at
+        FROM ${this.options.tablePrefix}_conversations
+        WHERE user_id = $1
+      `;
+      const params: any[] = [userId];
+      let paramCount = 2;
+
+      if (resourceId) {
+        sql += ` AND resource_id = $${paramCount}`;
+        params.push(resourceId);
+        paramCount++;
+      }
+
+      sql += ` ORDER BY ${orderBy} ${orderDirection}`;
+
+      if (limit > 0) {
+        sql += ` LIMIT $${paramCount} OFFSET $${paramCount + 1}`;
+        params.push(limit, offset);
+      }
+
+      const result = await client.query(sql, params);
+
+      return result.rows.map((row: any) => ({
+        id: row.id,
+        resourceId: row.resource_id,
+        userId: row.user_id,
+        title: row.title,
+        metadata: row.metadata,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      }));
+    } catch (error) {
+      this.debug("Error getting conversations by user ID:", error);
+      throw new Error("Failed to get conversations by user ID from PostgreSQL database");
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Query conversations with advanced options
+   */
+  async queryConversations(options: ConversationQueryOptions): Promise<Conversation[]> {
+    await this.initialized;
+
+    const {
+      userId,
+      resourceId,
+      limit = 50,
+      offset = 0,
+      orderBy = "updated_at",
+      orderDirection = "DESC",
+    } = options;
+
+    const client = await this.pool.connect();
+    try {
+      let sql = `
+        SELECT id, resource_id, user_id, title, metadata, created_at, updated_at
+        FROM ${this.options.tablePrefix}_conversations
+      `;
+      const params: any[] = [];
+      const conditions: string[] = [];
+      let paramCount = 1;
+
+      if (userId) {
+        conditions.push(`user_id = $${paramCount}`);
+        params.push(userId);
+        paramCount++;
+      }
+
+      if (resourceId) {
+        conditions.push(`resource_id = $${paramCount}`);
+        params.push(resourceId);
+        paramCount++;
+      }
+
+      if (conditions.length > 0) {
+        sql += ` WHERE ${conditions.join(" AND ")}`;
+      }
+
+      sql += ` ORDER BY ${orderBy} ${orderDirection}`;
+
+      if (limit > 0) {
+        sql += ` LIMIT $${paramCount} OFFSET $${paramCount + 1}`;
+        params.push(limit, offset);
+      }
+
+      const result = await client.query(sql, params);
+
+      return result.rows.map((row: any) => ({
+        id: row.id,
+        resourceId: row.resource_id,
+        userId: row.user_id,
+        title: row.title,
+        metadata: row.metadata,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      }));
+    } catch (error) {
+      this.debug("Error querying conversations:", error);
+      throw new Error("Failed to query conversations from PostgreSQL database");
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Get all messages for a specific conversation
+   */
+  async getConversationMessages(
+    conversationId: string,
+    options: { limit?: number; offset?: number } = {},
+  ): Promise<MemoryMessage[]> {
+    await this.initialized;
+
+    const { limit = 100, offset = 0 } = options;
+    const client = await this.pool.connect();
+
+    try {
+      let sql = `
+        SELECT message_id, role, content, type, created_at
+        FROM ${this.options.tablePrefix}_messages
+        WHERE conversation_id = $1
+        ORDER BY created_at ASC
+      `;
+      const params: any[] = [conversationId];
+
+      if (limit > 0) {
+        sql += " LIMIT $2 OFFSET $3";
+        params.push(limit, offset);
+      }
+
+      const result = await client.query(sql, params);
+
+      return result.rows.map((row: any) => ({
+        id: row.message_id,
+        role: row.role,
+        content: row.content,
+        type: row.type,
+        createdAt: row.created_at,
+      }));
+    } catch (error) {
+      this.debug("Error getting conversation messages:", error);
+      throw new Error("Failed to get conversation messages from PostgreSQL database");
     } finally {
       client.release();
     }
@@ -628,6 +1208,12 @@ export class PostgresStorage implements Memory {
         paramCount++;
       }
 
+      if (updates.userId !== undefined) {
+        setClauses.push(`user_id = $${paramCount}`);
+        values.push(updates.userId);
+        paramCount++;
+      }
+
       if (updates.title !== undefined) {
         setClauses.push(`title = $${paramCount}`);
         values.push(updates.title);
@@ -640,7 +1226,7 @@ export class PostgresStorage implements Memory {
         paramCount++;
       }
 
-      setClauses.push(`updated_at = timezone('utc'::text, now())`);
+      setClauses.push(`updated_at = timezone("utc"::text, now())`);
 
       values.push(id);
 
@@ -649,7 +1235,7 @@ export class PostgresStorage implements Memory {
         UPDATE ${this.options.tablePrefix}_conversations
         SET ${setClauses.join(", ")}
         WHERE id = $${paramCount}
-        RETURNING id, resource_id, title, metadata, created_at, updated_at
+        RETURNING id, resource_id, user_id, title, metadata, created_at, updated_at
         `,
         values,
       );
@@ -662,6 +1248,7 @@ export class PostgresStorage implements Memory {
       return {
         id: row.id,
         resourceId: row.resource_id,
+        userId: row.user_id,
         title: row.title,
         metadata: row.metadata,
         createdAt: row.created_at,
@@ -849,7 +1436,7 @@ export class PostgresStorage implements Memory {
         SELECT value 
         FROM ${this.options.tablePrefix}_agent_history_steps 
         WHERE history_id = $1 AND agent_id = $2
-        ORDER BY (value->>'timestamp')::timestamp ASC
+        ORDER BY (value->>"timestamp")::timestamp ASC
         `,
         [key, entry._agentId],
       );
@@ -987,7 +1574,7 @@ export class PostgresStorage implements Memory {
             SELECT value 
             FROM ${this.options.tablePrefix}_agent_history_steps 
             WHERE history_id = $1 AND agent_id = $2
-            ORDER BY (value->>'timestamp')::timestamp ASC
+            ORDER BY (value->>"timestamp")::timestamp ASC
             `,
             [entry.id, agentId],
           );
@@ -1067,5 +1654,151 @@ export class PostgresStorage implements Memory {
    */
   async close(): Promise<void> {
     await this.pool.end();
+    this.debug("PostgreSQL connection pool closed");
+  }
+}
+
+/**
+ * Extended PostgreSQL storage implementation with additional convenience methods
+ * This serves as an example of how users can extend the base storage
+ */
+export class ExtendedPostgresStorage extends PostgresStorage {
+  /**
+   * Get conversations for a user with a fluent query builder interface
+   * @param userId User ID to filter by
+   * @returns Query builder object
+   */
+  getUserConversations(userId: string) {
+    return {
+      /**
+       * Limit the number of results
+       * @param count Number of conversations to return
+       * @returns Query builder
+       */
+      limit: (count: number) => ({
+        /**
+         * Order results by a specific field
+         * @param field Field to order by
+         * @param direction Sort direction
+         * @returns Query builder
+         */
+        orderBy: (
+          field: "created_at" | "updated_at" | "title" = "updated_at",
+          direction: "ASC" | "DESC" = "DESC",
+        ) => ({
+          /**
+           * Execute the query and return results
+           * @returns Promise of conversations
+           */
+          execute: () =>
+            this.getConversationsByUserId(userId, {
+              limit: count,
+              orderBy: field,
+              orderDirection: direction,
+            }),
+        }),
+        /**
+         * Execute the query with default ordering
+         * @returns Promise of conversations
+         */
+        execute: () => this.getConversationsByUserId(userId, { limit: count }),
+      }),
+
+      /**
+       * Order results by a specific field
+       * @param field Field to order by
+       * @param direction Sort direction
+       * @returns Query builder
+       */
+      orderBy: (
+        field: "created_at" | "updated_at" | "title" = "updated_at",
+        direction: "ASC" | "DESC" = "DESC",
+      ) => ({
+        /**
+         * Limit the number of results
+         * @param count Number of conversations to return
+         * @returns Query builder
+         */
+        limit: (count: number) => ({
+          /**
+           * Execute the query and return results
+           * @returns Promise of conversations
+           */
+          execute: () =>
+            this.getConversationsByUserId(userId, {
+              limit: count,
+              orderBy: field,
+              orderDirection: direction,
+            }),
+        }),
+        /**
+         * Execute the query without limit
+         * @returns Promise of conversations
+         */
+        execute: () =>
+          this.getConversationsByUserId(userId, {
+            orderBy: field,
+            orderDirection: direction,
+          }),
+      }),
+
+      /**
+       * Execute the query with default options
+       * @returns Promise of conversations
+       */
+      execute: () => this.getConversationsByUserId(userId),
+    };
+  }
+
+  /**
+   * Get conversation by ID and ensure it belongs to the specified user
+   * @param conversationId Conversation ID
+   * @param userId User ID to validate ownership
+   * @returns Conversation or null
+   */
+  async getUserConversation(conversationId: string, userId: string): Promise<Conversation | null> {
+    const conversation = await this.getConversation(conversationId);
+    if (!conversation || conversation.userId !== userId) {
+      return null;
+    }
+    return conversation;
+  }
+
+  /**
+   * Get paginated conversations for a user
+   * @param userId User ID
+   * @param page Page number (1-based)
+   * @param pageSize Number of items per page
+   * @returns Object with conversations and pagination info
+   */
+  async getPaginatedUserConversations(
+    userId: string,
+    page = 1,
+    pageSize = 10,
+  ): Promise<{
+    conversations: Conversation[];
+    page: number;
+    pageSize: number;
+    hasMore: boolean;
+  }> {
+    const offset = (page - 1) * pageSize;
+
+    // Get one extra to check if there are more pages
+    const conversations = await this.getConversationsByUserId(userId, {
+      limit: pageSize + 1,
+      offset,
+      orderBy: "updated_at",
+      orderDirection: "DESC",
+    });
+
+    const hasMore = conversations.length > pageSize;
+    const results = hasMore ? conversations.slice(0, pageSize) : conversations;
+
+    return {
+      conversations: results,
+      page,
+      pageSize,
+      hasMore,
+    };
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [X] Related issue(s) linked
- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
- Message-centric
- Complex 3-column
- Manual filtering required
- Filter messages by conversation
- Multiple table joins needed

## What is the new behavior?
For LibSQL, Memory, Postgres, Supabase
- Conversation table
- 2-column
- getConversationsByUserId()
- getConversationMessages()
- Optimized single-table queries

fixes (issue)
#146 

## Notes for reviewers

- BEFORE
```
CREATE TABLE conversations (
  id TEXT,
  resource_id TEXT,  
  title TEXT
);

-- Had to join through messages
SELECT DISTINCT c.* FROM conversations c 
JOIN messages m ON c.id = m.conversation_id 
WHERE m.user_id = 'user123';  

```

- AFTER
```
CREATE TABLE conversations (
  id TEXT,
  resource_id TEXT,
  user_id TEXT,      
  title TEXT
);

-- Simple direct query
SELECT * FROM conversations 
WHERE user_id = 'user123' 
ORDER BY updated_at DESC;  
```

<!-- Add any notes/questions you may have for reviewers -->
