### PR TITLE
fix(anthropic-ai): improve generateObject JSON formatting with explicit system prompt

### DIFF
--- a/.changeset/fix-anthropic-json-formatting.md
+++ b/.changeset/fix-anthropic-json-formatting.md
@@ -1,0 +1,7 @@
+---
+"@voltagent/anthropic-ai": patch
+---
+
+fix(anthropic-ai): improve generateObject JSON formatting with explicit system prompt
+
+Enhanced system prompt to prevent AI from wrapping JSON responses in markdown code blocks, fixing JSON parsing errors in generateObject method.

--- a/packages/anthropic-ai/src/index.spec.ts
+++ b/packages/anthropic-ai/src/index.spec.ts
@@ -388,6 +388,66 @@ describe("AnthropicProvider", () => {
       expect(parsedContent).toEqual(testObject);
       expect(result.object).toEqual(testObject);
     });
+
+    it("should handle JSON parsing when response contains markdown formatting", async () => {
+      const testObject = {
+        name: "John Doe",
+        age: 30,
+        hobbies: ["reading", "gaming"],
+      };
+
+      // Mock response that simulates the previous problematic behavior where AI returns JSON wrapped in markdown
+      const markdownWrappedJSON = "```json\n" + JSON.stringify(testObject) + "\n```";
+
+      const mockAnthropicClient = {
+        messages: {
+          create: vi.fn().mockResolvedValue({
+            id: "msg_123456789",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "text", text: markdownWrappedJSON }],
+            model: "claude-3-7-sonnet-20250219",
+            stop_reason: "end_turn",
+            usage: {
+              input_tokens: 10,
+              output_tokens: 20,
+            },
+          }),
+        },
+      };
+
+      (Anthropic as MockedClass<typeof Anthropic>).mockImplementation(() => {
+        return mockAnthropicClient as unknown as Anthropic;
+      });
+
+      const provider = new AnthropicProvider({
+        apiKey: "sk-ant-api03-test-key",
+      });
+      const schema = z.object({
+        name: z.string(),
+        age: z.number(),
+        hobbies: z.array(z.string()),
+      });
+
+      // This should throw an error because the response contains markdown formatting
+      await expect(
+        provider.generateObject({
+          messages: [
+            { role: "system" as const, content: "You are a helpful assistant." },
+            { role: "user" as const, content: "Get user info" },
+          ],
+          model: "claude-3-7-sonnet-20250219",
+          schema,
+        }),
+      ).rejects.toThrow("Error while generating object in Anthropic AI");
+
+      // Verify the system message contains our explicit JSON formatting instructions
+      const createParams = mockAnthropicClient.messages.create.mock.calls[0][0];
+      expect(createParams.system).toContain(
+        "CRITICAL: You MUST return ONLY raw JSON without any markdown formatting",
+      );
+      expect(createParams.system).toContain("Do NOT wrap the JSON in ```json");
+    });
   });
 
   describe("streamObjects", () => {

--- a/packages/anthropic-ai/src/index.spec.ts
+++ b/packages/anthropic-ai/src/index.spec.ts
@@ -286,7 +286,9 @@ describe("AnthropicProvider", () => {
       expect(createParams.messages.length).toBe(1);
       expect(createParams.messages[0].role).toBe("user");
       expect(createParams.system).toContain("You are a helpful assistant.");
-      expect(createParams.system).toContain("You must return the response in valid JSON Format");
+      expect(createParams.system).toContain(
+        "CRITICAL: You MUST return ONLY raw JSON without any markdown formatting",
+      );
     });
 
     it("should format object response with JSON format in onStepFinish for AnthropicProvider", async () => {
@@ -556,7 +558,9 @@ describe("AnthropicProvider", () => {
       expect(createParams.messages.length).toBe(1);
       expect(createParams.messages[0].role).toBe("user");
       expect(createParams.system).toContain("You are a helpful assistant.");
-      expect(createParams.system).toContain("You must return the response in valid JSON Format");
+      expect(createParams.system).toContain(
+        "CRITICAL: You MUST return ONLY raw JSON without any markdown formatting",
+      );
 
       // Process the stream
       const reader = result.objectStream.getReader();
@@ -715,7 +719,7 @@ describe("AnthropicProvider", () => {
       // Verify the mock client was called correctly
       const createCall = mockAnthropicClient.messages.create.mock.calls[0][0];
       expect(createCall.stream).toBe(true);
-      expect(createCall.system).toMatch(/.*JSON Format.*/);
+      expect(createCall.system).toMatch(/.*CRITICAL: You MUST return ONLY raw JSON.*/);
     });
   });
 

--- a/packages/anthropic-ai/src/index.ts
+++ b/packages/anthropic-ai/src/index.ts
@@ -251,7 +251,7 @@ export class AnthropicProvider implements LLMProvider<string> {
   ): Promise<ProviderObjectResponse<any, z.infer<TSchema>>> {
     const { temperature = 0.2, maxTokens = 1024, topP, stopSequences } = options.provider || {};
     const JsonSchema = zodToJsonSchema(options.schema);
-    const systemPrompt = `${getSystemMessage(options.messages)}. Response Schema: ${JSON.stringify(JsonSchema)}. You must return the response in valid JSON Format with proper schema, nothing else `;
+    const systemPrompt = `${getSystemMessage(options.messages)}. Response Schema: ${JSON.stringify(JsonSchema)}. CRITICAL: You MUST return ONLY raw JSON without any markdown formatting, backticks, or code blocks. Do NOT wrap the JSON in \`\`\`json or any other markdown syntax. Do NOT include any explanatory text before or after the JSON. Return ONLY the raw JSON object that conforms to the provided schema.`;
 
     const anthropicMessages = this.getAnthropicMessages(options.messages);
     const model = (options.model || this.model) as string;
@@ -329,7 +329,7 @@ export class AnthropicProvider implements LLMProvider<string> {
     try {
       const anthropicMessages = this.getAnthropicMessages(options.messages);
       const JsonSchema = zodToJsonSchema(options.schema);
-      const systemPrompt = `${getSystemMessage(options.messages)}. Response Schema: ${JSON.stringify(JsonSchema)}. You must return the response in valid JSON Format with proper schema, nothing else `;
+      const systemPrompt = `${getSystemMessage(options.messages)}. Response Schema: ${JSON.stringify(JsonSchema)}. CRITICAL: You MUST return ONLY raw JSON without any markdown formatting, backticks, or code blocks. Do NOT wrap the JSON in \`\`\`json or any other markdown syntax. Do NOT include any explanatory text before or after the JSON. Return ONLY the raw JSON object that conforms to the provided schema.`;
       const { temperature = 0.2, maxTokens = 1024, topP, stopSequences } = options.provider || {};
 
       const response = await this.anthropic.messages.create({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

The generateObject method in the Anthropic AI provider returns invalid JSON responses because the AI model wraps JSON responses in markdown code blocks (e.g., \json ... `). This causes JSON parsing to fail, resulting in errors when trying to parse the response.

Root Cause: The system prompt was not explicit enough about the expected response format, leading the AI to format responses as markdown which included:
  - Wrapping JSON in \json` code blocks
  - Adding explanatory text before or after the JSON
  - Using markdown formatting that broke JSON parsing
  
## What is the new behavior?

Enhanced the system prompt in both generateObject and streamObject methods with explicit instructions that prevent markdown formatting:

```const systemPrompt = `${getSystemMessage(options.messages)}. Response Schema: ${JSON.stringify(JsonSchema)}. CRITICAL: You MUST return ONLY raw JSON without any markdown formatting, backticks, or code blocks. Do NOT wrap the JSON in \`\`\`json or any other markdown syntax. Do NOT include any explanatory text before or after the JSON. Return ONLY the raw JSON object that conforms to the provided schema.`;```
   

## Notes for reviewers
The fix ensures that the Anthropic AI provider consistently returns valid, parseable JSON responses for structured data generation use cases. The new test case specifically validates that the enhanced system prompt prevents the AI from returning markdown-wrapped JSON responses.
<!-- Add any notes/questions you may have for reviewers -->
