### PR TITLE
fix: gemini doesn't support only system role message

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,7 +122,9 @@ export class VoltAgent {
 
     // Auto-start server if enabled
     if (options.autoStart !== false) {
-      this.startServer().catch((err) => {
+      this.startServer({
+        port: options.port,
+      }).catch((err) => {
         devLogger.error("Failed to start server:", err);
         process.exit(1);
       });
@@ -174,7 +176,7 @@ export class VoltAgent {
   /**
    * Start the server
    */
-  public async startServer(): Promise<void> {
+  public async startServer(opts: { port?: number }): Promise<void> {
     if (this.serverStarted) {
       devLogger.info("Server is already running");
       return;
@@ -186,7 +188,7 @@ export class VoltAgent {
         registerCustomEndpoints(this.customEndpoints);
       }
 
-      await startServer();
+      await startServer(opts);
       this.serverStarted = true;
     } catch (error) {
       devLogger.error(

--- a/packages/core/src/mcp/client/index.spec.ts
+++ b/packages/core/src/mcp/client/index.spec.ts
@@ -413,6 +413,12 @@ describe("MCPClient", () => {
         { timeout: expect.any(Number) },
       );
       expect(result).toEqual({ content: "tool-result" });
+      // Verify beforeToolCall was emitted before the tool call
+      expect(toolCallEmitSpy).toHaveBeenCalledWith("beforeToolCall", {
+        name: "testTool",
+        arguments: { param: "value" },
+      });
+      // Verify toolCall was emitted after the tool call
       expect(toolCallEmitSpy).toHaveBeenCalledWith(
         "toolCall",
         "testTool",
@@ -488,21 +494,28 @@ describe("MCPClient", () => {
       const connectHandler = jest.fn();
       const disconnectHandler = jest.fn();
       const errorHandler = jest.fn();
+      const beforeToolCallHandler = jest.fn();
       const toolCallHandler = jest.fn();
 
       client.on("connect", connectHandler);
       client.on("disconnect", disconnectHandler);
       client.on("error", errorHandler);
+      client.on("beforeToolCall", beforeToolCallHandler);
       client.on("toolCall", toolCallHandler);
 
       client.emit("connect");
       client.emit("disconnect");
       client.emit("error", new Error("Test error"));
+      client.emit("beforeToolCall", { name: "testTool", arguments: { param: "value" } });
       client.emit("toolCall", "testTool", { param: "value" }, "result");
 
       expect(connectHandler).toHaveBeenCalled();
       expect(disconnectHandler).toHaveBeenCalled();
       expect(errorHandler).toHaveBeenCalledWith(new Error("Test error"));
+      expect(beforeToolCallHandler).toHaveBeenCalledWith({
+        name: "testTool",
+        arguments: { param: "value" },
+      });
       expect(toolCallHandler).toHaveBeenCalledWith("testTool", { param: "value" }, "result");
     });
   });

--- a/packages/core/src/mcp/types.ts
+++ b/packages/core/src/mcp/types.ts
@@ -171,6 +171,8 @@ export type MCPToolCall = {
    * Arguments to pass to the tool
    */
   arguments: Record<string, unknown>;
+
+  _meta?: Record<string, unknown>;
 };
 
 /**
@@ -201,6 +203,11 @@ export interface MCPClientEvents {
    * Emitted when an error occurs
    */
   error: (error: Error | TransportError) => void;
+
+  /**
+   * Emitted before a tool call is executed
+   */
+  beforeToolCall: (toolCall: MCPToolCall) => void;
 
   /**
    * Emitted when a tool call completes

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -123,7 +123,7 @@ const printServerStartup = (port: number) => {
   console.log(divider);
 };
 
-const tryStartServer = (port: number): Promise<ReturnType<typeof serve>> => {
+const tryStartServer = (port?: number): Promise<ReturnType<typeof serve>> => {
   return new Promise((resolve, reject) => {
     try {
       // Start the HTTP server
@@ -153,7 +153,7 @@ const tryStartServer = (port: number): Promise<ReturnType<typeof serve>> => {
 };
 
 // Function to start the server
-export const startServer = async (): Promise<ServerReturn> => {
+export const startServer = async (opts: { port?: number }): Promise<ServerReturn> => {
   // Collect all ports in an array - first preferred ports, then fallback ports
   const portsToTry: Array<PortConfig> = [
     ...preferredPorts,
@@ -166,7 +166,11 @@ export const startServer = async (): Promise<ServerReturn> => {
 
   // Try each port in sequence
   for (const portConfig of portsToTry) {
-    const { port } = portConfig;
+    let { port } = opts;
+    if (!port) {
+      // If no port is provided, use the preferred port
+      port = portConfig.port;
+    }
 
     try {
       // Try to start the server and wait until successful

--- a/packages/core/src/tool/index.ts
+++ b/packages/core/src/tool/index.ts
@@ -72,6 +72,8 @@ export class Tool<T extends ToolSchema = ToolSchema> /* implements BaseTool<z.in
    */
   readonly execute: (args: z.infer<T>, options?: ToolExecuteOptions) => Promise<unknown>;
 
+  _meta?: Record<string, unknown>;
+
   /**
    * Create a new tool
    */


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
agents with gemini models in a subagent flow throw errors
1. ```system messages are only supported at the beginning of the conversation' functionality not supported.```
2. ```Unable to submit request because at least one contents field is required. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini```


## What is the new behavior?
This fix suggests
1. re-format messages, where any "system" role message from the history gets changes to "assistant" role - it kind of making sense since those messages were generated by a model, it's just by different agent
2. system message will be resolved to a user message. Maybe it should be an "assistant" as well?


## Notes for reviewers

Please suggest a better approach cause I am not sure about the impact on the other models and a proper fix might require more thoughts and time