### PR TITLE
chore: move async-iterable utils out of core

### DIFF
--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -1,3 +1,4 @@
+import { createAsyncIterableStream } from "@voltagent/internal/utils";
 import type { Mock, Mocked } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
@@ -5,7 +6,6 @@ import { AgentEventEmitter } from "../events";
 import type { Memory, MemoryMessage } from "../memory/types";
 import { AgentRegistry } from "../server/registry";
 import { createTool } from "../tool";
-import { createAsyncIterableStream } from "../utils/async-iterable-stream";
 import { Agent } from "./index";
 import type {
   BaseMessage,
@@ -24,7 +24,6 @@ import type { NewTimelineEvent } from "../events/types";
 import type { BaseRetriever } from "../retriever/retriever";
 import type { VoltAgentExporter } from "../telemetry/exporter";
 import type { Tool, Toolkit } from "../tool";
-import { streamEventForwarder } from "../utils/streams/stream-event-forwarder";
 import { HistoryManager } from "./history";
 import { createHooks } from "./hooks";
 import type { AgentStatus, OperationContext, ToolExecutionContext } from "./types";

--- a/packages/core/src/agent/providers/base/types.ts
+++ b/packages/core/src/agent/providers/base/types.ts
@@ -1,6 +1,6 @@
+import type { AsyncIterableStream } from "@voltagent/internal/utils";
 import type { z } from "zod";
 import type { Tool } from "../../../tool";
-import type { AsyncIterableStream } from "../../../utils/async-iterable-stream";
 import type {
   OperationContext,
   ProviderOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,7 +55,6 @@ export { AgentRegistry } from "./server/registry";
 export { WorkflowRegistry } from "./workflow/registry";
 export { registerCustomEndpoint, registerCustomEndpoints } from "./server/api";
 export * from "./utils/update";
-export { createAsyncIterableStream, type AsyncIterableStream } from "./utils/async-iterable-stream";
 export * from "./voice";
 export {
   CustomEndpointDefinition,
@@ -72,3 +71,6 @@ export type {
 export type { ServerOptions, VoltAgentOptions } from "./types";
 export { VoltAgent } from "./voltagent";
 export { VoltAgent as default } from "./voltagent";
+
+// for backwards compatibility
+export { createAsyncIterableStream, type AsyncIterableStream } from "@voltagent/internal/utils";

--- a/packages/internal/package.spec.ts
+++ b/packages/internal/package.spec.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { PackageJson } from "type-fest";
+import { beforeAll, describe, expect, it } from "vitest";
+
+// TODO: once we move to ESM, we can use this
+// const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+describe("package.json", async () => {
+  let packageJson: PackageJson;
+
+  beforeAll(async () => {
+    packageJson = await readPackageJson();
+  });
+
+  it('should never include "@voltagent/* deps in dependencies to prevent circular deps', () => {
+    const packages = Object.keys(packageJson.dependencies ?? {});
+
+    for (const pkg of packages) {
+      expect(pkg).not.toMatch(/@voltagent\//);
+    }
+  });
+
+  it('should never include "@voltagent/* deps in devDependencies to prevent circular deps', () => {
+    const packages = Object.keys(packageJson.devDependencies ?? {});
+
+    for (const pkg of packages) {
+      expect(pkg).not.toMatch(/@voltagent\//);
+    }
+  });
+});
+
+async function readPackageJson() {
+  const packageJson = JSON.parse(await readFile(path.join(__dirname, "package.json"), "utf-8"));
+  return packageJson;
+}

--- a/packages/internal/src/utils/async-iterable-stream.spec.ts
+++ b/packages/internal/src/utils/async-iterable-stream.spec.ts
@@ -1,9 +1,10 @@
+import { describe, expect, it } from "vitest";
 import {
   convertArrayToReadableStream,
   convertAsyncIterableToArray,
   convertReadableStreamToArray,
-} from "@voltagent/internal/test";
-import { createAsyncIterableStream } from "./index";
+} from "../test";
+import { createAsyncIterableStream } from "./async-iterable-stream";
 
 describe("createAsyncIterableStream()", () => {
   it("should read all chunks from a non-empty stream using async iteration", async () => {

--- a/packages/internal/src/utils/async-iterable-stream.ts
+++ b/packages/internal/src/utils/async-iterable-stream.ts
@@ -1,3 +1,5 @@
+import type { Merge } from "type-fest";
+
 /**
  * An async iterable stream that can be read from.
  * @example
@@ -8,7 +10,7 @@
  * }
  * ```
  */
-export type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+export type AsyncIterableStream<T> = Merge<AsyncIterable<T>, ReadableStream<T>>;
 
 /**
  * Create an async iterable stream from a readable stream.

--- a/packages/internal/src/utils/index.ts
+++ b/packages/internal/src/utils/index.ts
@@ -1,2 +1,4 @@
 export { deepClone, hasKey } from "./objects";
 export { isNil, isObject, isEmptyObject, isFunction, isPlainObject } from "./lang";
+export type { AsyncIterableStream } from "./async-iterable-stream";
+export { createAsyncIterableStream } from "./async-iterable-stream";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1635,7 +1635,7 @@ importers:
         version: 3.2.4(vitest@3.2.4)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@swc/core@1.5.29)(typescript@5.8.3)
+        version: 8.5.0(typescript@5.8.3)
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0
@@ -1644,7 +1644,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.0.3)(@vitest/ui@1.6.1)(jsdom@22.1.0)
+        version: 3.2.4(@types/node@24.0.3)
 
   packages/langfuse-exporter:
     dependencies:
@@ -9809,7 +9809,7 @@ packages:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.0.3)(@vitest/ui@1.6.1)(jsdom@22.1.0)
+      vitest: 3.2.4(@types/node@24.0.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20337,6 +20337,50 @@ packages:
       - yaml
     dev: true
 
+  /tsup@8.5.0(typescript@5.8.3):
+    resolution: {integrity: sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.25.5)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.1
+      esbuild: 0.25.5
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1
+      resolve-from: 5.0.0
+      rollup: 4.43.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tree-kill: 1.2.2
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+    dev: true
+
   /tsx@4.19.3:
     resolution: {integrity: sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==}
     engines: {node: '>=18.0.0'}
@@ -21570,6 +21614,73 @@ packages:
       tinyrainbow: 2.0.0
       vite: 6.3.3(@types/node@20.19.1)
       vite-node: 3.2.4(@types/node@20.19.1)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
+  /vitest@3.2.4(@types/node@24.0.3):
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 5.2.2
+      '@types/node': 24.0.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.3.3)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.3.3(@types/node@24.0.3)
+      vite-node: 3.2.4(@types/node@24.0.3)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Currently the async-iterable util is nested in core but we need to use elsewhere and shouldn't be buried there.

## What is the new behavior?

n/a

## Notes for reviewers

Big question is should it be exported from `@voltagent/core` or should we just change all the providers that use it.

No changelog due to no public change
