### PR TITLE
docs: qdrant end-to-end example

### DIFF
--- a/examples/with-qdrant/.env.example
+++ b/examples/with-qdrant/.env.example
@@ -1,0 +1,11 @@
+# Required: Your OpenAI API key (for embeddings and LLM)
+# Get it from: https://platform.openai.com/api-keys
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Required: Your Qdrant URL
+# docker run -p 6333:6333 qdrant/qdrant
+QDRANT_URL=http://localhost:6333
+
+# Optional: Your Qdrant API key
+# Reference: https://qdrant.tech/documentation/guides/security/
+# QDRANT_API_KEY=

--- a/examples/with-qdrant/README.md
+++ b/examples/with-qdrant/README.md
@@ -1,0 +1,46 @@
+# VoltAgent Qdrant Example
+
+This example demonstrates how to use VoltAgent with [Qdrant](https://qdrant.tech/) as the vector database for retrieval-augmented generation (RAG).
+
+## Features
+
+- Two agents:
+  - **Assistant with Retriever**: Uses semantic search on every interaction.
+  - **Assistant with Tools**: LLM decides when to search autonomously.
+- Tracks sources and references for each answer.
+
+## Usage
+
+1. Install dependencies:
+
+   ```bash
+   $ docker run -p 6333:6333 qdrant/qdrant
+   $ pnpm install
+   ```
+
+2. Set up environment variables in `.env` (see `.env.example` for reference):
+   - `QDRANT_URL`
+   - `OPENAI_API_KEY` (required for embeddings)
+
+3. Start the example:
+
+   ```bash
+   pnpm run dev
+   ```
+
+You can manage your vectors from the Qdrant [dashboard](http://localhost:6333/dashboard).
+
+## Example Questions
+
+Try asking questions like:
+
+- What is VoltAgent?
+- Tell me about vector databases
+- How does Qdrant work?
+- What is RAG?
+- What is TypeScript?
+
+## Notes
+
+- The retriever will automatically populate the Qdrant collection with sample documents if empty.
+- Both agents track which documents were used for answers. Check `userContext.get('references')` for source IDs and scores.

--- a/examples/with-qdrant/package.json
+++ b/examples/with-qdrant/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "voltagent-example-with-qdrant",
+  "private": true,
+  "keywords": [
+    "voltagent",
+    "ai",
+    "agent",
+    "qdrant",
+    "vector-database"
+  ],
+  "license": "MIT",
+  "author": "",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --env-file=.env ./src",
+    "start": "node dist/index.js",
+    "volt": "volt"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^1.3.10",
+    "@qdrant/js-client-rest": "^1.15.0",
+    "@voltagent/cli": "^0.1.9",
+    "@voltagent/core": "^0.1.70",
+    "@voltagent/logger": "^0.1.1",
+    "@voltagent/vercel-ai": "^0.1.16",
+    "openai": "^4.73.1",
+    "zod": "3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.5",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  }
+}

--- a/examples/with-qdrant/src/index.ts
+++ b/examples/with-qdrant/src/index.ts
@@ -1,0 +1,56 @@
+import { openai } from "@ai-sdk/openai";
+import { Agent, VoltAgent } from "@voltagent/core";
+import { createPinoLogger } from "@voltagent/logger";
+import { VercelAIProvider } from "@voltagent/vercel-ai";
+
+import { retriever } from "./retriever/index.js";
+
+// Agent 1: Using retriever directly
+const agentWithRetriever = new Agent({
+  name: "Assistant with Retriever",
+  description:
+    "A helpful assistant that can retrieve information from the Qdrant knowledge base using semantic search to provide better answers. I automatically search for relevant information when needed.",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o-mini"),
+  retriever: retriever,
+});
+
+// Agent 2: Using retriever as tool
+const agentWithTools = new Agent({
+  name: "Assistant with Tools",
+  description:
+    "A helpful assistant that can search the Qdrant knowledge base using tools. The agent will decide when to search for information based on user questions.",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o-mini"),
+  tools: [retriever.tool],
+});
+
+// Create logger
+const logger = createPinoLogger({
+  name: "with-qdrant",
+  level: "info",
+});
+
+new VoltAgent({
+  agents: {
+    agentWithRetriever,
+    agentWithTools,
+  },
+  logger,
+});
+
+console.log("🚀 VoltAgent with Qdrant is running!");
+console.log("📚 Two different agents are ready:");
+console.log("  1️⃣ Assistant with Retriever - Automatic semantic search on every interaction");
+console.log("  2️⃣ Assistant with Tools - LLM decides when to search autonomously");
+console.log("");
+console.log("🔍 Try asking questions like:");
+console.log("  • 'What is VoltAgent?'");
+console.log("  • 'Tell me about vector databases'");
+console.log("  • 'How does Qdrant work?'");
+console.log("  • 'What is RAG?'");
+console.log("");
+console.log("💡 The Tools Agent will automatically search when needed!");
+console.log("");
+console.log("📋 Sources tracking: Both agents track which documents were used");
+console.log("   Check userContext.get('references') to see sources with IDs and scores");

--- a/examples/with-qdrant/src/retriever/index.ts
+++ b/examples/with-qdrant/src/retriever/index.ts
@@ -1,0 +1,211 @@
+import { QdrantClient } from "@qdrant/js-client-rest";
+import {
+  type BaseMessage,
+  BaseRetriever,
+  type RetrieveOptions,
+  createRetrieverTool,
+} from "@voltagent/core";
+
+// Initialize Qdrant client
+const qdrant = new QdrantClient({
+  url: process.env.QDRANT_URL || "http://localhost:6333",
+  apiKey: process.env.QDRANT_API_KEY,
+});
+
+const collectionName = "voltagent-knowledge-base";
+
+// Sample documents to populate the collection
+const sampleRecords = [
+  {
+    id: 1,
+    payload: {
+      text: "VoltAgent is a TypeScript framework for building AI agents with modular components.",
+      category: "frameworks",
+      topic: "voltagent",
+    },
+  },
+  {
+    id: 2,
+    payload: {
+      text: "Qdrant is a vector database built for machine learning applications that require fast, accurate vector search.",
+      category: "databases",
+      topic: "qdrant",
+    },
+  },
+  {
+    id: 3,
+    payload: {
+      text: "Vector databases store high-dimensional vectors and enable semantic search capabilities for AI applications.",
+      category: "databases",
+      topic: "vector-search",
+    },
+  },
+  {
+    id: 4,
+    payload: {
+      text: "Retrieval-Augmented Generation (RAG) combines information retrieval with language generation for better AI responses.",
+      category: "techniques",
+      topic: "rag",
+    },
+  },
+  {
+    id: 5,
+    payload: {
+      text: "TypeScript provides static typing for JavaScript, making code more reliable and maintainable for large applications.",
+      category: "programming",
+      topic: "typescript",
+    },
+  },
+];
+
+// Initialize collection with sample data
+async function initializeCollection() {
+  try {
+    // Check if collection exists
+    let exists = false;
+    try {
+      await qdrant.getCollection(collectionName);
+      exists = true;
+      console.log(`📋 Collection "${collectionName}" already exists`);
+    } catch (error) {
+      console.log(`📋 Creating new collection "${collectionName}"...`);
+    }
+
+    // Create collection if it doesn't exist
+    if (!exists) {
+      await qdrant.createCollection(collectionName, {
+        vectors: { size: 1536, distance: "Cosine" },
+      });
+      console.log(`✅ Collection "${collectionName}" created successfully`);
+    }
+
+    // Check if we need to populate with sample data
+    const stats = await qdrant.count(collectionName);
+    if (stats.count === 0) {
+      console.log("📚 Populating collection with sample documents...");
+      // Generate embeddings for sample documents using OpenAI
+      const OpenAI = await import("openai");
+      const openai = new OpenAI.default({
+        apiKey: process.env.OPENAI_API_KEY!,
+      });
+      const points = [];
+      for (const record of sampleRecords) {
+        try {
+          const embeddingResponse = await openai.embeddings.create({
+            model: "text-embedding-3-small",
+            input: record.payload.text,
+          });
+          points.push({
+            id: record.id,
+            vector: embeddingResponse.data[0].embedding,
+            payload: record.payload,
+          });
+        } catch (error) {
+          console.error(`Error generating embedding for ${record.id}:`, error);
+        }
+      }
+      if (points.length > 0) {
+        await qdrant.upsert(collectionName, { points });
+        console.log(`✅ Successfully upserted ${points.length} documents to collection`);
+      }
+    } else {
+      console.log(`📊 Collection already contains ${stats.count} documents`);
+    }
+  } catch (error) {
+    console.error("Error initializing Qdrant collection:", error);
+  }
+}
+
+// Call initialization
+initializeCollection();
+
+// Retriever function
+async function retrieveDocuments(query: string, topK = 3) {
+  try {
+    // Generate embedding for the query
+    const OpenAI = await import("openai");
+    const openai = new OpenAI.default({
+      apiKey: process.env.OPENAI_API_KEY!,
+    });
+    const embeddingResponse = await openai.embeddings.create({
+      model: "text-embedding-3-small",
+      input: query,
+    });
+    const queryVector = embeddingResponse.data[0].embedding;
+    // Perform search in Qdrant
+    const searchResults = (
+      await qdrant.query(collectionName, {
+        query: queryVector,
+        limit: topK,
+        with_payload: true,
+      })
+    ).points;
+    // Format results
+    return (
+      searchResults.map((match: any) => ({
+        content: match.payload?.text || "",
+        metadata: match.payload || {},
+        score: match.score || 0,
+        id: match.id,
+      })) || []
+    );
+  } catch (error) {
+    console.error("Error retrieving documents from Qdrant:", error);
+    return [];
+  }
+}
+
+/**
+ * Qdrant-based retriever implementation for VoltAgent
+ */
+export class QdrantRetriever extends BaseRetriever {
+  /**
+   * Retrieve documents from Qdrant based on semantic similarity
+   * @param input - The input to use for retrieval (string or BaseMessage[])
+   * @param options - Configuration and context for the retrieval
+   * @returns Promise resolving to a formatted context string
+   */
+  async retrieve(input: string | BaseMessage[], options: RetrieveOptions): Promise<string> {
+    // Convert input to searchable string
+    let searchText = "";
+    if (typeof input === "string") {
+      searchText = input;
+    } else if (Array.isArray(input) && input.length > 0) {
+      const lastMessage = input[input.length - 1];
+      if (Array.isArray(lastMessage.content)) {
+        const textParts = lastMessage.content
+          .filter((part: any) => part.type === "text")
+          .map((part: any) => part.text);
+        searchText = textParts.join(" ");
+      } else {
+        searchText = lastMessage.content as string;
+      }
+    }
+    // Perform semantic search using Qdrant
+    const results = await retrieveDocuments(searchText, 3);
+    // Add references to userContext if available
+    if (options.userContext && results.length > 0) {
+      const references = results.map((doc: any, index: number) => ({
+        id: doc.id,
+        title: doc.metadata.topic || `Document ${index + 1}`,
+        source: "Qdrant Knowledge Base",
+        score: doc.score,
+        category: doc.metadata.category,
+      }));
+      options.userContext.set("references", references);
+    }
+    // Return the concatenated content for the LLM
+    if (results.length === 0) {
+      return "No relevant documents found in the knowledge base.";
+    }
+    return results
+      .map(
+        (doc: any, index: number) =>
+          `Document ${index + 1} (ID: ${doc.id}, Score: ${doc.score.toFixed(4)}, Category: ${doc.metadata.category}):\n${doc.content}`,
+      )
+      .join("\n\n---\n\n");
+  }
+}
+
+// Create retriever instance
+export const retriever = new QdrantRetriever();

--- a/examples/with-qdrant/tsconfig.json
+++ b/examples/with-qdrant/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/website/docs/rag/overview.md
+++ b/website/docs/rag/overview.md
@@ -171,11 +171,23 @@ npm create voltagent-app@latest -- --example with-pinecone
 
 [**→ Full Pinecone Guide**](/docs/rag/pinecone)
 
+### Qdrant Vector Database
+
+Qdrant (read: quadrant) is an open-source vector search engine. It provides a production-ready service to store, search, and manage vectors with additional payload and extended filtering support.
+
+```bash
+npm create voltagent-app@latest -- --example with-qdrant
+```
+
+[**→ Full Qdrant Guide**](/docs/rag/qdrant)
+
 ## Choose Your Path
 
 **I want to try locally** → [Chroma Tutorial](/docs/rag/chroma) (10 mins)
 
 **I want production-ready** → [Pinecone Tutorial](/docs/rag/pinecone) (15 mins)
+
+**I want open-source and production-ready** → [Qdrant Tutorial](/docs/rag/qdrant) (10 mins)
 
 **I want to build custom** → [Build Your Own Retriever](/docs/rag/custom-retrievers)
 

--- a/website/docs/rag/qdrant.md
+++ b/website/docs/rag/qdrant.md
@@ -1,0 +1,381 @@
+---
+title: Qdrant Integration
+slug: /rag/qdrant
+---
+
+# VoltAgent with Qdrant
+
+[Qdrant](https://qdrant.tech/) is an open-source vector database designed for scalable, high-performance semantic search and retrieval. It supports REST and gRPC APIs, advanced filtering, and is easy to self-host or use as a managed service.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- Node.js 18+ installed
+- Qdrant instance (local or cloud)
+- Qdrant API key (if using cloud)
+- OpenAI API key (for embeddings)
+
+## Installation
+
+Create a new VoltAgent project with Qdrant integration:
+
+```bash
+npm create voltagent-app@latest -- --example with-qdrant
+cd with-qdrant
+```
+
+This creates a complete VoltAgent + Qdrant setup with sample data and two different agent configurations.
+
+Install the dependencies:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm install
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm install
+    ```
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+    ```bash
+    yarn install
+    ```
+  </TabItem>
+</Tabs>
+
+## Environment Setup
+
+Create a `.env` file with your configuration:
+
+```env
+# Qdrant URL
+# docker run -p 6333:6333 qdrant/qdrant
+QDRANT_URL=http://localhost:6333
+
+# Qdrant API key (Optional)
+QDRANT_API_KEY=your-qdrant-api-key-here
+
+# OpenAI API key for embeddings and LLM
+OPENAI_API_KEY=your-openai-api-key-here
+```
+
+## Run Your Application
+
+Start your VoltAgent application:
+
+<Tabs>
+  <TabItem value="npm" label="npm" default>
+    ```bash
+    npm run dev
+    ```
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+    ```bash
+    pnpm dev
+    ```
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+    ```bash
+    yarn dev
+    ```
+  </TabItem>
+</Tabs>
+
+You'll see:
+
+```
+🚀 VoltAgent with Qdrant is running!
+📚 Two different agents are ready:
+  1️⃣ Assistant with Retriever - Automatic semantic search on every interaction
+  2️⃣ Assistant with Tools - LLM decides when to search autonomously
+
+🔍 Try asking questions like:
+  • 'What is VoltAgent?'
+  • 'Tell me about vector databases'
+  • 'How does Qdrant work?'
+  • 'What is RAG?'
+
+💡 The Tools Agent will automatically search when needed!
+
+📋 Sources tracking: Both agents track which documents were used
+   Check userContext.get('references') to see sources with IDs and scores
+📋 Creating new collection "voltagent-knowledge-base"...
+
+
+══════════════════════════════════════════════════
+  VOLTAGENT SERVER STARTED SUCCESSFULLY
+══════════════════════════════════════════════════
+  ✓ HTTP Server:  http://localhost:3141
+  ✓ Swagger UI:   http://localhost:3141/ui
+
+  Test your agents with VoltOps Console: https://console.voltagent.dev
+══════════════════════════════════════════════════
+✅ Collection "voltagent-knowledge-base" created successfully
+📚 Populating collection with sample documents...
+✅ Successfully upserted 5 documents to collection
+```
+
+## Interact with Your Agents
+
+Your agents are now running! To interact with them:
+
+1. **Open the Console:** Click the [`https://console.voltagent.dev`](https://console.voltagent.dev) link in your terminal output (or copy-paste it into your browser).
+2. **Find Your Agents:** On the VoltOps LLM Observability Platform page, you should see both agents listed:
+   - "Assistant with Retriever"
+   - "Assistant with Tools"
+3. **Open Agent Details:** Click on either agent's name.
+4. **Start Chatting:** On the agent detail page, click the chat icon in the bottom right corner to open the chat window.
+5. **Test RAG Capabilities:** Try questions like:
+   - "What is VoltAgent?"
+   - "Tell me about Qdrant"
+   - "How does vector search work?"
+   - "What is RAG?"
+
+You should receive responses from your AI agents that include relevant information from your Qdrant knowledge base, along with source references showing which documents were used to generate the response.
+
+## How It Works
+
+The following sections explain how this example is built and how you can customize it.
+
+### Create the Qdrant Retriever
+
+Create `src/retriever/index.ts`:
+
+```typescript
+import { BaseRetriever, type BaseMessage, type RetrieveOptions } from "@voltagent/core";
+import { QdrantClient } from "@qdrant/js-client-rest";
+
+// Initialize Qdrant client
+const qdrant = new QdrantClient({
+  url: process.env.QDRANT_URL || "http://localhost:6333",
+  apiKey: process.env.QDRANT_API_KEY,
+});
+
+const collectionName = "voltagent-knowledge-base";
+```
+
+**Key Components Explained**:
+
+- **Qdrant Client**: Connects to Qdrant's REST API
+- **Collection**: A named container for your vectors in Qdrant
+- **Open Source & Cloud**: Use locally or as a managed service
+
+### Initialize Collection and Sample Data
+
+The example automatically creates and populates your Qdrant collection:
+
+```typescript
+async function initializeCollection() {
+  try {
+    // Check if collection exists
+    let exists = false;
+    try {
+      await qdrant.getCollection(collectionName);
+      exists = true;
+      console.log(`📋 Collection "${collectionName}" already exists`);
+    } catch (error) {
+      console.log(`📋 Creating new collection "${collectionName}"...`);
+    }
+
+    // Create collection if it doesn't exist
+    if (!exists) {
+      await qdrant.createCollection(collectionName, {
+        vectors: { size: 1536, distance: "Cosine" },
+      });
+      console.log(`✅ Collection "${collectionName}" created successfully`);
+    }
+
+    // Check if we need to populate with sample data
+    const stats = await qdrant.count(collectionName);
+    if (stats.count === 0) {
+      console.log("📚 Populating collection with sample documents...");
+      // Generate embeddings for sample documents using OpenAI
+      const OpenAI = await import("openai");
+      const openai = new OpenAI.default({
+        apiKey: process.env.OPENAI_API_KEY!,
+      });
+      const points = [];
+      for (const record of sampleRecords) {
+        try {
+          const embeddingResponse = await openai.embeddings.create({
+            model: "text-embedding-3-small",
+            input: record.payload.text,
+          });
+          points.push({
+            id: record.id,
+            vector: embeddingResponse.data[0].embedding,
+            payload: record.payload,
+          });
+        } catch (error) {
+          console.error(`Error generating embedding for ${record.id}:`, error);
+        }
+      }
+      if (points.length > 0) {
+        await qdrant.upsert(collectionName, { points });
+        console.log(`✅ Successfully upserted ${points.length} documents to collection`);
+      }
+    } else {
+      console.log(`📊 Collection already contains ${stats.count} documents`);
+    }
+  } catch (error) {
+    console.error("Error initializing Qdrant collection:", error);
+  }
+}
+```
+
+**What This Does**:
+
+- Creates a Qdrant collection with cosine similarity
+- Generates embeddings using OpenAI's API
+- Adds the embeddings and payloads to Qdrant
+
+### Implement the Retriever Class
+
+Create the main retriever class:
+
+```typescript
+// Retriever function
+async function retrieveDocuments(query: string, topK = 3) {
+  try {
+    // Generate embedding for the query
+    const OpenAI = await import("openai");
+    const openai = new OpenAI.default({
+      apiKey: process.env.OPENAI_API_KEY!,
+    });
+    const embeddingResponse = await openai.embeddings.create({
+      model: "text-embedding-3-small",
+      input: query,
+    });
+    const queryVector = embeddingResponse.data[0].embedding;
+    // Perform search in Qdrant
+    const searchResults = (
+      await qdrant.query(collectionName, {
+        query: queryVector,
+        limit: topK,
+        with_payload: true,
+      })
+    ).points;
+    // Format results
+    return (
+      searchResults.map((match: any) => ({
+        content: match.payload?.text || "",
+        metadata: match.payload || {},
+        score: match.score || 0,
+        id: match.id,
+      })) || []
+    );
+  } catch (error) {
+    console.error("Error retrieving documents from Qdrant:", error);
+    return [];
+  }
+}
+
+/**
+ * Qdrant-based retriever implementation for VoltAgent
+ */
+export class QdrantRetriever extends BaseRetriever {
+  /**
+   * Retrieve documents from Qdrant based on semantic similarity
+   * @param input - The input to use for retrieval (string or BaseMessage[])
+   * @param options - Configuration and context for the retrieval
+   * @returns Promise resolving to a formatted context string
+   */
+  async retrieve(input: string | BaseMessage[], options: RetrieveOptions): Promise<string> {
+    // Convert input to searchable string
+    let searchText = "";
+    if (typeof input === "string") {
+      searchText = input;
+    } else if (Array.isArray(input) && input.length > 0) {
+      const lastMessage = input[input.length - 1];
+      if (Array.isArray(lastMessage.content)) {
+        const textParts = lastMessage.content
+          .filter((part: any) => part.type === "text")
+          .map((part: any) => part.text);
+        searchText = textParts.join(" ");
+      } else {
+        searchText = lastMessage.content as string;
+      }
+    }
+    // Perform semantic search using Qdrant
+    const results = await retrieveDocuments(searchText, 3);
+    // Add references to userContext if available
+    if (options.userContext && results.length > 0) {
+      const references = results.map((doc: any, index: number) => ({
+        id: doc.id,
+        title: doc.metadata.topic || `Document ${index + 1}`,
+        source: "Qdrant Knowledge Base",
+        score: doc.score,
+        category: doc.metadata.category,
+      }));
+      options.userContext.set("references", references);
+    }
+    // Return the concatenated content for the LLM
+    if (results.length === 0) {
+      return "No relevant documents found in the knowledge base.";
+    }
+    return results
+      .map(
+        (doc: any, index: number) =>
+          `Document ${index + 1} (ID: ${doc.id}, Score: ${doc.score.toFixed(4)}, Category: ${doc.metadata.category}):\n${doc.content}`
+      )
+      .join("\n\n---\n\n");
+  }
+}
+
+// Create retriever instance
+export const retriever = new QdrantRetriever();
+```
+
+### Create Your Agents
+
+Now create agents using different retrieval patterns in `src/index.ts`:
+
+```typescript
+import { openai } from "@ai-sdk/openai";
+import { Agent, VoltAgent } from "@voltagent/core";
+import { createPinoLogger } from "@voltagent/logger";
+import { VercelAIProvider } from "@voltagent/vercel-ai";
+
+import { retriever } from "./retriever/index.js";
+
+// Agent 1: Using retriever directly
+const agentWithRetriever = new Agent({
+  name: "Assistant with Retriever",
+  description:
+    "A helpful assistant that can retrieve information from the Qdrant knowledge base using semantic search to provide better answers. I automatically search for relevant information when needed.",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o-mini"),
+  retriever: retriever,
+});
+
+// Agent 2: Using retriever as tool
+const agentWithTools = new Agent({
+  name: "Assistant with Tools",
+  description:
+    "A helpful assistant that can search the Qdrant knowledge base using tools. The agent will decide when to search for information based on user questions.",
+  llm: new VercelAIProvider(),
+  model: openai("gpt-4o-mini"),
+  tools: [retriever.tool],
+});
+
+// Create logger
+const logger = createPinoLogger({
+  name: "with-qdrant",
+  level: "info",
+});
+
+new VoltAgent({
+  agents: {
+    agentWithRetriever,
+    agentWithTools,
+  },
+  logger,
+});
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -88,6 +88,7 @@ const sidebars: SidebarsConfig = {
         "rag/custom-retrievers",
         "rag/chroma",
         "rag/pinecone",
+        "rag/qdrant",
       ],
     },
     {


### PR DESCRIPTION
## PR Checklist

This PR adds a new RAG example with [Qdrant](https://qdrant.tech) as the vector database.

Associated docs have been added and I've tested the example end-to-end.

## Changes

- [x] Docs have been added / updated

# NOTE

I have not committed the `pnpm-lock.yaml` file yet to keep a sane diff.

