### PR TITLE
fix(core): Prevent errors in SubAgents from being passed to the client when using `fullStream`

### DIFF
--- a/.changeset/giant-turkeys-bow.md
+++ b/.changeset/giant-turkeys-bow.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix(core): Default to filtering `error` types from the `fullStream` to allow for error handling to happen properly

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ vitest.config.*.timestamp*
 
 # .ignore
 .ignore
+
+# vscode
+.vscode

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -589,7 +589,9 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
         // Use the utility function to forward events
         await streamEventForwarder(event, {
           forwarder: internalStreamForwarder,
-          filterTypes: [], // Don't filter any events in this context
+          // default to only filtering out error events to prevent errors from being forwarded to the client
+          // from a subagent, so the supervisor agent can handle the error and continue processing
+          filterTypes: ["error"],
           addSubAgentPrefix: true,
         });
       };

--- a/packages/core/src/utils/streams/stream-event-forwarder.ts
+++ b/packages/core/src/utils/streams/stream-event-forwarder.ts
@@ -17,7 +17,7 @@ export async function streamEventForwarder(
   event: StreamEvent,
   options: StreamEventForwarderOptions = {},
 ): Promise<void> {
-  const { forwarder, filterTypes = ["text-delta", "reasoning", "source"] } = options;
+  const { forwarder, filterTypes = ["text-delta", "reasoning", "source", "error"] } = options;
 
   try {
     // Validate event structure


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
