### PR TITLE
feat(docs-mcp): dynamically discover example files

### DIFF
--- a/.changeset/cold-results-heal.md
+++ b/.changeset/cold-results-heal.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/docs-mcp": minor
+---
+
+feat(docs-mcp): dynamically discover example files
+
+Refactor the getExampleContent function to dynamically discover all relevant files in an example directory instead of relying on a hardcoded list. This introduces a new discoverExampleFiles helper function that recursively scans for .ts files in src, app, and voltagent directories with depth limits, while retaining backward compatibility. This ensures that documentation examples with complex file structures containing voltagent related code are fully captured and displayed.
+
+Resolves #365


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

![image](https://github.com/user-attachments/assets/1fd86ff8-06bb-4da0-9cab-342fa4b2d386)

Currently, **@voltagent/docs-mcp** only includes files that match a specific set of relative paths within each example directory when generating output from the `get_voltagent_example` tool.

**LIST OF FILES INCLUDED IN THE CURRENT BEHAVIOR**

<blockquote><details><summary>CLICK TO EXPAND</summary>

```sh
examples/base/package.json
examples/base/README.md
examples/base/src/index.ts
examples/github-repo-analyzer/package.json
examples/github-repo-analyzer/README.md
examples/github-repo-analyzer/src/index.ts
examples/sdk-trace-example/package.json
examples/sdk-trace-example/README.md
examples/sdk-trace-example/src/index.ts
examples/with-anthropic/package.json
examples/with-anthropic/README.md
examples/with-anthropic/src/index.ts
examples/with-chroma/package.json
examples/with-chroma/README.md
examples/with-chroma/src/index.ts
examples/with-composio-mcp/package.json
examples/with-composio-mcp/README.md
examples/with-composio-mcp/src/index.ts
examples/with-custom-endpoints/package.json
examples/with-custom-endpoints/README.md
examples/with-custom-endpoints/src/index.ts
examples/with-dynamic-parameters/package.json
examples/with-dynamic-parameters/README.md
examples/with-dynamic-parameters/src/index.ts
examples/with-dynamic-prompts/package.json
examples/with-dynamic-prompts/README.md
examples/with-dynamic-prompts/src/index.ts
examples/with-google-ai/package.json
examples/with-google-ai/README.md
examples/with-google-ai/src/index.ts
examples/with-google-drive-mcp/README.md
examples/with-google-vertex-ai/package.json
examples/with-google-vertex-ai/README.md
examples/with-google-vertex-ai/src/index.ts
examples/with-groq-ai/package.json
examples/with-groq-ai/README.md
examples/with-groq-ai/src/index.ts
examples/with-hugging-face-mcp/package.json
examples/with-hugging-face-mcp/README.md
examples/with-hugging-face-mcp/src/index.ts
examples/with-langfuse/package.json
examples/with-langfuse/README.md
examples/with-langfuse/src/index.ts
examples/with-mcp/package.json
examples/with-mcp/README.md
examples/with-mcp/src/index.ts
examples/with-nextjs/package.json
examples/with-nextjs/README.md
examples/with-peaka-mcp/package.json
examples/with-peaka-mcp/README.md
examples/with-peaka-mcp/src/index.ts
examples/with-pinecone/package.json
examples/with-pinecone/README.md
examples/with-pinecone/src/index.ts
examples/with-playwright/package.json
examples/with-playwright/README.md
examples/with-playwright/src/index.ts
examples/with-postgres/package.json
examples/with-postgres/README.md
examples/with-postgres/src/index.ts
examples/with-rag-chatbot/package.json
examples/with-rag-chatbot/README.md
examples/with-rag-chatbot/src/index.ts
examples/with-retrieval/package.json
examples/with-retrieval/README.md
examples/with-retrieval/src/index.ts
examples/with-subagents/package.json
examples/with-subagents/README.md
examples/with-subagents/src/index.ts
examples/with-supabase/package.json
examples/with-supabase/README.md
examples/with-supabase/src/index.ts
examples/with-thinking-tool/package.json
examples/with-thinking-tool/README.md
examples/with-thinking-tool/src/index.ts
examples/with-tools/package.json
examples/with-tools/README.md
examples/with-tools/src/index.ts
examples/with-turso/package.json
examples/with-turso/README.md
examples/with-turso/src/index.ts
examples/with-vercel-ai/package.json
examples/with-vercel-ai/README.md
examples/with-vercel-ai/src/index.ts
examples/with-voice-elevenlabs/package.json
examples/with-voice-elevenlabs/README.md
examples/with-voice-elevenlabs/src/index.ts
examples/with-voice-openai/package.json
examples/with-voice-openai/README.md
examples/with-voice-openai/src/index.ts
examples/with-voice-xsai/package.json
examples/with-voice-xsai/README.md
examples/with-voice-xsai/src/index.ts
examples/with-voltagent-exporter/package.json
examples/with-voltagent-exporter/README.md
examples/with-voltagent-exporter/src/index.ts
examples/with-xsai/package.json
examples/with-xsai/README.md
examples/with-xsai/src/index.ts
examples/with-zapier-mcp/package.json
examples/with-zapier-mcp/README.md
examples/with-zapier-mcp/src/index.ts
```

</details></blockquote>

## What is the new behavior?

![image](https://github.com/user-attachments/assets/ce5d19b8-4f8b-4c2f-97d4-61d9677da457)

Resolves #365

**LIST OF FILES INCLUDED IN THE NEW BEHAVIOR**

<details><summary>CLICK TO EXPAND</summary>

```sh
examples/github-repo-analyzer/src/tools.ts
examples/with-chroma/src/retriever/index.ts
examples/with-langfuse/src/tools/calendar.ts
examples/with-langfuse/src/tools/index.ts
examples/with-langfuse/src/tools/search.ts
examples/with-langfuse/src/tools/weather.ts
examples/with-nextjs/app/api/chat/route.ts
examples/with-nextjs/voltagent/index.ts
examples/with-pinecone/src/retriever/index.ts
examples/with-playwright/src/tools/browserBaseTools.ts
examples/with-playwright/src/tools/index.ts
examples/with-playwright/src/tools/interactionTool.ts
examples/with-playwright/src/tools/navigationTool.ts
examples/with-playwright/src/tools/outputTool.ts
examples/with-playwright/src/tools/playwrightToolHandler.ts
examples/with-playwright/src/tools/responseTool.ts
examples/with-playwright/src/tools/screenshotTool.ts
examples/with-playwright/src/tools/visiblePageTool.ts
examples/with-retrieval/src/data/documents.ts
examples/with-retrieval/src/retriever/index.ts
examples/with-subagents/src/advanced-methods.ts
examples/with-subagents/src/override-system-message.ts
examples/with-tools/src/tools/calendar.ts
examples/with-tools/src/tools/index.ts
examples/with-tools/src/tools/search.ts
examples/with-tools/src/tools/weather.ts
examples/with-voltagent-exporter/src/tools/calendar.ts
examples/with-voltagent-exporter/src/tools/index.ts
examples/with-voltagent-exporter/src/tools/search.ts
examples/with-voltagent-exporter/src/tools/weather.ts
```

</details>

## Notes for reviewers

Like the previous approach, this implementation does not indiscriminately include all files from the `examples` directory in **docs-mcp**. Instead, it uses targeted glob patterns that match the common file structures relevant to **voltagent** implementations, ensuring the AI model receives concise and pertinent context.

The current version includes a total of 102 files from the `examples/` directory. With this update, only 30 additional files are included, bringing

> **NOTE:**
> Files from [examples/with-google-drive-mcp](https://github.com/VoltAgent/voltagent/tree/78ce4eeea1a0897b8694742a54e67c1632e84a93/examples/with-google-drive-mcp) (~15k tokens) are not included in the tool output, nor are `.tsx` or other files unrelated to **voltagent**.  
> No files have been intentionally excluded; rather, only those not explicitly included by the new patterns are omitted. If a file is missing in this version, it was also missing in the previous one. The unique structure of the **with-google-drive-mcp** example was a decisive factor in this approach.