### PR TITLE
feat(core): allow configuration for supervisor system message

### DIFF
--- a/.changeset/eager-falcons-go.md
+++ b/.changeset/eager-falcons-go.md
@@ -1,0 +1,7 @@
+---
+"@voltagent/core": patch
+---
+
+feat(core): configurable system message for supervisor manager
+
+This feature allows the user to inject different systemMessage for the supervisor than the default one.

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -69,6 +69,7 @@ import type {
   VoltAgentError,
 } from "./types";
 import type { PromptContent } from "../voltops/types";
+import type { SupervisorSystemMessageConfig } from "./subagent/types";
 
 /**
  * Agent class for interacting with AI models
@@ -191,6 +192,7 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
         voice?: Voice;
         markdown?: boolean;
         voltOpsClient?: VoltOpsClient;
+        supervisorSystemMessageConfig?: SupervisorSystemMessageConfig;
       },
   ) {
     this.id = options.id || options.name;
@@ -243,7 +245,11 @@ export class Agent<TProvider extends { llm: LLMProvider<unknown> }> {
     this.toolManager = new ToolManager(staticTools);
 
     // Initialize sub-agent manager
-    this.subAgentManager = new SubAgentManager(this.name, options.subAgents || []);
+    this.subAgentManager = new SubAgentManager(
+      this.name,
+      options.subAgents || [],
+      options.supervisorSystemMessageConfig,
+    );
 
     // Initialize history manager with VoltOpsClient or legacy telemetryExporter support
     let chosenExporter: VoltAgentExporter | undefined;

--- a/packages/core/src/agent/subagent/types.ts
+++ b/packages/core/src/agent/subagent/types.ts
@@ -8,3 +8,8 @@ export type SubAgentStreamPart = Merge<
     subAgentName: string;
   }
 >;
+
+export type SupervisorSystemMessageConfig = {
+  includeMemory: boolean;
+  systemMessage: string;
+};

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -26,6 +26,9 @@ import type {
   PromptContent,
 } from "../voltops/types";
 
+import type { VoltOpsClient } from "../voltops/client";
+import type { SupervisorSystemMessageConfig } from "./subagent/types";
+
 // Re-export for backward compatibility
 export type { DynamicValueOptions, DynamicValue, PromptHelper };
 
@@ -149,6 +152,11 @@ export type AgentOptions = {
    * ✨ Benefits: Observability + prompt management + dynamic prompts from console
    */
   telemetryExporter?: VoltAgentExporter;
+
+  /**
+   * Supervisor system message configuration
+   */
+  supervisorSystemMessageConfig?: SupervisorSystemMessageConfig;
 } & (
   | {
       /**


### PR DESCRIPTION


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Currently, the supervisor manager is created with default behavior for `maxSteps` and default `systemMessage`.

## What is the new behavior?

Users can now configure `maxSteps` and the supervisor `systemMessage` when they create the supervisor agent

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
