### PR TITLE
fix: generate an ID if missing to make sure we don't have an ID of empty string

### DIFF
--- a/.changeset/dirty-papers-glow.md
+++ b/.changeset/dirty-papers-glow.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/vercel-ui": patch
+---
+
+fix: Fixed passing along an ID of empty string

--- a/packages/vercel-ui/src/messages/convert-to-ui.spec.ts
+++ b/packages/vercel-ui/src/messages/convert-to-ui.spec.ts
@@ -235,6 +235,32 @@ describe("convertToUIMessages", () => {
     expect(result[0].createdAt).toEqual(customDate);
   });
 
+  it("should generate ID when message has no id property", () => {
+    const message: Message = {
+      role: "user",
+      content: "Hello!",
+    };
+    const ctx = createFauxContext([message]);
+    const result = convertToUIMessages(ctx);
+    expect(result[0].id).toBeDefined();
+    expect(typeof result[0].id).toBe("string");
+    expect(result[0].id.length).toBeGreaterThan(0);
+  });
+
+  it("should generate ID when message has empty string id", () => {
+    const message: Message = {
+      id: "",
+      role: "user",
+      content: "Hello!",
+    };
+    const ctx = createFauxContext([message]);
+    const result = convertToUIMessages(ctx);
+    expect(result[0].id).toBeDefined();
+    expect(typeof result[0].id).toBe("string");
+    expect(result[0].id.length).toBeGreaterThan(0);
+    expect(result[0].id).not.toBe("");
+  });
+
   it("should handle file part with data property in message content", () => {
     const message: Message = {
       role: "user",

--- a/packages/vercel-ui/src/messages/convert-to-ui.ts
+++ b/packages/vercel-ui/src/messages/convert-to-ui.ts
@@ -230,13 +230,19 @@ function convertToV4UIMessages(
     responseMessages,
   }).map((message) => ({
     ...message,
+    id: getId(message),
   }));
 
   return finalMessages as UIMessage[];
 }
 
+/**
+ * Get the id of a message or generate a new one if it doesn't exist.
+ * @param message - The message to get the id of.
+ * @returns The id of the message.
+ */
 function getId(message: unknown): string {
-  if (hasKey(message, "id") && typeof message.id === "string") {
+  if (hasKey(message, "id") && typeof message.id === "string" && message.id.length > 0) {
     return message.id;
   }
   return generateMessageId();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Currently Volt is passing an empty string (most likely in core). Patching in the vercel-ui to prevent breaking as a unique ID is needed.

## What is the new behavior?

fixes passing an empty string

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
