### PR TITLE
fix: add back `workflow.run` result due to bad state mgmt

### DIFF
--- a/.changeset/shy-kiwis-bet.md
+++ b/.changeset/shy-kiwis-bet.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix(core): Add back the result for a workflow execution, as the result was removed due to change in state management process

--- a/packages/core/src/workflow/chain.spec.ts
+++ b/packages/core/src/workflow/chain.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createWorkflowChain } from "./chain";
+
+describe("workflow.run", () => {
+  it("should return the expected result", async () => {
+    const workflow = createWorkflowChain({
+      id: "test",
+      name: "test",
+      input: z.object({
+        name: z.string(),
+      }),
+      result: z.object({
+        name: z.string(),
+      }),
+    })
+      .andThen({
+        execute: async (input) => {
+          return {
+            name: [input.name, "john"].join(" "),
+          };
+        },
+      })
+      .andThen({
+        execute: async (input) => {
+          return {
+            name: [input.name, "doe"].join(" "),
+          };
+        },
+      });
+
+    const result = await workflow.run({
+      name: "Who is",
+    });
+
+    expect(result).toEqual({
+      executionId: expect.any(String),
+      startAt: expect.any(Date),
+      endAt: expect.any(Date),
+      status: "completed",
+      result: {
+        name: "Who is john doe",
+      },
+    });
+  });
+});

--- a/packages/core/src/workflow/core.spec.ts
+++ b/packages/core/src/workflow/core.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createWorkflow } from "./core";
+import { andThen } from "./steps";
+
+describe("workflow.run", () => {
+  it("should return the expected result", async () => {
+    const workflow = createWorkflow(
+      {
+        id: "test",
+        name: "test",
+        input: z.object({
+          name: z.string(),
+        }),
+        result: z.object({
+          name: z.string(),
+        }),
+      },
+      andThen({
+        execute: async (input) => {
+          return {
+            name: [input.name, "john"].join(" "),
+          };
+        },
+      }),
+      andThen({
+        execute: async (input) => {
+          return {
+            name: [input.name, "doe"].join(" "),
+          };
+        },
+      }),
+    );
+
+    const result = await workflow.run({
+      name: "Who is",
+    });
+
+    expect(result).toEqual({
+      executionId: expect.any(String),
+      startAt: expect.any(Date),
+      endAt: expect.any(Date),
+      status: "completed",
+      result: {
+        name: "Who is john doe",
+      },
+    });
+  });
+});

--- a/packages/core/src/workflow/internal/state.ts
+++ b/packages/core/src/workflow/internal/state.ts
@@ -153,7 +153,7 @@ class WorkflowStateManagerInternal<DATA, RESULT> implements WorkflowStateManager
     assertCanMutate(this.#state);
     this.#state = {
       ...this.#state,
-      ...transformToMutableState(stateUpdate),
+      ...stateUpdate,
     };
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
