### PR TITLE
fix: export PromptContent type to resolve "cannot be named" TypeScript error

### DIFF
--- a/.changeset/fine-queens-train.md
+++ b/.changeset/fine-queens-train.md
@@ -1,0 +1,21 @@
+---
+"@voltagent/core": patch
+---
+
+fix: export PromptContent type to resolve "cannot be named" TypeScript error
+
+Fixed a TypeScript compilation error where users would get "cannot be named" errors when exporting variables that use `InstructionsDynamicValue` type. This occurred because `InstructionsDynamicValue` references `PromptContent` type, but `PromptContent` was not being re-exported from the public API.
+
+**Before:**
+
+```typescript
+export type { DynamicValueOptions, DynamicValue, PromptHelper };
+```
+
+**After:**
+
+```typescript
+export type { DynamicValueOptions, DynamicValue, PromptHelper, PromptContent };
+```
+
+This ensures that all types referenced by public API types are properly exported, preventing TypeScript compilation errors when users export agents or variables that use dynamic instructions.

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -28,7 +28,7 @@ import type {
 } from "../voltops/types";
 
 // Re-export for backward compatibility
-export type { DynamicValueOptions, DynamicValue, PromptHelper };
+export type { DynamicValueOptions, DynamicValue, PromptHelper, PromptContent };
 
 /**
  * Enhanced dynamic value for instructions that supports prompt management


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

- https://discord.com/channels/1361559153780195478/1390900532276629575

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
