### PR TITLE
feat(core): add config to disable swagger ui

### DIFF
--- a/.changeset/twelve-cats-repair.md
+++ b/.changeset/twelve-cats-repair.md
@@ -1,19 +1,78 @@
 ---
-"@voltagent/core": major
+"@voltagent/core": patch
 ---
 
-feat(core): Config to disable swagger ui
+feat(core): Enhanced server configuration with unified `server` object and Swagger UI control
 
-## By default:
+Server configuration options have been enhanced with a new unified `server` object for better organization and flexibility while maintaining full backward compatibility.
 
-In development (NODE_ENV !== 'production'): Swagger UI is enabled
+**What's New:**
 
-In production (NODE_ENV === 'production'): Swagger UI is disabled
+- **Unified Server Configuration:** All server-related options (`autoStart`, `port`, `enableSwaggerUI`, `customEndpoints`) are now grouped under a single `server` object.
+- **Swagger UI Control:** Fine-grained control over Swagger UI availability with environment-specific defaults.
+- **Backward Compatibility:** Legacy individual options are still supported but deprecated.
+- **Override Logic:** New `server` object takes precedence over deprecated individual options.
 
-// Enable Swagger UI even in production
-`startServer({ enableSwaggerUI: true });`
+**Migration Guide:**
 
-// Disable Swagger UI even in development
-`startServer({ enableSwaggerUI: false });`
+**New Recommended Usage:**
+
+```typescript
+import { Agent, VoltAgent } from "@voltagent/core";
+import { VercelAIProvider } from "@voltagent/vercel-ai";
+import { openai } from "@ai-sdk/openai";
+
+const agent = new Agent({
+  name: "My Assistant",
+  instructions: "A helpful assistant",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o-mini"),
+});
+
+new VoltAgent({
+  agents: { agent },
+  server: {
+    autoStart: true,
+    port: 3000,
+    enableSwaggerUI: true,
+    customEndpoints: [
+      {
+        path: "/health",
+        method: "get",
+        handler: async (c) => c.json({ status: "ok" }),
+      },
+    ],
+  },
+});
+```
+
+**Legacy Usage (Deprecated but Still Works):**
+
+```typescript
+new VoltAgent({
+  agents: { agent },
+  autoStart: true, // @deprecated - use server.autoStart
+  port: 3000, // @deprecated - use server.port
+  customEndpoints: [], // @deprecated - use server.customEndpoints
+});
+```
+
+**Mixed Usage (Server Object Overrides):**
+
+```typescript
+new VoltAgent({
+  agents: { agent },
+  autoStart: false, // This will be overridden
+  server: {
+    autoStart: true, // This takes precedence
+  },
+});
+```
+
+**Swagger UI Defaults:**
+
+- Development (`NODE_ENV !== 'production'`): Swagger UI enabled
+- Production (`NODE_ENV === 'production'`): Swagger UI disabled
+- Override with `server.enableSwaggerUI: true/false`
 
 Resolves [#241](https://github.com/VoltAgent/voltagent/issues/241)

--- a/.changeset/twelve-cats-repair.md
+++ b/.changeset/twelve-cats-repair.md
@@ -1,0 +1,19 @@
+---
+"@voltagent/core": major
+---
+
+feat(core): Config to disable swagger ui
+
+## By default:
+
+In development (NODE_ENV !== 'production'): Swagger UI is enabled
+
+In production (NODE_ENV === 'production'): Swagger UI is disabled
+
+// Enable Swagger UI even in production
+`startServer({ enableSwaggerUI: true });`
+
+// Disable Swagger UI even in development
+`startServer({ enableSwaggerUI: false });`
+
+Resolves [#241](https://github.com/VoltAgent/voltagent/issues/241)

--- a/packages/core/src/server/api.ts
+++ b/packages/core/src/server/api.ts
@@ -38,6 +38,7 @@ import type { AgentResponse, ApiContext, ApiResponse } from "./types";
 // Configuration interface
 export interface ServerConfig {
   enableSwaggerUI?: boolean;
+  port?: number;
 }
 
 const app = new OpenAPIHono();

--- a/packages/core/src/server/api.ts
+++ b/packages/core/src/server/api.ts
@@ -35,7 +35,22 @@ import {
 import { AgentRegistry } from "./registry";
 import type { AgentResponse, ApiContext, ApiResponse } from "./types";
 
+// Configuration interface
+export interface ServerConfig {
+  enableSwaggerUI?: boolean;
+}
+
 const app = new OpenAPIHono();
+
+// Function to setup Swagger UI based on config
+export const setupSwaggerUI = (config?: ServerConfig) => {
+  const isProduction = process.env.NODE_ENV === "production";
+  const shouldEnableSwaggerUI = config?.enableSwaggerUI ?? !isProduction;
+
+  if (shouldEnableSwaggerUI) {
+    app.get("/ui", swaggerUI({ url: "/doc" }));
+  }
+};
 
 // Nerdy landing page
 app.get("/", (c) => {
@@ -751,9 +766,6 @@ app.doc("/doc", {
   },
   servers: [{ url: "http://localhost:3141", description: "Local development server" }],
 });
-
-// Swagger UI endpoint
-app.get("/ui", swaggerUI({ url: "/doc" }));
 
 /**
  * Register a single custom endpoint with the API server

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -162,15 +162,26 @@ export const startServer = async (config?: ServerConfig): Promise<ServerReturn> 
   // Setup Swagger UI based on config
   setupSwaggerUI(config);
 
-  // Collect all ports in an array - first preferred ports, then fallback ports
-  const portsToTry: Array<PortConfig> = [
+  // Collect all ports in an array - first user specified port, then preferred ports, then fallback ports
+  const portsToTry: Array<PortConfig> = [];
+
+  // If user specified a port, try that first
+  if (config?.port) {
+    portsToTry.push({
+      port: config.port,
+      messages: [`Using custom port: ${config.port}`],
+    });
+  }
+
+  // Then try preferred ports and fallbacks
+  portsToTry.push(
     ...preferredPorts,
     // Add fallback ports between 4300-4400
     ...Array.from({ length: 101 }, (_, i) => ({
       port: 4300 + i,
       messages: ["This port is not a coincidence."],
     })),
-  ];
+  );
 
   // Try each port in sequence
   for (const portConfig of portsToTry) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,43 +2,71 @@
  * Basic type definitions for VoltAgent Core
  */
 
+import type { Agent } from "./agent";
+import type { CustomEndpointDefinition } from "./server/custom-endpoints";
+
+import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
+import type { VoltAgentExporter } from "./telemetry/exporter";
+
 /**
- * Retry configuration for error handling
+ * Server configuration options for VoltAgent
  */
-export interface RetryConfig {
+export type ServerOptions = {
   /**
-   * Maximum number of retry attempts
-   * @default 3
+   * Whether to automatically start the server
+   * @default true
    */
-  maxRetries?: number;
+  autoStart?: boolean;
+  /**
+   * Port number for the server
+   * @default 3141 (or next available port)
+   */
+  port?: number;
+  /**
+   * Optional flag to enable/disable Swagger UI
+   * By default:
+   * - In development (NODE_ENV !== 'production'): Swagger UI is enabled
+   * - In production (NODE_ENV === 'production'): Swagger UI is disabled
+   */
+  enableSwaggerUI?: boolean;
+  /**
+   * Optional array of custom endpoint definitions to register with the API server
+   */
+  customEndpoints?: CustomEndpointDefinition[];
+};
 
+/**
+ * VoltAgent constructor options
+ */
+export type VoltAgentOptions = {
+  agents: Record<string, Agent<any>>;
   /**
-   * Initial delay between retries in milliseconds
-   * @default 1000
+   * Server configuration options
    */
-  initialDelay?: number;
-
+  server?: ServerOptions;
   /**
-   * Backoff multiplier for exponential backoff
-   * @default 2
+   * @deprecated Use `server.port` instead
    */
-  backoffMultiplier?: number;
-
+  port?: number;
   /**
-   * Maximum delay between retries in milliseconds
-   * @default 30000
+   * @deprecated Use `server.autoStart` instead
    */
-  maxDelay?: number;
-
+  autoStart?: boolean;
+  checkDependencies?: boolean;
   /**
-   * Callback function called when an error occurs
-   * Return true to retry, false to abort
-   * @param error The error that occurred
-   * @param attempt Current attempt number (1-based)
-   * @param maxRetries Maximum number of retries
-   * @returns Boolean indicating whether to retry
+   * @deprecated Use `server.customEndpoints` instead
    */
-  onError?:
-    | ((error: Error, attempt: number, maxRetries: number) => boolean | Promise<boolean>)
-    | null;
-}
+  customEndpoints?: CustomEndpointDefinition[];
+  /**
+   * @deprecated Use `server.enableSwaggerUI` instead
+   */
+  enableSwaggerUI?: boolean;
+  /**
+   * Optional OpenTelemetry SpanExporter instance or array of instances.
+   * or a VoltAgentExporter instance or array of instances.
+   * If provided, VoltAgent will attempt to initialize and register
+   * a NodeTracerProvider with a BatchSpanProcessor for the given exporter(s).
+   * It's recommended to only provide this in one VoltAgent instance per application process.
+   */
+  telemetryExporter?: (SpanExporter | VoltAgentExporter) | (SpanExporter | VoltAgentExporter)[];
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [X] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [X] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
No option to disable Swagger UI

## What is the new behavior?

By default:
In development (NODE_ENV !== 'production'): Swagger UI is enabled
In production (NODE_ENV === 'production'): Swagger UI is disabled

// Enable Swagger UI even in production
`startServer({ enableSwaggerUI: true });`

// Disable Swagger UI even in development
`startServer({ enableSwaggerUI: false });`

fixes (issue)
#241 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
