### PR TITLE
feat(core): add in better method types for the Agent based on the LLMProvider

### DIFF
--- a/.changeset/smooth-comics-fry.md
+++ b/.changeset/smooth-comics-fry.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Add better types for the primary generation methods based on the Agent Provider

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -45,7 +45,10 @@ import type {
   ModelType,
   OperationContext,
   ProviderInstance,
-  PublicGenerateOptions,
+  PublicGenerateObjectOptions,
+  PublicGenerateTextOptions,
+  PublicStreamObjectOptions,
+  PublicStreamTextOptions,
   StandardizedObjectResult,
   StandardizedTextResult,
   StreamObjectFinishResult,
@@ -730,9 +733,9 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
   /**
    * Generate a text response without streaming
    */
-  async generateText(
+  public async generateText(
     input: string | BaseMessage[],
-    options: PublicGenerateOptions = {},
+    options: PublicGenerateTextOptions<TProvider> = {},
   ): Promise<InferGenerateTextResponse<TProvider>> {
     const internalOptions: InternalGenerateOptions = options as InternalGenerateOptions;
     const {
@@ -1151,9 +1154,9 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
   /**
    * Stream a text response
    */
-  async streamText(
+  public async streamText(
     input: string | BaseMessage[],
-    options: PublicGenerateOptions = {},
+    options: PublicStreamTextOptions<TProvider> = {},
   ): Promise<InferStreamTextResponse<TProvider>> {
     const internalOptions: InternalGenerateOptions = options as InternalGenerateOptions;
     const {
@@ -1633,10 +1636,10 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
   /**
    * Generate a structured object response
    */
-  async generateObject<T extends z.ZodType>(
+  public async generateObject<T extends z.ZodType>(
     input: string | BaseMessage[],
     schema: T,
-    options: PublicGenerateOptions = {},
+    options: PublicGenerateObjectOptions<TProvider> = {},
   ): Promise<InferGenerateObjectResponse<TProvider>> {
     const internalOptions: InternalGenerateOptions = options as InternalGenerateOptions;
     const {
@@ -1912,10 +1915,10 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
   /**
    * Stream a structured object response
    */
-  async streamObject<T extends z.ZodType>(
+  public async streamObject<T extends z.ZodType>(
     input: string | BaseMessage[],
     schema: T,
-    options: PublicGenerateOptions = {},
+    options: PublicStreamObjectOptions<TProvider> = {},
   ): Promise<InferStreamObjectResponse<TProvider>> {
     const internalOptions: InternalGenerateOptions = options as InternalGenerateOptions;
     const {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -138,11 +138,25 @@ export type ModelType<T> = T extends { llm: LLMProvider<any> }
   : never;
 
 /**
+ * Infer generate text options type
+ */
+export type InferGenerateTextOptions<T extends { llm: LLMProvider<any> }> = Parameters<
+  T["llm"]["generateText"]
+>[0];
+
+/**
  * Infer generate text response type
  */
 export type InferGenerateTextResponse<T extends { llm: LLMProvider<any> }> = Awaited<
   ReturnType<T["llm"]["generateText"]>
 >;
+
+/**
+ * Infer generate object options type
+ */
+export type InferStreamTextOptions<T extends { llm: LLMProvider<any> }> = Parameters<
+  T["llm"]["streamText"]
+>[0];
 
 /**
  * Infer stream text response type
@@ -152,11 +166,25 @@ export type InferStreamTextResponse<T extends { llm: LLMProvider<any> }> = Await
 >;
 
 /**
+ * Infer stream text options type
+ */
+export type InferGenerateObjectOptions<T extends { llm: LLMProvider<any> }> = Parameters<
+  T["llm"]["generateObject"]
+>[0];
+
+/**
  * Infer generate object response type
  */
 export type InferGenerateObjectResponse<T extends { llm: LLMProvider<any> }> = Awaited<
   ReturnType<T["llm"]["generateObject"]>
 >;
+
+/**
+ * Infer stream object options type
+ */
+export type InferStreamObjectOptions<T extends { llm: LLMProvider<any> }> = Parameters<
+  T["llm"]["streamObject"]
+>[0];
 
 /**
  * Infer stream object response type
@@ -215,14 +243,34 @@ export interface InternalGenerateOptions extends CommonGenerateOptions {
   parentHistoryEntryId?: string;
 }
 
+type BasePublicGenerateOptions = Omit<
+  CommonGenerateOptions,
+  "historyEntryId" | "operationContext" | "provider"
+>;
+
 /**
  * Public-facing generate options for external users
  * Omits internal implementation details like historyEntryId and operationContext
  */
-export type PublicGenerateOptions = Omit<
-  CommonGenerateOptions,
-  "historyEntryId" | "operationContext"
->;
+export type PublicGenerateTextOptions<TProvider extends { llm: LLMProvider<any> }> =
+  BasePublicGenerateOptions & {
+    provider?: InferGenerateTextOptions<TProvider>;
+  };
+
+export type PublicGenerateObjectOptions<TProvider extends { llm: LLMProvider<any> }> =
+  BasePublicGenerateOptions & {
+    provider?: InferGenerateObjectOptions<TProvider>;
+  };
+
+export type PublicStreamTextOptions<TProvider extends { llm: LLMProvider<any> }> =
+  BasePublicGenerateOptions & {
+    provider?: InferStreamTextOptions<TProvider>;
+  };
+
+export type PublicStreamObjectOptions<TProvider extends { llm: LLMProvider<any> }> =
+  BasePublicGenerateOptions & {
+    provider?: InferStreamObjectOptions<TProvider>;
+  };
 
 /**
  * Agent status information


### PR DESCRIPTION
> [!CAUTION]
> Work in Progress

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Currently uses default/base types that use `any` a lot and are missing core types

## What is the new behavior?

Allows for proper types using the provider

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
