### PR TITLE
feat(core): add streamable HTTP transport support for MCP client

### DIFF
--- a/.changeset/streamable-http-transport.md
+++ b/.changeset/streamable-http-transport.md
@@ -1,0 +1,15 @@
+---
+"@voltagent/core": minor
+---
+
+feat(core): add streamable HTTP transport support for MCP
+
+- Upgrade @modelcontextprotocol/sdk from 1.10.1 to 1.12.1
+- Add support for streamable HTTP transport (the newer MCP protocol)
+- Modified existing `type: "http"` to use automatic selection with streamable HTTP → SSE fallback
+- Added two new transport types:
+  - `type: "sse"` - Force SSE transport only (legacy)
+  - `type: "streamable-http"` - Force streamable HTTP only (no fallback)
+- Maintain full backward compatibility - existing `type: "http"` configurations continue to work via automatic fallback
+
+Fixes #246

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "@hono/swagger-ui": "^0.5.1",
     "@hono/zod-openapi": "^0.19.6",
     "@libsql/client": "^0.15.0",
-    "@modelcontextprotocol/sdk": "^1.10.1",
+    "@modelcontextprotocol/sdk": "^1.12.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",

--- a/packages/core/src/mcp/types.ts
+++ b/packages/core/src/mcp/types.ts
@@ -101,10 +101,15 @@ export type MCPClientConfig = {
 /**
  * MCP server configuration options
  */
-export type MCPServerConfig = HTTPServerConfig | StdioServerConfig;
+export type MCPServerConfig =
+  | HTTPServerConfig
+  | SSEServerConfig
+  | StreamableHTTPServerConfig
+  | StdioServerConfig;
 
 /**
- * HTTP-based MCP server configuration via SSE
+ * HTTP-based MCP server configuration with automatic fallback
+ * Tries streamable HTTP first, falls back to SSE if not supported
  */
 export type HTTPServerConfig = {
   /**
@@ -123,9 +128,59 @@ export type HTTPServerConfig = {
   requestInit?: RequestInit;
 
   /**
+   * Event source initialization options (used for SSE fallback)
+   */
+  eventSourceInit?: EventSourceInit;
+};
+
+/**
+ * SSE-based MCP server configuration (explicit SSE transport)
+ */
+export type SSEServerConfig = {
+  /**
+   * Type of server connection
+   */
+  type: "sse";
+
+  /**
+   * URL of the MCP server
+   */
+  url: string;
+
+  /**
+   * Request initialization options
+   */
+  requestInit?: RequestInit;
+
+  /**
    * Event source initialization options
    */
   eventSourceInit?: EventSourceInit;
+};
+
+/**
+ * Streamable HTTP-based MCP server configuration (no fallback)
+ */
+export type StreamableHTTPServerConfig = {
+  /**
+   * Type of server connection
+   */
+  type: "streamable-http";
+
+  /**
+   * URL of the MCP server
+   */
+  url: string;
+
+  /**
+   * Request initialization options
+   */
+  requestInit?: RequestInit;
+
+  /**
+   * Session ID for the connection
+   */
+  sessionId?: string;
 };
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1158,8 +1158,8 @@ importers:
         specifier: ^0.15.0
         version: 0.15.0
       '@modelcontextprotocol/sdk':
-        specifier: ^1.10.1
-        version: 1.10.1
+        specifier: ^1.12.1
+        version: 1.12.1
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -4868,10 +4868,11 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
-  /@modelcontextprotocol/sdk@1.10.1:
-    resolution: {integrity: sha512-xNYdFdkJqEfIaTVP1gPKoEvluACHZsHZegIoICX8DM1o6Qf3G5u2BQJHmgd0n4YgRPqqK/u1ujQvrgAxxSJT9w==}
+  /@modelcontextprotocol/sdk@1.12.1:
+    resolution: {integrity: sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==}
     engines: {node: '>=18'}
     dependencies:
+      ajv: 6.12.6
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
@@ -7278,7 +7279,6 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-    dev: true
 
   /ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
@@ -9390,7 +9390,6 @@ packages:
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
-    dev: true
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
@@ -11367,7 +11366,6 @@ packages:
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-    dev: true
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -14130,7 +14128,6 @@ packages:
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-    dev: true
 
   /pupa@2.1.1:
     resolution: {integrity: sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==}
@@ -16009,7 +16006,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
-    dev: true
 
   /url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}

--- a/website/docs/agents/mcp.md
+++ b/website/docs/agents/mcp.md
@@ -7,6 +7,15 @@ slug: /agents/mcp
 
 The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) provides a **standardized way** for large language models (LLMs) and AI agents to interact with external tools and services. VoltAgent implements MCP client capabilities, enabling your agents to seamlessly access diverse functionalities like filesystem operations, browser automation, database interactions, specific AI models hosted externally, and more, provided they adhere to the MCP specification.
 
+## Transport Types
+
+VoltAgent supports multiple transport types for MCP connections:
+
+- **`streamable-http`**: Modern streamable HTTP transport for efficient bidirectional communication
+- **`http`**: Smart transport that attempts streamable HTTP first and automatically falls back to SSE for compatibility
+- **`sse`**: Server-Sent Events transport for servers that explicitly use SSE
+- **`stdio`**: Standard input/output for local processes and CLI tools
+
 ## Getting Started with MCPConfiguration
 
 The `MCPConfiguration` class is the central point for managing connections to one or more MCP servers. It handles the connection process and makes the tools offered by these servers available to your agents.
@@ -18,9 +27,15 @@ import path from "node:path"; // Used for filesystem path example
 // Create MCP Configuration with multiple types of servers
 const mcpConfig = new MCPConfiguration({
   servers: {
-    // Example 1: HTTP-based server (e.g., external web service or API gateway)
+    // Example 1: Streamable HTTP transport (modern, efficient)
+    github: {
+      type: "streamable-http",
+      url: "https://api.githubcopilot.com/mcp",
+    },
+
+    // Example 2: HTTP with automatic fallback (recommended for compatibility)
     reddit: {
-      type: "http",
+      type: "http", // Tries streamable HTTP first, falls back to SSE if needed
       url: "https://mcp.composio.dev/reddit/your-api-key-here", // URL of the MCP endpoint
       // Optional: Custom headers or options for the initial fetch request
       requestInit: {
@@ -30,7 +45,13 @@ const mcpConfig = new MCPConfiguration({
       eventSourceInit: { withCredentials: true },
     },
 
-    // Example 2: stdio-based server (e.g., a local script or application)
+    // Example 3: SSE transport (explicit Server-Sent Events)
+    linear: {
+      type: "sse",
+      url: "https://mcp.linear.app/sse",
+    },
+
+    // Example 4: stdio-based server (e.g., a local script or application)
     filesystem: {
       type: "stdio", // Connects via standard input/output
       command: "npx", // The command to execute


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [X] Related issue(s) linked
- [X] Tests for the changes have been added
- [X] Docs have been added / updated
- [X] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

VoltAgent's MCP client only supports SSE transport for HTTP connections. The `type: "http"` configuration uses the legacy SSEClientTransport from @modelcontextprotocol/sdk v1.10.1.

## What is the new behavior?

- Upgraded @modelcontextprotocol/sdk to v1.12.1 to access StreamableHTTPClientTransport
- Modified existing `type: "http"` to use automatic transport selection with streamable HTTP → SSE fallback
- Added two new transport types:
  - `type: "sse"` - Force SSE transport only
  - `type: "streamable-http"` - Force streamable HTTP transport only
- Existing HTTP configurations work unchanged via automatic fallback
- Updated documentation with transport types section and examples

fixes [#246](https://github.com/VoltAgent/voltagent/issues/246)

## Notes for reviewers

The implementation maintains full backward compatibility. Existing `type: "http"` configurations will now attempt streamable HTTP first and automatically fall back to SSE if not supported by the server.

@omeraplak I think this is a reasonable approach to avoid a breaking change but I'm happy to adapt the PR if you'd prefer an alternate solution.