### PR TITLE
feat: Add `AgentHooks` to the generate methods to execute only on the invocation vs the global `AgentHooks`

### DIFF
--- a/.changeset/silly-plums-stand.md
+++ b/.changeset/silly-plums-stand.md
@@ -1,0 +1,26 @@
+---
+"@voltagent/core": patch
+---
+
+feat(core): Add ability to pass hooks into the generate functions (i.e. streamText) that do not update/mutate the agent hooks
+
+### Usage
+
+```ts
+const agent = new Agent({
+  name: "My Agent with Hooks",
+  instructions: "An assistant demonstrating hooks",
+  llm: provider,
+  model: openai("gpt-4o"),
+  hooks: myAgentHooks,
+});
+
+// both the myAgentHooks and the hooks passed in the generateText method will be called
+await agent.generateText("Hello, how are you?", {
+  hooks: {
+    onEnd: async ({ context }) => {
+      console.log("End of generation but only on this invocation!");
+    },
+  },
+});
+```

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -26,6 +26,7 @@ import type {
   PromptContent,
   PromptHelper,
 } from "../voltops/types";
+import type { AgentHooks } from "./hooks";
 
 // Re-export for backward compatibility
 export type { DynamicValueOptions, DynamicValue, PromptHelper, PromptContent };
@@ -324,6 +325,9 @@ export interface CommonGenerateOptions {
 
   // Optional user-defined context to be passed from a parent operation
   userContext?: UserContext;
+
+  // Optional hooks to be included only during the operation call and not persisted in the agent
+  hooks?: AgentHooks;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
