### PR TITLE
fix(postgres): fix default value being interpreted as column name

### DIFF
--- a/.changeset/puny-bikes-laugh.md
+++ b/.changeset/puny-bikes-laugh.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/postgres": minor
+---
+
+fix(postgres): Fix default value being interpreted as column name

--- a/.changeset/puny-bikes-laugh.md
+++ b/.changeset/puny-bikes-laugh.md
@@ -1,5 +1,5 @@
 ---
-"@voltagent/postgres": minor
+"@voltagent/postgres": patch
 ---
 
 fix(postgres): Fix default value being interpreted as column name

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -269,7 +269,7 @@ export class PostgresStorage implements Memory {
           end_time TIMESTAMPTZ,
           status TEXT,
           status_message TEXT,
-          level TEXT DEFAULT "INFO",
+          level TEXT DEFAULT 'INFO',
           version TEXT,
           parent_event_id TEXT,
           tags JSONB,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
Currently in the postgres migration method, there is the following line `level TEXT DEFAULT "INFO",`, however "INFO" here is interpreted as a table name, throwing an error

```
[PostgresStorage] Error initializing database: error: cannot use column reference in DEFAULT expression
    at /Users/wouter/Desktop/ADSR/agent/node_modules/pg/lib/client.js:545:17
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  length: 121,
  severity: 'ERROR',
  code: '0A000',
  detail: undefined,
  hint: undefined,
  position: '467',
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'parse_expr.c',
  line: '563',
  routine: 'transformColumnRef'
}
Error: Failed to initialize PostgreSQL database
    at PostgresStorage.<anonymous> (/Users/wouter/Desktop/ADSR/agent/node_modules/@voltagent/postgres/src/index.ts:434:13)
    at Generator.next (<anonymous>)
    at fulfilled (file:///Users/wouter/Desktop/ADSR/agent/node_modules/@voltagent/postgres/dist/index.mjs:25:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
^C/Users/wouter/Desktop/ADSR/agent/node_modules/npm-check-updates/src/lib/programError.ts:21
    throw new Error(message)
```

## What is the new behavior?
The migration method runs successfully.
