### PR TITLE
refactor(packages)!: move to esm-only

### DIFF
--- a/packages/anthropic-ai/package.json
+++ b/packages/anthropic-ai/package.json
@@ -2,15 +2,14 @@
   "name": "@voltagent/anthropic-ai",
   "version": "0.1.11",
   "description": "Anthropic AI provider for VoltAgent",
+  "type": "module",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/anthropic-ai/package.json
+++ b/packages/anthropic-ai/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },

--- a/packages/anthropic-ai/tsup.config.ts
+++ b/packages/anthropic-ai/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,9 @@
     "agent"
   ],
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "volt": "dist/index.js"
   },

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.58",
   "description": "VoltAgent Core - AI agent framework for JavaScript",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/create-voltagent-app/package.json
+++ b/packages/create-voltagent-app/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.32",
   "description": "Create VoltAgent applications with one command",
   "license": "MIT",
+  "type": "module",
   "main": "dist/index.js",
   "bin": {
     "create-voltagent": "./dist/index.js",

--- a/packages/create-voltagent-app/tsup.config.ts
+++ b/packages/create-voltagent-app/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/docs-mcp/package.json
+++ b/packages/docs-mcp/package.json
@@ -7,12 +7,10 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
     "voltagent-docs-mcp": "dist/index.js"

--- a/packages/docs-mcp/tsup.config.ts
+++ b/packages/docs-mcp/tsup.config.ts
@@ -132,7 +132,7 @@ function copyPackageChangelogs(sourcePkgPath: string, targetPkgPath: string) {
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["esm", "cjs"],
+  format: "esm",
   dts: true,
   sourcemap: true,
   clean: false,

--- a/packages/google-ai/package.json
+++ b/packages/google-ai/package.json
@@ -3,15 +3,14 @@
   "version": "0.4.0",
   "description": "VoltAgent Google AI - Google Generative AI provider integration for VoltAgent",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/google-ai/tsup.config.ts
+++ b/packages/google-ai/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/groq-ai/package.json
+++ b/packages/groq-ai/package.json
@@ -11,7 +11,6 @@
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/groq-ai/package.json
+++ b/packages/groq-ai/package.json
@@ -3,11 +3,11 @@
   "version": "0.1.13",
   "description": "VoltAgent Groq AI - Groq provider integration for VoltAgent",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",

--- a/packages/groq-ai/tsup.config.ts
+++ b/packages/groq-ai/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -3,33 +3,29 @@
   "version": "0.0.4",
   "description": "VoltAgent internal - an internal set of tools for the VoltAgent packages",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/main/index.d.ts",
-      "import": "./dist/main/index.mjs",
-      "require": "./dist/main/index.js"
+      "default": "./dist/main/index.js"
     },
     "./dev": {
       "types": "./dist/dev/index.d.ts",
-      "import": "./dist/dev/index.mjs",
-      "require": "./dist/dev/index.js"
+      "default": "./dist/dev/index.js"
     },
     "./test": {
       "types": "./dist/test/index.d.ts",
-      "import": "./dist/test/index.mjs",
-      "require": "./dist/test/index.js"
+      "default": "./dist/test/index.js"
     },
     "./utils": {
       "types": "./dist/utils/index.d.ts",
-      "import": "./dist/utils/index.mjs",
-      "require": "./dist/utils/index.js"
+      "default": "./dist/utils/index.js"
     },
     "./types": {
       "types": "./dist/types/index.d.ts"
     }
   },
   "main": "dist/main/index.js",
-  "module": "dist/main/index.mjs",
   "types": "dist/main/index.d.ts",
   "files": [
     "dist/**/*",

--- a/packages/internal/tsup.config.ts
+++ b/packages/internal/tsup.config.ts
@@ -1,7 +1,7 @@
 import { type Options as TsupConfigOptions, defineConfig } from "tsup";
 
 const baseConfig = {
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/langfuse-exporter/package.json
+++ b/packages/langfuse-exporter/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.4",
   "description": "OpenTelemetry SpanExporter for sending VoltAgent traces to Langfuse.",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/langfuse-exporter/tsup.config.ts
+++ b/packages/langfuse-exporter/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.7",
   "description": "VoltAgent PostgreSQL - PostgreSQL Memory provider integration for VoltAgent",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/postgres/tsup.config.ts
+++ b/packages/postgres/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.5",
   "description": "VoltAgent SDK - Client SDK for interacting with VoltAgent API",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.12",
   "description": "VoltAgent Supabase - Supabase Memory provider integration for VoltAgent",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/supabase/tsup.config.ts
+++ b/packages/supabase/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/vercel-ai-exporter/package.json
+++ b/packages/vercel-ai-exporter/package.json
@@ -17,15 +17,14 @@
   },
   "license": "MIT",
   "author": "VoltAgent Team",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/vercel-ai-exporter/tsup.config.ts
+++ b/packages/vercel-ai-exporter/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   dts: true,
   splitting: false,
   sourcemap: true,

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.13",
   "description": "VoltAgent Vercel AI - Vercel AI provider integration for VoltAgent",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/vercel-ai/tsup.config.ts
+++ b/packages/vercel-ai/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/vercel-ui/package.json
+++ b/packages/vercel-ui/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.5",
   "description": "VoltAgent Vercel UI - Vercel UI integration for VoltAgent",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/vercel-ui/tsup.config.ts
+++ b/packages/vercel-ui/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -3,15 +3,14 @@
   "version": "0.2.1",
   "description": "VoltAgent Voice - Voice capabilities for AI agents",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/voice/tsup.config.ts
+++ b/packages/voice/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,

--- a/packages/xsai/package.json
+++ b/packages/xsai/package.json
@@ -3,15 +3,14 @@
   "version": "0.2.4",
   "description": "VoltAgent xsAI - xsAI provider integration for VoltAgent",
   "license": "MIT",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/xsai/tsup.config.ts
+++ b/packages/xsai/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
+  format: "esm",
   splitting: false,
   sourcemap: true,
   clean: false,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

CJS is used by default, and ESM export is also available.

## What is the new behavior?

move to ESM-only

## Notes for reviewers

discussed at https://github.com/orgs/VoltAgent/discussions/144#discussioncomment-13455643

read also: https://antfu.me/posts/move-on-to-esm-only
