### PR TITLE
feat: migrate the provider streams to `AsyncIterableStream`

### DIFF
--- a/.changeset/polite-wings-enter.md
+++ b/.changeset/polite-wings-enter.md
@@ -2,4 +2,4 @@
 "@voltagent/core": patch
 ---
 
-fix: fix the types for the primary methods with schema (currently outputs as any)
+fix: fix the types for the primary methods with schema (currently outputs as `any`)

--- a/.changeset/polite-wings-enter.md
+++ b/.changeset/polite-wings-enter.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix: fix the types for the primary methods with schema (currently outputs as any)

--- a/.changeset/polite-wings-enter.md
+++ b/.changeset/polite-wings-enter.md
@@ -2,4 +2,39 @@
 "@voltagent/core": patch
 ---
 
-fix: fix the types for the primary methods with schema (currently outputs as `any`)
+fix: migrate the provider streams to `AsyncIterableStream`
+
+Example:
+
+```typescript
+const stream = createAsyncIterableStream(
+  new ReadableStream({
+    start(controller) {
+      controller.enqueue("Hello");
+      controller.enqueue(", ");
+      controller.enqueue("world!");
+      controller.close();
+    },
+  })
+);
+
+for await (const chunk of stream) {
+  console.log(chunk);
+}
+
+// in the agent
+const result = await agent.streamObject({
+  messages,
+  model: "test-model",
+  schema,
+});
+
+for await (const chunk of result.objectStream) {
+  console.log(chunk);
+}
+```
+
+New exports:
+
+- `createAsyncIterableStream`
+- `type AsyncIterableStream`

--- a/.changeset/polite-wings-enter.md
+++ b/.changeset/polite-wings-enter.md
@@ -1,5 +1,9 @@
 ---
 "@voltagent/core": patch
+"@voltagent/xsai": patch
+"@voltagent/anthropic-ai": patch
+"@voltagent/google-ai": patch
+"@voltagent/groq-ai": patch
 ---
 
 fix: migrate the provider streams to `AsyncIterableStream`

--- a/examples/with-vercel-ai/src/index.ts
+++ b/examples/with-vercel-ai/src/index.ts
@@ -1,4 +1,4 @@
-import { VoltAgent, Agent } from "@voltagent/core";
+import { Agent, VoltAgent } from "@voltagent/core";
 import { VercelAIProvider } from "@voltagent/vercel-ai";
 
 import { openai } from "@ai-sdk/openai";

--- a/packages/core/src/agent/index.spec.ts
+++ b/packages/core/src/agent/index.spec.ts
@@ -1,3 +1,4 @@
+import { ReadableStream } from "node:stream/web";
 // @ts-ignore - To prevent errors when loading Jest mocks
 import { z } from "zod";
 import { AgentEventEmitter } from "../events";

--- a/packages/core/src/agent/index.spec.ts
+++ b/packages/core/src/agent/index.spec.ts
@@ -1,5 +1,4 @@
 import { ReadableStream } from "node:stream/web";
-// @ts-ignore - To prevent errors when loading Jest mocks
 import { z } from "zod";
 import { AgentEventEmitter } from "../events";
 import type { Memory, MemoryMessage } from "../memory/types";

--- a/packages/core/src/agent/index.spec.ts
+++ b/packages/core/src/agent/index.spec.ts
@@ -1,9 +1,9 @@
-import { ReadableStream } from "node:stream/web";
 import { z } from "zod";
 import { AgentEventEmitter } from "../events";
 import type { Memory, MemoryMessage } from "../memory/types";
 import { AgentRegistry } from "../server/registry";
 import { createTool } from "../tool";
+import { createAsyncIterableStream } from "../utils/async-iterable-stream";
 import { Agent } from "./index";
 import type {
   BaseMessage,
@@ -232,27 +232,31 @@ class MockProvider implements LLMProvider<MockModelType> {
     this.streamTextCalls++;
     this.lastMessages = options.messages;
 
-    const stream = new ReadableStream<{
-      type: "text-delta";
-      textDelta: string;
-    }>({
-      start(controller) {
-        controller.enqueue({ type: "text-delta", textDelta: "Hello" });
-        controller.enqueue({ type: "text-delta", textDelta: ", " });
-        controller.enqueue({ type: "text-delta", textDelta: "world!" });
-        controller.close();
-      },
-    });
+    const stream = createAsyncIterableStream(
+      new ReadableStream<{
+        type: "text-delta";
+        textDelta: string;
+      }>({
+        start(controller) {
+          controller.enqueue({ type: "text-delta", textDelta: "Hello" });
+          controller.enqueue({ type: "text-delta", textDelta: ", " });
+          controller.enqueue({ type: "text-delta", textDelta: "world!" });
+          controller.close();
+        },
+      }),
+    );
 
     // Create a text stream
-    const textStream = new ReadableStream<string>({
-      start(controller) {
-        controller.enqueue("Hello");
-        controller.enqueue(", ");
-        controller.enqueue("world!");
-        controller.close();
-      },
-    });
+    const textStream = createAsyncIterableStream(
+      new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue("Hello");
+          controller.enqueue(", ");
+          controller.enqueue("world!");
+          controller.close();
+        },
+      }),
+    );
 
     return {
       provider: stream,
@@ -339,7 +343,7 @@ class MockProvider implements LLMProvider<MockModelType> {
 
     return {
       provider: result,
-      objectStream: partialObjectStream,
+      objectStream: createAsyncIterableStream(partialObjectStream),
     };
   }
 }

--- a/packages/core/src/agent/providers/base/types.ts
+++ b/packages/core/src/agent/providers/base/types.ts
@@ -1,6 +1,6 @@
-import type { ReadableStream } from "node:stream/web";
 import type { z } from "zod";
 import type { Tool } from "../../../tool";
+import type { AsyncIterableStream } from "../../../utils/async-iterable-stream";
 import type {
   OperationContext,
   ProviderOptions,
@@ -76,7 +76,7 @@ export type ProviderTextStreamResponse<TOriginalResponse> = {
   /**
    * Text stream for consuming the response
    */
-  textStream: ReadableStream<string>;
+  textStream: AsyncIterableStream<string>;
 };
 
 /**
@@ -116,7 +116,7 @@ export type ProviderObjectStreamResponse<TOriginalResponse, TObject> = {
   /**
    * Object stream for consuming partial objects
    */
-  objectStream: ReadableStream<Partial<TObject>>;
+  objectStream: AsyncIterableStream<Partial<TObject>>;
 };
 
 /**
@@ -348,9 +348,7 @@ export type InferProviderParams<T> = T extends {
     : Record<string, never>
   : Record<string, never>;
 
-// Base provider type
 export type LLMProvider<TProvider> = {
-  // Core methods
   /**
    * Generates a text response based on the provided options.
    * Implementers should catch underlying SDK/API errors and throw a VoltAgentError.
@@ -360,6 +358,11 @@ export type LLMProvider<TProvider> = {
     options: GenerateTextOptions<InferModel<TProvider>>,
   ): Promise<ProviderTextResponse<InferGenerateTextResponse<TProvider>>>;
 
+  /**
+   * Streams a text response based on the provided options.
+   * Implementers should catch underlying SDK/API errors and throw a VoltAgentError.
+   * @throws {VoltAgentError} If an error occurs during streaming.
+   */
   streamText(
     options: StreamTextOptions<InferModel<TProvider>>,
   ): Promise<ProviderTextStreamResponse<InferStreamResponse<TProvider>>>;
@@ -373,14 +376,25 @@ export type LLMProvider<TProvider> = {
     options: GenerateObjectOptions<InferModel<TProvider>, TSchema>,
   ): Promise<ProviderObjectResponse<InferGenerateObjectResponse<TProvider>, z.infer<TSchema>>>;
 
+  /**
+   * Streams a structured object response based on the provided options and schema.
+   * Implementers should catch underlying SDK/API errors and throw a VoltAgentError.
+   * @throws {VoltAgentError} If an error occurs during streaming.
+   */
   streamObject<TSchema extends z.ZodType>(
     options: StreamObjectOptions<InferModel<TProvider>, TSchema>,
   ): Promise<ProviderObjectStreamResponse<InferStreamResponse<TProvider>, z.infer<TSchema>>>;
 
-  // Message conversion methods
+  /**
+   * Converts a base message to a provider-specific message.
+   * @param message The base message to convert.
+   * @returns The provider-specific message.
+   */
   toMessage(message: BaseMessage): InferMessage<TProvider>;
 
-  // Optional tool conversion method
+  /**
+   * Optional tool conversion method.
+   */
   toTool?: (tool: BaseTool) => InferTool<TProvider>;
 
   /**

--- a/packages/core/src/agent/providers/base/types.ts
+++ b/packages/core/src/agent/providers/base/types.ts
@@ -1,3 +1,4 @@
+import type { ReadableStream } from "node:stream/web";
 import type { z } from "zod";
 import type { Tool } from "../../../tool";
 import type {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,5 +1,12 @@
 import type { Span } from "@opentelemetry/api";
-import type { BaseMessage } from "../agent/providers/base/types";
+import type { z } from "zod";
+import type {
+  BaseMessage,
+  ProviderObjectResponse,
+  ProviderObjectStreamResponse,
+  ProviderTextResponse,
+  ProviderTextStreamResponse,
+} from "../agent/providers/base/types";
 import type { Memory, MemoryOptions } from "../memory/types";
 import type { VoltAgentExporter } from "../telemetry/exporter";
 import type { Tool, Toolkit } from "../tool";
@@ -140,29 +147,35 @@ export type ModelType<T> = T extends { llm: LLMProvider<any> }
 /**
  * Infer generate text response type
  */
-export type InferGenerateTextResponse<T extends { llm: LLMProvider<any> }> = Awaited<
-  ReturnType<T["llm"]["generateText"]>
->;
+export type InferGenerateTextResponseFromProvider<TProvider extends { llm: LLMProvider<any> }> =
+  ProviderTextResponse<InferOriginalResponseFromProvider<TProvider, "generateText">>;
 
 /**
  * Infer stream text response type
  */
-export type InferStreamTextResponse<T extends { llm: LLMProvider<any> }> = Awaited<
-  ReturnType<T["llm"]["streamText"]>
->;
+export type InferStreamTextResponseFromProvider<TProvider extends { llm: LLMProvider<any> }> =
+  ProviderTextStreamResponse<InferOriginalResponseFromProvider<TProvider, "streamText">>;
 
 /**
  * Infer generate object response type
  */
-export type InferGenerateObjectResponse<T extends { llm: LLMProvider<any> }> = Awaited<
-  ReturnType<T["llm"]["generateObject"]>
+export type InferGenerateObjectResponseFromProvider<
+  TProvider extends { llm: LLMProvider<any> },
+  TSchema extends z.ZodType,
+> = ProviderObjectResponse<
+  InferOriginalResponseFromProvider<TProvider, "generateObject">,
+  z.infer<TSchema>
 >;
 
 /**
  * Infer stream object response type
  */
-export type InferStreamObjectResponse<T extends { llm: LLMProvider<any> }> = Awaited<
-  ReturnType<T["llm"]["streamObject"]>
+export type InferStreamObjectResponseFromProvider<
+  TProvider extends { llm: LLMProvider<any> },
+  TSchema extends z.ZodType,
+> = ProviderObjectStreamResponse<
+  InferOriginalResponseFromProvider<TProvider, "streamObject">,
+  z.infer<TSchema>
 >;
 
 /**
@@ -567,3 +580,13 @@ export type AgentOperationOutput =
   | StreamTextFinishResult
   | StandardizedObjectResult<unknown> // Object type generalized
   | StreamObjectFinishResult<unknown>; // Object type generalized
+
+type InferResponseFromProvider<
+  TProvider extends { llm: LLMProvider<any> },
+  TMethod extends "generateText" | "streamText" | "generateObject" | "streamObject",
+> = Awaited<ReturnType<TProvider["llm"][TMethod]>>;
+
+type InferOriginalResponseFromProvider<
+  TProvider extends { llm: LLMProvider<any> },
+  TMethod extends "generateText" | "streamText" | "generateObject" | "streamObject",
+> = InferResponseFromProvider<TProvider, TMethod>["provider"];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export * from "./mcp";
 export { AgentRegistry } from "./server/registry";
 export { registerCustomEndpoint, registerCustomEndpoints } from "./server/api";
 export * from "./utils/update";
+export { createAsyncIterableStream, type AsyncIterableStream } from "./utils/async-iterable-stream";
 export * from "./voice";
 export {
   CustomEndpointDefinition,

--- a/packages/core/src/server/api.ts
+++ b/packages/core/src/server/api.ts
@@ -274,7 +274,7 @@ app.openapi(textRoute, async (c) => {
 
     const response = await agent.generateText(input, options);
     return c.json(
-      { success: true, data: response } satisfies z.infer<typeof TextResponseSchema>,
+      { success: true, data: response.text } satisfies z.infer<typeof TextResponseSchema>,
       200,
     );
   } catch (error) {
@@ -467,7 +467,7 @@ app.openapi(objectRoute, async (c) => {
 
     const response = await agent.generateObject(input, schemaInZodObject, options);
     return c.json(
-      { success: true, data: response } satisfies z.infer<typeof ObjectResponseSchema>,
+      { success: true, data: response.object } satisfies z.infer<typeof ObjectResponseSchema>,
       200,
     );
   } catch (error) {

--- a/packages/core/src/server/api.ts
+++ b/packages/core/src/server/api.ts
@@ -273,8 +273,13 @@ app.openapi(textRoute, async (c) => {
     const { input, options = {} } = c.req.valid("json") as z.infer<typeof TextRequestSchema>;
 
     const response = await agent.generateText(input, options);
+
+    // TODO: Fix this once we can force a change to the response type
+    const fixBadResponseTypeForBackwardsCompatibility = response as any;
     return c.json(
-      { success: true, data: response.text } satisfies z.infer<typeof TextResponseSchema>,
+      { success: true, data: fixBadResponseTypeForBackwardsCompatibility } satisfies z.infer<
+        typeof TextResponseSchema
+      >,
       200,
     );
   } catch (error) {
@@ -466,8 +471,14 @@ app.openapi(objectRoute, async (c) => {
     const schemaInZodObject = convertJsonSchemaToZod(schema) as unknown as z.ZodType;
 
     const response = await agent.generateObject(input, schemaInZodObject, options);
+
+    // TODO: Fix this once we can force a change to the response type
+    const fixBadResponseTypeForBackwardsCompatibility = response as any;
     return c.json(
-      { success: true, data: response.object } satisfies z.infer<typeof ObjectResponseSchema>,
+      {
+        success: true,
+        data: fixBadResponseTypeForBackwardsCompatibility,
+      } satisfies z.infer<typeof ObjectResponseSchema>,
       200,
     );
   } catch (error) {

--- a/packages/core/src/utils/async-iterable-stream/index.spec.ts
+++ b/packages/core/src/utils/async-iterable-stream/index.spec.ts
@@ -1,0 +1,33 @@
+import {
+  convertArrayToReadableStream,
+  convertAsyncIterableToArray,
+  convertReadableStreamToArray,
+} from "../internal/test";
+import { createAsyncIterableStream } from "./index";
+
+describe("createAsyncIterableStream()", () => {
+  it("should read all chunks from a non-empty stream using async iteration", async () => {
+    const testData = ["Hello", "World", "Stream"];
+
+    const source = convertArrayToReadableStream(testData);
+    const asyncIterableStream = createAsyncIterableStream(source);
+
+    expect(await convertAsyncIterableToArray(asyncIterableStream)).toEqual(testData);
+  });
+
+  it("should handle an empty stream gracefully", async () => {
+    const source = convertArrayToReadableStream<string>([]);
+    const asyncIterableStream = createAsyncIterableStream(source);
+
+    expect(await convertAsyncIterableToArray(asyncIterableStream)).toEqual([]);
+  });
+
+  it("should maintain ReadableStream functionality", async () => {
+    const testData = ["Hello", "World"];
+
+    const source = convertArrayToReadableStream(testData);
+    const asyncIterableStream = createAsyncIterableStream(source);
+
+    expect(await convertReadableStreamToArray(asyncIterableStream)).toEqual(testData);
+  });
+});

--- a/packages/core/src/utils/async-iterable-stream/index.ts
+++ b/packages/core/src/utils/async-iterable-stream/index.ts
@@ -1,0 +1,44 @@
+/**
+ * An async iterable stream that can be read from.
+ * @example
+ * ```typescript
+ * const stream: AsyncIterableStream<string> = getStream();
+ * for await (const chunk of stream) {
+ *   console.log(chunk);
+ * }
+ * ```
+ */
+export type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+/**
+ * Create an async iterable stream from a readable stream.
+ *
+ * This is useful for creating an async iterable stream from a readable stream.
+ *
+ * @example
+ * ```typescript
+ * const stream: AsyncIterableStream<string> = createAsyncIterableStream(new ReadableStream({
+ *   start(controller) {
+ *     controller.enqueue("Hello");
+ *     controller.close();
+ *   },
+ * }));
+ * ```
+ * @param source The readable stream to create an async iterable stream from.
+ * @returns The async iterable stream.
+ */
+export function createAsyncIterableStream<T>(source: ReadableStream<T>): AsyncIterableStream<T> {
+  const stream = source.pipeThrough(new TransformStream<T, T>());
+
+  (stream as AsyncIterableStream<T>)[Symbol.asyncIterator] = () => {
+    const reader = stream.getReader();
+    return {
+      async next(): Promise<IteratorResult<T>> {
+        const { done, value } = await reader.read();
+        return done ? { done: true, value: undefined } : { done: false, value };
+      },
+    };
+  };
+
+  return stream as AsyncIterableStream<T>;
+}

--- a/packages/core/src/utils/internal/test/index.ts
+++ b/packages/core/src/utils/internal/test/index.ts
@@ -1,0 +1,49 @@
+export async function convertReadableStreamToArray<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const reader = stream.getReader();
+  const result: T[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    result.push(value);
+  }
+
+  return result;
+}
+
+export function convertArrayToAsyncIterable<T>(values: T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const value of values) {
+        yield value;
+      }
+    },
+  };
+}
+
+export async function convertAsyncIterableToArray<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of iterable) {
+    result.push(item);
+  }
+  return result;
+}
+
+export function convertArrayToReadableStream<T>(values: T[]): ReadableStream<T> {
+  return new ReadableStream({
+    start(controller) {
+      try {
+        for (const value of values) {
+          controller.enqueue(value);
+        }
+      } finally {
+        controller.close();
+      }
+    },
+  });
+}
+
+export async function convertResponseStreamToArray(response: Response): Promise<string[]> {
+  // biome-ignore lint/style/noNonNullAssertion: ignore this
+  return convertReadableStreamToArray(response.body!.pipeThrough(new TextDecoderStream()));
+}

--- a/packages/xsai/src/index.spec.ts
+++ b/packages/xsai/src/index.spec.ts
@@ -275,7 +275,8 @@ describe("XSAIProvider", () => {
         }),
       );
       expect(result.provider).toBe(mockResult);
-      expect(result.textStream).toBe(mockStream);
+      expect(result.textStream).toBeInstanceOf(ReadableStream);
+      expect(result.textStream).toHaveProperty([Symbol.asyncIterator]);
     });
 
     // TODO: Add tests for onStepFinish and onFinish callback wrapping within streamText
@@ -511,7 +512,8 @@ describe("XSAIProvider", () => {
         }),
       );
       expect(result.provider).toBe(mockResult);
-      expect(result.objectStream).toBe(mockStream);
+      expect(result.objectStream).toBeInstanceOf(ReadableStream);
+      expect(result.objectStream).toHaveProperty([Symbol.asyncIterator]);
     });
 
     // TODO: Add tests for onStepFinish and onFinish callback wrapping within streamObject

--- a/packages/xsai/src/index.ts
+++ b/packages/xsai/src/index.ts
@@ -13,6 +13,7 @@ import type {
   ProviderTextStreamResponse,
   StepWithContent,
 } from "@voltagent/core";
+import { createAsyncIterableStream } from "@voltagent/core";
 import type {
   GenerateObjectResult,
   GenerateTextResult,
@@ -281,7 +282,7 @@ export class XSAIProvider implements LLMProvider<string> {
     // Return only provider and textStream - usage, toolCalls, etc. come in the stream
     return {
       provider: result,
-      textStream: result.textStream,
+      textStream: createAsyncIterableStream(result.textStream),
     };
   }
 
@@ -394,7 +395,7 @@ export class XSAIProvider implements LLMProvider<string> {
     // Return only provider and objectStream - other data comes in the stream
     return {
       provider: result,
-      objectStream: result.partialObjectStream,
+      objectStream: createAsyncIterableStream(result.partialObjectStream),
     };
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Currently the `streamObject` and `streamText` return a `ReadableStream` which is not iterable.

## What is the new behavior?

`streamObject` and `streamText` return an `AsyncIterableStream` that can be iterated safely:

```typescript

const result = agent.streamText();

for await (const chunk of result.textStream) {
  console.log(chunk);
}
```

in addition it standardizes the core primitive or textStream and objectStream so its the same across the board, instead of dependent on the provider.

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
