### PR TITLE
fix(postgres): fields being identified as identifiers

### DIFF
--- a/.changeset/silver-cobras-cheer.md
+++ b/.changeset/silver-cobras-cheer.md
@@ -2,4 +2,4 @@
 "@voltagent/postgres": patch
 ---
 
-updated the offending fields with single quotes in order to be interpreted as string literals
+fix: errors related to missing columns "timestamp" and "utc" in Postgres schema - #316 

--- a/.changeset/silver-cobras-cheer.md
+++ b/.changeset/silver-cobras-cheer.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/postgres": patch
+---
+
+updated the offending fields with single quotes in order to be interpreted as string literals

--- a/packages/postgres/src/index.ts
+++ b/packages/postgres/src/index.ts
@@ -1407,7 +1407,7 @@ export class PostgresStorage implements Memory {
         paramCount++;
       }
 
-      setClauses.push(`updated_at = timezone("utc"::text, now())`);
+      setClauses.push(`updated_at = timezone('utc'::text, now())`);
 
       values.push(id);
 
@@ -1628,7 +1628,7 @@ export class PostgresStorage implements Memory {
         SELECT value 
         FROM ${this.options.tablePrefix}_agent_history_steps 
         WHERE history_id = $1 AND agent_id = $2
-        ORDER BY (value->>"timestamp")::timestamp ASC
+        ORDER BY (value->>'timestamp')::timestamp ASC
         `,
         [key, entry._agentId],
       );
@@ -1768,7 +1768,7 @@ export class PostgresStorage implements Memory {
             SELECT value 
             FROM ${this.options.tablePrefix}_agent_history_steps 
             WHERE history_id = $1 AND agent_id = $2
-            ORDER BY (value->>"timestamp")::timestamp ASC
+            ORDER BY (value->>'timestamp')::timestamp ASC
             `,
             [entry.id, agentId],
           );


### PR DESCRIPTION
updated the offending fields with single quotes in order to be interpreted as string literals

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (#316)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
