### PR TITLE
feat: enhance retrieval functionality with userContext support

### DIFF
--- a/.changeset/sixty-cows-cheer.md
+++ b/.changeset/sixty-cows-cheer.md
@@ -1,0 +1,32 @@
+---
+"@voltagent/core": patch
+---
+
+Add userContext support to retrievers for tracking references and metadata
+
+Retrievers can now store additional information (like references, sources, citations) in userContext that can be accessed from agent responses. This enables tracking which documents were used to generate responses, perfect for citation systems and audit trails.
+
+```ts
+class MyRetriever extends BaseRetriever {
+  async retrieve(input: string, options: RetrieveOptions): Promise<string> {
+    // Find relevant documents
+    const docs = this.findRelevantDocs(input);
+
+    // Store references in userContext
+    if (options.userContext) {
+      const references = docs.map((doc) => ({
+        id: doc.id,
+        title: doc.title,
+        source: doc.source,
+      }));
+      options.userContext.set("references", references);
+    }
+
+    return docs.map((doc) => doc.content).join("\n");
+  }
+}
+
+// Access references from response
+const response = await agent.generateText("What is VoltAgent?");
+const references = response.userContext?.get("references");
+```

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -473,6 +473,9 @@ export interface StreamTextFinishResult {
 
   /** Any warnings generated during the completion (if available). */
   warnings?: unknown[];
+
+  /** User context containing any custom metadata from the operation. */
+  userContext?: Map<string | symbol, unknown>;
 }
 
 /**
@@ -500,6 +503,9 @@ export interface StreamObjectFinishResult<TObject> {
 
   /** The reason the stream finished (if available). Although less common for object streams. */
   finishReason?: string;
+
+  /** User context containing any custom metadata from the operation. */
+  userContext?: Map<string | symbol, unknown>;
 }
 
 /**
@@ -524,6 +530,8 @@ export interface StandardizedTextResult {
   finishReason?: string;
   /** Warnings (if available from provider). */
   warnings?: unknown[];
+  /** User context containing any custom metadata from the operation. */
+  userContext?: Map<string | symbol, unknown>;
 }
 
 /**
@@ -541,6 +549,8 @@ export interface StandardizedObjectResult<TObject> {
   finishReason?: string;
   /** Warnings (if available from provider). */
   warnings?: unknown[];
+  /** User context containing any custom metadata from the operation. */
+  userContext?: Map<string | symbol, unknown>;
 }
 
 /**

--- a/packages/core/src/retriever/index.ts
+++ b/packages/core/src/retriever/index.ts
@@ -4,5 +4,5 @@
  */
 
 export { BaseRetriever } from "./retriever";
-export type { Retriever, RetrieverOptions } from "./types";
+export type { Retriever, RetrieverOptions, RetrieveOptions } from "./types";
 export { createRetrieverTool } from "./tools";

--- a/packages/core/src/retriever/retriever.ts
+++ b/packages/core/src/retriever/retriever.ts
@@ -1,7 +1,7 @@
 import type { BaseMessage } from "../agent/providers";
 import type { AgentTool } from "../tool";
 import { createRetrieverTool } from "./tools";
-import type { Retriever, RetrieverOptions } from "./types";
+import type { Retriever, RetrieverOptions, RetrieveOptions } from "./types";
 
 /**
  * Abstract base class for Retriever implementations.
@@ -56,19 +56,18 @@ export abstract class BaseRetriever {
 
     // Explicitly bind all methods to 'this' to support destructuring
     if (this.retrieve) {
-      const originalRetrieve = this.retrieve;
-      this.retrieve = (input: string | BaseMessage[]) => {
-        return originalRetrieve.call(this, input);
-      };
+      const originalRetrieve = this.retrieve.bind(this);
+      this.retrieve = originalRetrieve as any;
     }
   }
 
   /**
-   * Retrieve information based on input.
-   * This method must be implemented by all concrete subclasses.
+   * Abstract method that must be implemented by concrete retriever classes.
+   * Retrieves relevant information based on the input text or messages.
    *
-   * @param input - The input to base the retrieval on, can be string or BaseMessage array
-   * @returns A Promise that resolves to a formatted context string
+   * @param input - The input to use for retrieval (string or BaseMessage array)
+   * @param options - Configuration and context for the retrieval
+   * @returns Promise resolving to a string with the retrieved content
    */
-  abstract retrieve(input: string | BaseMessage[]): Promise<string>;
+  abstract retrieve(input: string | BaseMessage[], options: RetrieveOptions): Promise<string>;
 }

--- a/packages/core/src/retriever/types.ts
+++ b/packages/core/src/retriever/types.ts
@@ -23,15 +23,27 @@ export type RetrieverOptions = {
 };
 
 /**
+ * Options passed to retrieve method
+ */
+export interface RetrieveOptions {
+  /**
+   * User-managed context map for this specific retrieval operation
+   * Can be used to store metadata, results, or any custom data
+   */
+  userContext?: Map<string | symbol, unknown>;
+}
+
+/**
  * Retriever interface for retrieving relevant information
  */
 export type Retriever = {
   /**
    * Retrieve relevant documents based on input text
    * @param text The text to use for retrieval
-   * @returns Promise resolving to an array of retrieval results
+   * @param options Configuration and context for the retrieval
+   * @returns Promise resolving to a string with the retrieved content
    */
-  retrieve(text: string): Promise<string>;
+  retrieve(text: string, options: RetrieveOptions): Promise<string>;
 
   /**
    * Configuration options for the retriever

--- a/website/docs/agents/context.md
+++ b/website/docs/agents/context.md
@@ -9,359 +9,313 @@ import TabItem from '@theme/TabItem';
 
 # Operation Context (`userContext`)
 
-`userContext` allows you to pass custom data throughout a single agent operation. Think of it as a temporary, isolated bag of information specific to one task your agent is performing. It becomes especially powerful when coordinating tasks between supervisor and sub-agents.
+`userContext` allows you to pass custom data throughout a single agent operation. Think of it as a shared bag of information that all components (hooks, tools, retrievers, sub-agents) can access during one agent task.
 
-**Quick Examples: Initializing `userContext`**
+## Basic Concept
 
-There are two primary ways to initialize or populate `userContext` for an operation:
+Here's how `userContext` flows through an agent operation:
 
-<Tabs groupId="usercontext-initialization">
-  <TabItem value="hooks" label="Managed by Hooks">
+```
+You → Agent → Hooks → Tools → Retrievers → Sub-Agents
+     ↑                                              ↓
+     ← ← ← ← ← userContext flows everywhere ← ← ← ← ←
+```
+
+Let's see this in action with simple examples:
+
+## Initialize userContext
+
+You can provide initial data when calling the agent:
 
 ```typescript
-// Filename: agentHooksContext.ts
-import {
-  Agent,
-  createHooks,
-  VercelAIProvider,
-  type OnStartHookArgs,
-  type OnEndHookArgs,
-} from "@voltagent/core";
+import { Agent, VercelAIProvider } from "@voltagent/core";
 import { openai } from "@ai-sdk/openai";
 
-// Agent populates userContext internally via hooks
-const agentManagingInternally = new Agent({
-  name: "InternalContextAgent",
+const agent = new Agent({
+  name: "SimpleAgent",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
+  instructions: "You are a helpful assistant.",
+});
+
+// Method 1: Pass userContext when calling the agent
+const initialContext = new Map();
+initialContext.set("language", "English");
+
+const response = await agent.generateText("Hello!", {
+  userContext: initialContext,
+});
+
+// Now you can access the data from the response
+console.log("Language:", response.userContext?.get("language"));
+```
+
+## Hooks Access userContext
+
+Hooks can read and write to `userContext`:
+
+```typescript
+import { createHooks } from "@voltagent/core";
+
+const agent = new Agent({
+  name: "HookAgent",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
   hooks: createHooks({
-    onStart: ({ agent, context }: OnStartHookArgs) => {
-      const operationSpecificId = `op-${agent.name}-${Date.now()}`;
-      context.userContext.set("internalOpId", operationSpecificId);
-      console.log(
-        `[${agent.name}] HOOK: Operation started. OpID set internally: ${operationSpecificId}`
-      );
+    onStart: ({ context }) => {
+      // Read data that was passed in
+      const language = context.userContext.get("language");
+      console.log(`Starting operation for language: ${language}`);
+
+      // Add new data
+      context.userContext.set("requestId", `req-${Date.now()}`);
+      context.userContext.set("startTime", new Date().toISOString());
     },
-    onEnd: ({ agent, context }: OnEndHookArgs) => {
-      const opId = context.userContext.get("internalOpId");
-      console.log(`[${agent.name}] HOOK: Operation ended. Retrieved internal OpID: ${opId}`);
+    onEnd: ({ context }) => {
+      // Read data from context
+      const requestId = context.userContext.get("requestId");
+      const startTime = context.userContext.get("startTime");
+      console.log(`Request ${requestId} completed (started at ${startTime})`);
     },
   }),
+  instructions: "You are a helpful assistant.",
 });
 
-async function runInternalContextTask() {
-  console.log("\n--- Running Task: Context Managed by Hooks ---");
-  await agentManagingInternally.generateText("Tell me a story about a brave otter.");
-}
-// runInternalContextTask();
+// Usage
+const context = new Map();
+context.set("language", "English");
+
+await agent.generateText("Hello!", { userContext: context });
 ```
 
-In this approach, the `userContext` starts empty for the operation, and hooks (like `onStart`) are responsible for populating it with relevant data.
+## Tools Access userContext
 
-  </TabItem>
-  <TabItem value="options" label="Passed via Options">
+Tools can read and write to `userContext` through their options:
 
 ```typescript
-// Filename: agentOptionsContext.ts
-import {
-  Agent,
-  createHooks,
-  VercelAIProvider,
-  type OnStartHookArgs,
-  type OnEndHookArgs,
-} from "@voltagent/core";
-import { openai } from "@ai-sdk/openai";
+import { createTool } from "@voltagent/core";
+import { z } from "zod";
 
-// Agent receives userContext via generateText options
-const agentReceivingContext = new Agent({
-  name: "OptionsContextAgent",
+const loggerTool = createTool({
+  name: "log_message",
+  description: "Logs a message with user context",
+  parameters: z.object({
+    message: z.string(),
+  }),
+  execute: async ({ message }, options) => {
+    // Read from userContext
+    const language = options?.operationContext?.userContext?.get("language");
+    const requestId = options?.operationContext?.userContext?.get("requestId");
+
+    console.log(`[${requestId}] Language ${language}: ${message}`);
+
+    // Write to userContext
+    const userContext = options?.operationContext?.userContext;
+    if (userContext) {
+      const logs = userContext.get("logs") || [];
+      logs.push({ message, timestamp: new Date().toISOString() });
+      userContext.set("logs", logs);
+    }
+
+    return `Message logged for language ${language}`;
+  },
+});
+
+const agentWithTool = new Agent({
+  name: "ToolAgent",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
-  hooks: createHooks({
-    onStart: ({ agent, context }: OnStartHookArgs) => {
-      // Reads data passed in via options
-      const externalTraceId = context.userContext.get("traceId");
-      console.log(
-        `[${agent.name}] HOOK: Operation started. Received traceId from options: ${externalTraceId}`
-      );
-      // Can also add more context if needed
-      context.userContext.set("hookProcessed", true);
-    },
-    onEnd: ({ agent, context }: OnEndHookArgs) => {
-      const externalTraceId = context.userContext.get("traceId");
-      const processed = context.userContext.get("hookProcessed");
-      console.log(
-        `[${agent.name}] HOOK: Operation ended. TraceId: ${externalTraceId}, Processed by hook: ${processed}`
-      );
-    },
-  }),
+  tools: [loggerTool],
+  instructions: "Use the log_message tool to log what the user says.",
 });
 
-async function runOptionsContextTask() {
-  console.log("\n--- Running Task: Context Passed via Options ---");
-  const initialContext = new Map<string | symbol, unknown>();
-  initialContext.set("traceId", `trace-${Date.now()}`);
-  initialContext.set("userId", "user123");
+// Usage
+const context = new Map();
+context.set("language", "English");
+context.set("requestId", "req-456");
 
-  await agentReceivingContext.generateText("Analyze this user feedback.", {
-    userContext: initialContext,
-  });
-}
-// runOptionsContextTask();
+const response = await agentWithTool.generateText("Log this: Hello world!", {
+  userContext: context,
+});
+
+// Check what was logged
+const logs = response.userContext?.get("logs");
+console.log("All logs:", logs);
 ```
 
-Here, you provide an initial `userContext` map directly when calling the agent's generation method. The agent's `OperationContext` is then initialized with a _clone_ of this map. Hooks and tools can then access and potentially add to this context.
+## Retrievers Store References
 
-  </TabItem>
-</Tabs>
-
-## Key Concepts & Usage
-
-`userContext` is a `Map<string | symbol, unknown>` within an `OperationContext`. It lets you store and retrieve data relevant to the current agent task.
-
-**When to Use `userContext`:**
-
-- **Carry Request-Specific Data:** Pass unique IDs (trace, session, request IDs) or configurations that apply only to the current operation.
-  - _Example:_ Set a `correlationId` in `onStart` and use it in tools for logging.
-- **Share State Between Hooks & Tools:** Data set by an `onStart` hook can be read by tools called during that operation, or by the `onEnd` hook.
-  - _Example:_ The "Quick Example" above shows setting an ID in `onStart` and reading it in `onEnd`.
-- **Coordinate Supervisor & Sub-Agents:** A supervisor agent can pass down common information (like a `globalSessionId`) to sub-agents.
-  - _Example:_ See the "`userContext` in Sub-Agent Scenarios" section below.
-- **Manage Operation-Scoped Resources:** Handle resources like a Playwright page that should live only for the duration of one operation.
-  - _Example:_ See the "Advanced Use Case: Managing Playwright Browser Instances" section.
-
-**Core Principles (How to Think About It):**
-
-1.  **Accessibility:**
-    - In **Hooks** (`onStart`, `onEnd`): Access via `context.userContext`.
-    - In **Tools** (`execute` function): Access via `options.operationContext.userContext`.
-2.  **Initialization & Propagation:**
-    - For a new top-level agent operation, `userContext` starts empty.
-    - If an agent call includes `userContext` in its options (e.g., `agent.generateText("...", { userContext: myDataMap })`), the operation starts with a clone of `myDataMap`.
-    - When a **supervisor agent delegates to a sub-agent** (e.g., via `delegate_task`), the supervisor's current `userContext` is automatically cloned and passed to the sub-agent. The sub-agent's operation then begins with this inherited context.
-3.  **Isolation:**
-    - Each top-level agent operation (e.g., two separate calls to `agent.generateText(...)`) has its own completely independent `userContext`.
-    - When context is passed to a sub-agent, it's a _clone_. Modifications by the sub-agent don't affect the supervisor's original `userContext` or other sub-agents.
-
-### Advanced Use Case: Managing Playwright Browser Instances
-
-Another powerful illustration of `userContext` is managing operation-scoped resources, like a Playwright `Browser` or `Page` instance. This avoids manually passing instances between hooks and tools.
-
-**Scenario:** An agent needs to perform browser automation. Each agent operation (e.g., a `generateText` call) requires its own isolated browser session.
-
-1.  **Lazy Initialization & Context Storage:** A helper function (e.g., `ensurePage`) checks `userContext` for an existing `Page`. If not found (or closed), it launches Playwright, creates a new `Page`, and stores both the `Page` and `Browser` instances in `userContext` using unique symbols as keys.
-2.  **Tool Access:** Tools needing browser access call this helper, passing their `operationContext`. The helper ensures they get the correct `Page` instance for the current operation from `userContext`.
-3.  **Scoped Cleanup via `onEnd` Hook:** An `onEnd` hook retrieves the `Browser` instance from the operation's `userContext` and closes it, ensuring resources are released when the specific operation concludes.
+Retrievers can store source information in `userContext`:
 
 ```typescript
-import {
-  Agent,
-  createHooks,
-  createTool,
-  type OnEndHookArgs,
-  type OperationContext,
-  type ToolExecutionContext,
-} from "@voltagent/core";
-import { z } from "zod"; // Make sure z is imported if not already
-import { chromium, type Browser, type Page } from "playwright";
-// Assume VercelAIProvider and openai are configured as in the first example
+import { BaseRetriever } from "@voltagent/core";
 
-const PAGE_KEY = Symbol("playwrightPage");
-const BROWSER_KEY = Symbol("playwrightBrowser");
+class SimpleRetriever extends BaseRetriever {
+  async retrieve(input, options) {
+    // Simulate finding documents
+    const foundDocs = [
+      { title: "VoltAgent Guide", url: "https://docs.example.com" },
+      { title: "Agent Tutorial", url: "https://tutorial.example.com" },
+    ];
 
-async function ensurePage(context: OperationContext): Promise<Page> {
-  let page = context.userContext.get(PAGE_KEY) as Page | undefined;
-  if (!page || page.isClosed()) {
-    console.log(`[${context.operationId}] LAZY: Creating new browser/page for operation...`);
-    const browser = await chromium.launch();
-    page = await browser.newPage();
-    context.userContext.set(BROWSER_KEY, browser);
-    context.userContext.set(PAGE_KEY, page);
+    // Store references in userContext
+    if (options?.userContext) {
+      options.userContext.set("references", foundDocs);
+      options.userContext.set("searchQuery", input);
+    }
+
+    // Return content for LLM
+    return foundDocs.map((doc) => `${doc.title}: Some helpful content...`).join("\n");
   }
-  return page;
 }
 
-const playwrightHooks = createHooks({
-  onEnd: async ({ context }: OnEndHookArgs) => {
-    const browser = context.userContext.get(BROWSER_KEY) as Browser | undefined;
-    if (browser) {
-      console.log(`[${context.operationId}] CLEANUP: Closing browser for operation...`);
-      await browser.close();
-    }
-  },
-});
-
-const navigateTool = createTool({
-  name: "navigate_url",
-  description: "Navigates to a specified URL.", // Added description
-  parameters: z.object({ url: z.string().url() }),
-  execute: async ({ url }, options?: ToolExecutionContext) => {
-    if (!options?.operationContext) throw new Error("OperationContext is required for this tool.");
-    const page = await ensurePage(options.operationContext);
-    await page.goto(url);
-    console.log(`[${options.operationContext.operationId}] ACTION: Navigated to ${url}`);
-    return `Successfully navigated to ${url}`;
-  },
-});
-
-const browserAutomationAgent = new Agent({
-  name: "BrowserAutomationAgent",
+const agentWithRetriever = new Agent({
+  name: "RetrievalAgent",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
-  hooks: playwrightHooks,
-  tools: [navigateTool],
-  instructions: "You are an agent that can browse the web. Use the navigate_url tool.",
+  retriever: new SimpleRetriever(),
+  instructions: "Answer using retrieved information.",
 });
 
-async function runBrowserTasks() {
-  console.log("--- Starting Browser Task 1 ---");
-  await browserAutomationAgent.generateText("Navigate to https://example.com using the tool.");
-  console.log("--- Browser Task 1 Finished ---");
+// Usage
+const response = await agentWithRetriever.generateText("How do I use VoltAgent?");
 
-  console.log("\n--- Starting Browser Task 2 (separate browser instance) ---");
-  await browserAutomationAgent.generateText("Navigate to https://google.com using the tool.");
-  console.log("--- Browser Task 2 Finished ---");
-}
-
-// runBrowserTasks();
+console.log("Answer:", response.text);
+console.log("Search query:", response.userContext?.get("searchQuery"));
+console.log("References:", response.userContext?.get("references"));
 ```
 
-This pattern ensures each call to `browserAutomationAgent.generateText` gets its own, clean browser environment, managed entirely through the operation-specific `userContext`.
+## Sub-Agents Share Context
 
-For a full implementation of this pattern, see the [VoltAgent Playwright Example](https://github.com/voltagent/voltagent/tree/main/examples/with-playwright).
-
-## Illustrating Core Access Patterns
-
-Let's solidify how to access `userContext` with a direct example focusing on hooks and tools. This expands on the "Quick Example" by showing tool interaction.
+When a supervisor delegates to sub-agents, `userContext` is automatically passed:
 
 ```typescript
-// Logger tool using context
-const simpleContextTool = createTool({
-  name: "log_with_context",
-  description: "Logs a message using an ID from userContext.",
-  parameters: z.object({ message: z.string() }),
-  execute: async (params: { message: string }, options?: ToolExecutionContext) => {
-    const operationIdFromContext = options?.operationContext?.userContext?.get("myOperationId");
-    const logMessage = `[Tool Log][OpID: ${operationIdFromContext || "N/A"}] Message: ${params.message}`;
-    console.log(logMessage);
-    return `Logged: ${params.message} (OpID: ${operationIdFromContext || "N/A"})`;
-  },
-});
-
-const agentWithToolContext = new Agent({
-  name: "ToolContextAgent",
+// Worker agent
+const workerAgent = new Agent({
+  name: "WorkerAgent",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
-  tools: [simpleContextTool],
   hooks: createHooks({
-    // Using hooks from the first "Quick Example"
-    onStart: ({ agent, context }: OnStartHookArgs) => {
-      const operationSpecificId = `op-${agent.name}-${Date.now()}`;
-      context.userContext.set("myOperationId", operationSpecificId);
-      console.log(`[${agent.name}] HOOK: Operation started. OpID set to: ${operationSpecificId}`);
-    },
-    onEnd: ({ agent, context }: OnEndHookArgs) => {
-      const opId = context.userContext.get("myOperationId");
-      console.log(`[${agent.name}] HOOK: Operation finished. Retrieved OpID: ${opId}`);
+    onStart: ({ context }) => {
+      // Gets userContext from supervisor
+      const projectId = context.userContext.get("projectId");
+      const language = context.userContext.get("language");
+      console.log(`Worker starting for project ${projectId}, language ${language}`);
     },
   }),
-  instructions: "Use the log_with_context tool to log your thoughts.",
+  instructions: "You are a worker that processes tasks.",
 });
 
-async function runToolContextTask() {
-  await agentWithToolContext.generateText(
-    "Log this message: 'Hello from the tool, using context!'"
-  );
-}
-// runToolContextTask();
+// Supervisor agent
+const supervisorAgent = new Agent({
+  name: "SupervisorAgent",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o"),
+  subAgents: [workerAgent],
+  hooks: createHooks({
+    onStart: ({ context }) => {
+      // Add project tracking
+      context.userContext.set("projectId", `project-${Date.now()}`);
+    },
+  }),
+  instructions: "You supervise tasks. Delegate work to WorkerAgent when needed.",
+});
+
+// Usage
+const context = new Map();
+context.set("language", "English");
+
+// When supervisor delegates, worker gets the same userContext
+await supervisorAgent.generateText("Please delegate this task to the worker", {
+  userContext: context,
+});
 ```
 
-This example explicitly shows:
+## Complete Flow Example
 
-- `onStart` hook setting a value in `userContext`.
-- A tool (`log_with_context`) accessing this value via `options.operationContext.userContext`.
-- `onEnd` hook also accessing the same value.
-
-## `userContext` in Sub-Agent Scenarios
-
-As highlighted in the "Core Principles", `userContext` is automatically cloned and passed from a supervisor agent to its sub-agents during delegation. This allows sub-agents to access shared information seamlessly.
-
-**Example: Propagating a Session ID to a Sub-Agent**
-
-Let's see a supervisor agent passing a `sessionId` to its sub-agent. The sub-agent then uses this ID in its hooks and tools.
+Here's how all pieces work together:
 
 ```typescript
-// Assume VercelAIProvider, openai, createTool, z, Agent, createHooks,
-// OnStartHookArgs, ToolExecutionContext are imported as in previous examples.
+import { Agent, createHooks, createTool, BaseRetriever } from "@voltagent/core";
+import { z } from "zod";
 
-// Sub-Agent that will use the context
-const subAgentProcessingTool = createTool({
-  name: "sub_task_processor_with_session",
-  description: "Processes a sub-task using an inherited session ID from context.",
-  parameters: z.object({ task_details: z.string() }),
-  execute: async (params, options?: ToolExecutionContext) => {
-    const sessionId = options?.operationContext?.userContext?.get("sessionId") || "unknown-session";
-    const logMessage = `[Sub-Agent TOOL][SessionID: ${sessionId}] Processing: ${params.task_details}`;
-    console.log(logMessage);
-    return `Sub-task for session ${sessionId} processed successfully.`;
+// Simple retriever
+class BasicRetriever extends BaseRetriever {
+  async retrieve(input, options) {
+    if (options.userContext) {
+      options.userContext.set("references", [{ title: "Document 1", source: "knowledge-base" }]);
+    }
+    return "Retrieved content about the topic";
+  }
+}
+
+// Simple tool
+const counterTool = createTool({
+  name: "increment_counter",
+  description: "Increments a counter",
+  parameters: z.object({}),
+  execute: async (_, options) => {
+    const userContext = options.operationContext?.userContext;
+    if (userContext) {
+      const count = (userContext.get("counter") || 0) + 1;
+      userContext.set("counter", count);
+      return `Counter is now: ${count}`;
+    }
+    return "Counter incremented";
   },
 });
 
-const workerAgentWithContext = new Agent({
-  name: "WorkerAgentWithContext",
+// Agent with everything
+const fullAgent = new Agent({
+  name: "FullAgent",
   llm: new VercelAIProvider(),
   model: openai("gpt-4o"),
-  tools: [subAgentProcessingTool],
+  retriever: new BasicRetriever(),
+  tools: [counterTool],
   hooks: createHooks({
-    onStart: ({ agent, context }: OnStartHookArgs) => {
-      const sessionId = context.userContext.get("sessionId");
-      console.log(`[${agent.name} HOOK] Operation started. Inherited SessionID: ${sessionId}`);
+    onStart: ({ context }) => {
+      console.log("🚀 Operation started");
+      context.userContext.set("operationId", `op-${Date.now()}`);
     },
-    onEnd: ({ agent, context }: OnStartHookArgs) => {
-      const sessionId = context.userContext.get("sessionId");
-      console.log(`[${agent.name} HOOK] Operation finished for SessionID: ${sessionId}`);
-    }
-  }),
-  instructions: "You are a worker agent. Use your tools to process tasks based on session ID."
-});
+    onEnd: ({ context }) => {
+      const opId = context.userContext.get("operationId");
+      const counter = context.userContext.get("counter");
+      const references = context.userContext.get("references");
 
-// Supervisor Agent
-const supervisorAgentWithDelegation = new Agent({
-  name: "SupervisorAgentWithDelegation",
-  llm: new VercelAIProvider(),
-  model: openai("gpt-4o"),
-  hooks: createHooks({
-    onStart: ({ agent, context }: OnStartHookArgs) => {
-      const sessionId = context.userContext.get("sessionId");
-      console.log(`[${agent.name} HOOK] Supervisor Operation started. SessionID set to: ${sessionId}`);
+      console.log("✅ Operation completed");
+      console.log(`Operation ID: ${opId}`);
+      console.log(`Counter final value: ${counter}`);
+      console.log(`References found: ${references?.length || 0}`);
     },
   }),
-  subAgents: [workerAgentWithContext], // This makes delegate_task available
-  instructions: "You are a supervisor. Delegate tasks to WorkerAgentWithContext."
+  instructions: "Use tools and retrieval to help users. Always increment the counter.",
 });
 
-async function runDelegationWithContext() {
-  const supervisorSessionMap = new Map<string | symbol, unknown>();
-  const newSessionId = `session-${Date.now()}`;
-  supervisorSessionMap.set("sessionId", newSessionId);
+// Usage showing the complete flow
+async function demonstrateFlow() {
+  const initialContext = new Map();
+  initialContext.set("language", "English");
 
-  console.log(`\n--- Supervisor starting operation with SessionID: ${newSessionId} ---\`);
-  // Supervisor's generateText call includes the userContext.
-  // If it calls delegate_task for WorkerAgentWithContext, this context will be passed.
-  await supervisorAgentWithDelegation.generateText(
-    `Delegate processing of 'important financial data' to WorkerAgentWithContext for session ${newSessionId}.`,
-    { userContext: supervisorSessionMap }
+  const response = await fullAgent.generateText(
+    "Use the increment tool and search for information",
+    { userContext: initialContext }
   );
-  console.log("--- Supervisor operation finished ---");
-}
 
-// runDelegationWithContext();
+  console.log("Text:", response.text);
+  const finalContext = response.userContext;
+  for (const [key, value] of finalContext.entries()) {
+    console.log(`${String(key)}: ${JSON.stringify(value)}`);
+  }
+}
 ```
 
-In this example:
+## Key Points
 
-- When `supervisorAgentWithDelegation.generateText` is called with a `userContext` containing a `sessionId`, this context is established for the supervisor's operation.
-- If the supervisor LLM uses the `delegate_task` tool (automatically available due to `subAgents` configuration) to delegate to `WorkerAgentWithContext`, the `SubAgentManager` ensures the `supervisorSessionMap` (as a clone) is passed to the worker.
-- `WorkerAgentWithContext`'s `onStart` hook and its `subAgentProcessingTool` can then access this `sessionId` from their own `userContext`.
+1. **Initialization**: Pass data via `{ userContext: myMap }` when calling the agent
+2. **Hooks**: Access via `context.userContext` in `onStart`/`onEnd`
+3. **Tools**: Access via `options.operationContext.userContext` in `execute`
+4. **Retrievers**: Access via `options.userContext` in `retrieve`
+5. **Sub-Agents**: Automatically get a copy of supervisor's `userContext`
+6. **Response**: Access final state via `response.userContext`
 
-This pattern is crucial for maintaining contextual coherence when tasks are broken down and distributed across multiple specialized agents.
+Each component can read existing data and add new data. The `userContext` travels through the entire operation, making it easy to share state and track information across all parts of your agent system.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Currently, retrievers cannot share metadata or reference information with the calling agent. When a retriever finds and returns relevant documents, there's no way to track which specific sources were used, making it impossible to implement citation systems or audit trails.

## What is the new behavior?

Retrievers now support userContext, allowing them to store additional metadata that can be accessed from agent responses:

- **userContext support**: Retrievers can store references, sources, and metadata in `options.userContext`
- **Response access**: Agent responses now include `userContext` for accessing retriever metadata
- **References tracking**: Perfect for citation systems and audit trails
- **Simplified API**: Removed method overloads, making `options` parameter required

```ts
// Retriever can store references
class MyRetriever extends BaseRetriever {
  async retrieve(input: string, options: RetrieveOptions): Promise<string> {
    const docs = this.findRelevantDocs(input);
    
    // Store references in userContext
    if (options.userContext) {
      const references = docs.map((doc) => ({
        id: doc.id,
        title: doc.title,
        source: doc.source,
      }));
      options.userContext.set("references", references);
    }
    
    return docs.map((doc) => doc.content).join("\n");
  }
}

// Access references from response
const response = await agent.generateText("What is VoltAgent?");
const references = response.userContext?.get("references");
```

This change opens up powerful use cases like showing users which documents influenced the response, implementing proper citation systems, and maintaining audit trails for compliance.