### PR TITLE
chore: update documentation and types to drop Node.js 18 support

### DIFF
--- a/examples/with-anthropic/README.md
+++ b/examples/with-anthropic/README.md
@@ -6,7 +6,7 @@ An [VoltAgent](https://github.com/vercel/voltagent) application.
 
 ### Prerequisites
 
-- Node.js (v18 or newer)
+- Node.js (v20 or newer)
 - npm, yarn, or pnpm
 
 ### Installation

--- a/examples/with-composio-mcp/README.md
+++ b/examples/with-composio-mcp/README.md
@@ -25,12 +25,12 @@ Escape the limitations of no-code builders and the complexity of starting from s
 </div>
 
 <div align="center">
-    
+
 [![npm version](https://img.shields.io/npm/v/@voltagent/core.svg)](https://www.npmjs.com/package/@voltagent/core)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 [![Twitter Follow](https://img.shields.io/twitter/follow/voltagent_dev?style=social)](https://twitter.com/voltagent_dev)
-    
+
 </div>
 
 <br/>
@@ -63,7 +63,7 @@ This example demonstrates how to integrate VoltAgent with Composio's Model Conte
 
 ## Prerequisites
 
-- Node.js (v18 or later recommended)
+- Node.js (v20 or later recommended)
 - pnpm (or npm/yarn)
 - An OpenAI API key (or setup for another supported LLM provider)
 - A Composio MCP account (sign up at [https://mcp.composio.dev/](https://mcp.composio.dev/))

--- a/examples/with-zapier-mcp/README.md
+++ b/examples/with-zapier-mcp/README.md
@@ -25,12 +25,12 @@ Escape the limitations of no-code builders and the complexity of starting from s
 </div>
 
 <div align="center">
-    
+
 [![npm version](https://img.shields.io/npm/v/@voltagent/core.svg)](https://www.npmjs.com/package/@voltagent/core)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 [![Twitter Follow](https://img.shields.io/twitter/follow/voltagent_dev?style=social)](https://twitter.com/voltagent_dev)
-    
+
 </div>
 
 <br/>
@@ -54,7 +54,7 @@ This example demonstrates how to integrate VoltAgent with a Zapier Model Context
 
 ## Prerequisites
 
-- Node.js (v18 or later recommended)
+- Node.js (v20 or later recommended)
 - pnpm (or npm/yarn)
 - AWS credentials for Amazon Bedrock (see below) or you can use OpenAI
 - A Zapier MCP account (see [Zapier documentation](https://zapier.com/mcp/))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,13 +2,19 @@
   "name": "@voltagent/cli",
   "version": "0.1.6",
   "description": "CLI tool for VoltAgent applications",
-  "keywords": ["voltagent", "cli", "agent"],
+  "keywords": [
+    "voltagent",
+    "cli",
+    "agent"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "bin": {
     "volt": "dist/index.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
@@ -35,7 +41,7 @@
     "@types/boxen": "^3.0.1",
     "@types/figlet": "^1.5.8",
     "@types/inquirer": "^9.0.7",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "@types/semver": "^7.5.6",
     "@types/update-notifier": "^6.0.8",
     "@types/uuid": "^9.0.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "@types/uuid": "^9.0.8",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",

--- a/packages/create-voltagent-app/package.json
+++ b/packages/create-voltagent-app/package.json
@@ -42,7 +42,7 @@
     "@types/gradient-string": "^1.1.5",
     "@types/inquirer": "^9.0.7",
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "@types/tar": "^6.1.10",
     "@types/uuid": "^9.0.8",
     "jest": "^29.5.0",

--- a/packages/create-voltagent-app/templates/base/README.md.template
+++ b/packages/create-voltagent-app/templates/base/README.md.template
@@ -6,7 +6,7 @@ An [VoltAgent](https://github.com/vercel/voltagent) application.
 
 ### Prerequisites
 
-- Node.js (v18 or newer)
+- Node.js (v20 or newer)
 - npm, yarn, or pnpm
 
 ### Installation

--- a/packages/google-ai/package.json
+++ b/packages/google-ai/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "eslint": "^8.0.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",

--- a/packages/groq-ai/package.json
+++ b/packages/groq-ai/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "eslint": "^8.0.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",

--- a/packages/langfuse-exporter/package.json
+++ b/packages/langfuse-exporter/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsup": "^6.7.0",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "@types/pg": "^8.15.2",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsup": "^6.7.0",

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsup": "^6.7.0",

--- a/packages/vercel-ai-exporter/README.md
+++ b/packages/vercel-ai-exporter/README.md
@@ -151,7 +151,7 @@ What you'll find in the guide:
 
 ## Requirements
 
-- Node.js 18+
+- Node.js 20+
 - Vercel AI SDK 3.0+
 - OpenTelemetry SDK
 

--- a/packages/vercel-ai-exporter/package.json
+++ b/packages/vercel-ai-exporter/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsup": "^6.7.0",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "eslint": "^8.0.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "tsup": "^6.7.0",

--- a/packages/xsai/package.json
+++ b/packages/xsai/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.19.0",
     "eslint": "^8.0.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 2.28.1
       '@commitlint/cli':
         specifier: ^18.2.0
-        version: 18.6.1(@types/node@20.17.30)(typescript@5.8.2)
+        version: 18.6.1(@types/node@20.19.0)(typescript@5.8.2)
       '@commitlint/config-conventional':
         specifier: ^18.2.0
         version: 18.6.3
@@ -297,7 +297,7 @@ importers:
         version: 8.31.1(eslint@9.25.1)(typescript@5.7.3)
       vite:
         specifier: ^6.3.1
-        version: 6.3.3(@types/node@20.17.30)
+        version: 6.3.3(@types/node@20.19.0)
 
   examples/with-google-drive-mcp/server:
     dependencies:
@@ -1116,8 +1116,8 @@ importers:
         specifier: ^9.0.7
         version: 9.0.7
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       '@types/semver':
         specifier: ^7.5.6
         version: 7.7.0
@@ -1129,7 +1129,7 @@ importers:
         version: 9.0.8
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -1195,14 +1195,14 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -1274,8 +1274,8 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       '@types/tar':
         specifier: ^6.1.10
         version: 6.1.13
@@ -1284,7 +1284,7 @@ importers:
         version: 9.0.8
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -1314,14 +1314,14 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -1351,14 +1351,14 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -1391,11 +1391,11 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.87
+        specifier: ^20.19.0
+        version: 20.19.0
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.87)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.3)
@@ -1419,14 +1419,14 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.97
+        specifier: ^20.19.0
+        version: 20.19.0
       '@types/pg':
         specifier: ^8.15.2
         version: 8.15.2
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.97)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.3)
@@ -1447,11 +1447,11 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.97
+        specifier: ^20.19.0
+        version: 20.19.0
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.97)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.3)
@@ -1475,11 +1475,11 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -1509,14 +1509,14 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -1549,11 +1549,11 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.97
+        specifier: ^20.19.0
+        version: 20.19.0
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.97)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.3)
@@ -1586,11 +1586,11 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -1617,14 +1617,14 @@ importers:
         specifier: ^29.5.0
         version: 29.5.14
       '@types/node':
-        specifier: ^18.15.11
-        version: 18.19.79
+        specifier: ^20.19.0
+        version: 20.19.0
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@18.19.79)
+        version: 29.7.0(@types/node@20.19.0)
       ts-jest:
         specifier: ^29.1.0
         version: 29.2.6(@babel/core@7.27.1)(esbuild@0.17.19)(jest@29.7.0)(typescript@5.8.2)
@@ -3009,14 +3009,14 @@ packages:
     dev: true
     optional: true
 
-  /@commitlint/cli@18.6.1(@types/node@20.17.30)(typescript@5.8.2):
+  /@commitlint/cli@18.6.1(@types/node@20.19.0)(typescript@5.8.2):
     resolution: {integrity: sha512-5IDE0a+lWGdkOvKH892HHAZgbAjcj1mT5QrfA/SVbLJV/BbBMGyKN0W5mhgjekPJJwEQdVNvhl9PwUacY58Usw==}
     engines: {node: '>=v18'}
     hasBin: true
     dependencies:
       '@commitlint/format': 18.6.1
       '@commitlint/lint': 18.6.1
-      '@commitlint/load': 18.6.1(@types/node@20.17.30)(typescript@5.8.2)
+      '@commitlint/load': 18.6.1(@types/node@20.19.0)(typescript@5.8.2)
       '@commitlint/read': 18.6.1
       '@commitlint/types': 18.6.1
       execa: 5.1.1
@@ -3088,7 +3088,7 @@ packages:
       '@commitlint/types': 18.6.1
     dev: true
 
-  /@commitlint/load@18.6.1(@types/node@20.17.30)(typescript@5.8.2):
+  /@commitlint/load@18.6.1(@types/node@20.19.0)(typescript@5.8.2):
     resolution: {integrity: sha512-p26x8734tSXUHoAw0ERIiHyW4RaI4Bj99D8YgUlVV9SedLf8hlWAfyIFhHRIhfPngLlCe0QYOdRKYFt8gy56TA==}
     engines: {node: '>=v18'}
     dependencies:
@@ -3098,7 +3098,7 @@ packages:
       '@commitlint/types': 18.6.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.8.2)
-      cosmiconfig-typescript-loader: 5.1.0(@types/node@20.17.30)(cosmiconfig@8.3.6)(typescript@5.8.2)
+      cosmiconfig-typescript-loader: 5.1.0(@types/node@20.19.0)(cosmiconfig@8.3.6)(typescript@5.8.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -4225,7 +4225,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -4246,14 +4246,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.30)
+      jest-config: 29.7.0(@types/node@20.19.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4281,7 +4281,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       jest-mock: 29.7.0
     dev: true
 
@@ -4308,7 +4308,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -4341,7 +4341,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4429,7 +4429,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
     dev: true
@@ -6453,7 +6453,7 @@ packages:
       '@tailwindcss/node': 4.1.4
       '@tailwindcss/oxide': 4.1.4
       tailwindcss: 4.1.4
-      vite: 6.3.3(@types/node@20.17.30)
+      vite: 6.3.3(@types/node@20.19.0)
     dev: false
 
   /@tootallnate/once@2.0.0:
@@ -6547,13 +6547,13 @@ packages:
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
     dev: true
 
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
     dev: true
 
   /@types/gradient-string@1.1.6:
@@ -6605,13 +6605,13 @@ packages:
   /@types/jsonfile@6.1.4:
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
     dev: true
 
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
     dev: false
 
   /@types/mdast@4.0.4:
@@ -6635,13 +6635,13 @@ packages:
   /@types/mute-stream@0.0.4:
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
     dev: false
 
   /@types/node-fetch@2.6.12:
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       form-data: 4.0.2
     dev: false
 
@@ -6649,27 +6649,22 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@18.19.79:
-    resolution: {integrity: sha512-90K8Oayimbctc5zTPHPfZloc/lGVs7f3phUAAMcTgEPtg8kKquGZDERC8K4vkBYkQQh48msiYUslYtxTWvqcAg==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
-
-  /@types/node@18.19.87:
-    resolution: {integrity: sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==}
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
-
   /@types/node@18.19.97:
     resolution: {integrity: sha512-4r3Y9EuCJjWduiam85Fo4GBQtneaEuoaBSdiKo+o6qwQUh0JFVBe7cRUK6I6yVzA0S1gBJJfoQx4VtBH4e5ikg==}
     dependencies:
       undici-types: 5.26.5
+    dev: false
 
   /@types/node@20.17.30:
     resolution: {integrity: sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==}
     dependencies:
       undici-types: 6.19.8
+    dev: true
+
+  /@types/node@20.19.0:
+    resolution: {integrity: sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==}
+    dependencies:
+      undici-types: 6.21.0
 
   /@types/node@22.14.0:
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
@@ -6695,7 +6690,7 @@ packages:
   /@types/pg@8.15.2:
     resolution: {integrity: sha512-+BKxo5mM6+/A1soSHBI7ufUglqYXntChLDyTbvcAn1Lawi9J7J9Ok3jt6w7I0+T/UDJ4CyhHk66+GZbwmkYxSg==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       pg-protocol: 1.10.0
       pg-types: 4.0.2
     dev: true
@@ -6720,7 +6715,7 @@ packages:
   /@types/responselike@1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
     dev: false
 
   /@types/retry@0.12.0:
@@ -6738,14 +6733,14 @@ packages:
   /@types/tar@6.1.13:
     resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       minipass: 4.2.8
     dev: true
 
   /@types/through@0.0.33:
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
     dev: true
 
   /@types/tinycolor2@1.4.6:
@@ -6780,7 +6775,7 @@ packages:
   /@types/ws@8.18.1:
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
     dev: false
 
   /@types/yargs-parser@21.0.3:
@@ -6923,7 +6918,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.3(@types/node@20.17.30)
+      vite: 6.3.3(@types/node@20.19.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8314,7 +8309,7 @@ packages:
       vary: 1.1.2
     dev: false
 
-  /cosmiconfig-typescript-loader@5.1.0(@types/node@20.17.30)(cosmiconfig@8.3.6)(typescript@5.8.2):
+  /cosmiconfig-typescript-loader@5.1.0(@types/node@20.19.0)(cosmiconfig@8.3.6)(typescript@5.8.2):
     resolution: {integrity: sha512-7PtBB+6FdsOvZyJtlF3hEPpACq7RQX6BVGsgC7/lfVXnKMvNCu/XY3ykreqG5w/rBNdu2z8LCIKoF3kpHHdHlA==}
     engines: {node: '>=v16'}
     peerDependencies:
@@ -8322,7 +8317,7 @@ packages:
       cosmiconfig: '>=8.2'
       typescript: '>=4'
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       cosmiconfig: 8.3.6(typescript@5.8.2)
       jiti: 1.21.7
       typescript: 5.8.2
@@ -8376,63 +8371,6 @@ packages:
       typescript: 5.8.2
     dev: true
 
-  /create-jest@29.7.0(@types/node@18.19.79):
-    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.79)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /create-jest@29.7.0(@types/node@18.19.87):
-    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.87)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /create-jest@29.7.0(@types/node@18.19.97):
-    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.97)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /create-jest@29.7.0(@types/node@20.17.30):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -8443,6 +8381,25 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@20.17.30)
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /create-jest@29.7.0(@types/node@20.19.0):
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.19.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10762,7 +10719,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -10781,90 +10738,6 @@ packages:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-    dev: true
-
-  /jest-cli@29.7.0(@types/node@18.19.79):
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.79)
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.79)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest-cli@29.7.0(@types/node@18.19.87):
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.87)
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.87)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest-cli@29.7.0(@types/node@18.19.97):
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.97)
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.97)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
     dev: true
 
   /jest-cli@29.7.0(@types/node@20.17.30):
@@ -10895,124 +10768,32 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.7.0(@types/node@18.19.79):
-    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+  /jest-cli@29.7.0(@types/node@20.19.0):
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
     peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
+      node-notifier:
         optional: true
     dependencies:
-      '@babel/core': 7.27.1
-      '@jest/test-sequencer': 29.7.0
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 18.19.79
-      babel-jest: 29.7.0(@babel/core@7.27.1)
       chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
+      create-jest: 29.7.0(@types/node@20.19.0)
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0(@types/node@20.19.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
+      yargs: 17.7.2
     transitivePeerDependencies:
+      - '@types/node'
       - babel-plugin-macros
       - supports-color
-    dev: true
-
-  /jest-config@29.7.0(@types/node@18.19.87):
-    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.27.1
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 18.19.87
-      babel-jest: 29.7.0(@babel/core@7.27.1)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    dev: true
-
-  /jest-config@29.7.0(@types/node@18.19.97):
-    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.27.1
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 18.19.97
-      babel-jest: 29.7.0(@babel/core@7.27.1)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
+      - ts-node
     dev: true
 
   /jest-config@29.7.0(@types/node@20.17.30):
@@ -11031,6 +10812,46 @@ packages:
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.17.30
+      babel-jest: 29.7.0(@babel/core@7.27.1)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    dev: true
+
+  /jest-config@29.7.0(@types/node@20.19.0):
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.27.1
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.0
       babel-jest: 29.7.0(@babel/core@7.27.1)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -11090,7 +10911,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
     dev: true
@@ -11106,7 +10927,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11157,7 +10978,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       jest-util: 29.7.0
     dev: true
 
@@ -11212,7 +11033,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -11243,7 +11064,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -11295,7 +11116,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -11320,7 +11141,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -11332,73 +11153,10 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: true
-
-  /jest@29.7.0(@types/node@18.19.79):
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.79)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest@29.7.0(@types/node@18.19.87):
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.87)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
-  /jest@29.7.0(@types/node@18.19.97):
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.97)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
     dev: true
 
   /jest@29.7.0(@types/node@20.17.30):
@@ -11415,6 +11173,27 @@ packages:
       '@jest/types': 29.6.3
       import-local: 3.1.0
       jest-cli: 29.7.0(@types/node@20.17.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    dev: true
+
+  /jest@29.7.0(@types/node@20.19.0):
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.1.0
+      jest-cli: 29.7.0(@types/node@20.19.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15689,7 +15468,7 @@ packages:
       ejs: 3.1.10
       esbuild: 0.17.19
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.19.79)
+      jest: 29.7.0(@types/node@20.19.0)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -15981,9 +15760,11 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: false
 
   /undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+    dev: true
 
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -16243,7 +16024,7 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
-  /vite@6.3.3(@types/node@20.17.30):
+  /vite@6.3.3(@types/node@20.19.0):
     resolution: {integrity: sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -16283,7 +16064,7 @@ packages:
       yaml:
         optional: true
     dependencies:
-      '@types/node': 20.17.30
+      '@types/node': 20.19.0
       esbuild: 0.25.2
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2

--- a/website/docs/community/contributing.md
+++ b/website/docs/community/contributing.md
@@ -51,7 +51,7 @@ Understanding the purpose of each package helps in directing your contributions 
 
 ### Requirements
 
-- [Node.js](https://nodejs.org/en/) version 18 or higher
+- [Node.js](https://nodejs.org/en/) version 20 or higher
 - [Git](https://git-scm.com/) and [GitHub](https://github.com) account
 - [pnpm](https://pnpm.io/) version 8.10.5 or higher (as per `package.json`)
 
@@ -182,9 +182,9 @@ pnpm changeset
 
 Follow the prompts:
 
-1.  Select the package(s) you modified.
-2.  Choose the appropriate semantic version bump (`major`, `minor`, `patch`).
-3.  Write a clear description of the change. Reference the relevant GitHub issue number (e.g., `Fixes #123`).
+1. Select the package(s) you modified.
+2. Choose the appropriate semantic version bump (`major`, `minor`, `patch`).
+3. Write a clear description of the change. Reference the relevant GitHub issue number (e.g., `Fixes #123`).
 
 Commit the generated `.changeset/*.md` file along with your code changes.
 
@@ -208,10 +208,10 @@ Fixes #789
 
 ### Creating a Pull Request
 
-1.  Push your changes (including the changeset file) to your forked repository.
-2.  Create a Pull Request against the `main` branch of the main VoltAgent repository (link-to-your-repo).
-3.  Ensure your PR title and description are clear. Reference any related issues.
-4.  CI checks (linting, tests, commitlint, changeset validation) will run automatically. Please address any failures.
-5.  Maintainers will review your PR. Be responsive to feedback.
+1. Push your changes (including the changeset file) to your forked repository.
+2. Create a Pull Request against the `main` branch of the main VoltAgent repository (link-to-your-repo).
+3. Ensure your PR title and description are clear. Reference any related issues.
+4. CI checks (linting, tests, commitlint, changeset validation) will run automatically. Please address any failures.
+5. Maintainers will review your PR. Be responsive to feedback.
 
 We look forward to your contributions! 🎉

--- a/website/src/components/ops/Deployment.tsx
+++ b/website/src/components/ops/Deployment.tsx
@@ -116,7 +116,7 @@ const initialDeploymentLogs: DeploymentLog[] = [
   // --- Stage 3: Building Application ---
   {
     id: 6,
-    message: "Using Node.js v18.18.0",
+    message: "Using Node.js v20.19.0",
     timestamp: "10:30:03.100",
     stageId: 3,
     visible: false,


### PR DESCRIPTION
follow up of https://github.com/VoltAgent/voltagent/pull/213

Added updates to documentation and `@types/node` that were previously missed. Node 18 support should now be fully dropped in all relevant places.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
