### PR TITLE
fix: Skipping inferred types `andRace` and `andAll` in `createWorkflow`

### DIFF
--- a/.changeset/new-mammals-divide.md
+++ b/.changeset/new-mammals-divide.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix: Fixed types in andAll and andRace where the inferred result from the steps was NOT being passed along

--- a/packages/core/src/workflow/core.spec.ts
+++ b/packages/core/src/workflow/core.spec.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
-import { createWorkflow } from "./core";
-import { andThen } from "./steps";
 import { createTestLibSQLStorage } from "../test-utils/libsql-test-helpers";
+import { createWorkflow } from "./core";
 import { WorkflowRegistry } from "./registry";
+import { andAll, andThen } from "./steps";
 
 describe.sequential("workflow.run", () => {
   beforeEach(() => {
@@ -35,6 +35,21 @@ describe.sequential("workflow.run", () => {
             name: [data.name, "john"].join(" "),
           };
         },
+      }),
+      andAll({
+        id: "step-2-add-surname",
+        name: "Add surname",
+        steps: [
+          andThen({
+            id: "step-2-add-surname",
+            name: "Add surname",
+            execute: async ({ data }) => {
+              return {
+                name: [data.name, "doe"].join(" "),
+              };
+            },
+          }),
+        ],
       }),
       andThen({
         id: "step-2-add-surname",

--- a/packages/core/src/workflow/core.spec.ts
+++ b/packages/core/src/workflow/core.spec.ts
@@ -36,21 +36,6 @@ describe.sequential("workflow.run", () => {
           };
         },
       }),
-      andAll({
-        id: "step-2-add-surname",
-        name: "Add surname",
-        steps: [
-          andThen({
-            id: "step-2-add-surname",
-            name: "Add surname",
-            execute: async ({ data }) => {
-              return {
-                name: [data.name, "doe"].join(" "),
-              };
-            },
-          }),
-        ],
-      }),
       andThen({
         id: "step-2-add-surname",
         name: "Add surname",

--- a/packages/core/src/workflow/steps/and-all.ts
+++ b/packages/core/src/workflow/steps/and-all.ts
@@ -1,16 +1,16 @@
-import type { InternalAnyWorkflowStep, InternalInferWorkflowStepsResult } from "../internal/types";
-import { defaultStepConfig } from "../internal/utils";
+import { getGlobalLogger } from "../../logger";
 import {
+  createParallelSubStepContext,
+  createStepContext,
+  createWorkflowStepErrorEvent,
   createWorkflowStepStartEvent,
   createWorkflowStepSuccessEvent,
-  createWorkflowStepErrorEvent,
   publishWorkflowEvent,
-  createStepContext,
-  createParallelSubStepContext,
 } from "../event-utils";
+import type { InternalAnyWorkflowStep, InternalInferWorkflowStepsResult } from "../internal/types";
+import { defaultStepConfig } from "../internal/utils";
 import { matchStep } from "./helpers";
 import type { WorkflowStepParallelAll, WorkflowStepParallelAllConfig } from "./types";
-import { getGlobalLogger } from "../../logger";
 
 /**
  * Creates a parallel execution step that runs multiple steps simultaneously and waits for all to complete
@@ -60,8 +60,9 @@ export function andAll<
   DATA,
   RESULT,
   STEPS extends ReadonlyArray<InternalAnyWorkflowStep<INPUT, DATA, RESULT>>,
-  INFERRED_RESULT = InternalInferWorkflowStepsResult<STEPS>,
 >({ steps, ...config }: WorkflowStepParallelAllConfig<STEPS>) {
+  type INFERRED_RESULT = InternalInferWorkflowStepsResult<STEPS>;
+
   return {
     ...defaultStepConfig(config),
     type: "parallel-all",

--- a/packages/core/src/workflow/steps/and-race.ts
+++ b/packages/core/src/workflow/steps/and-race.ts
@@ -1,20 +1,20 @@
+import { getGlobalLogger } from "../../logger";
+import {
+  createParallelSubStepContext,
+  createStepContext,
+  createWorkflowStepErrorEvent,
+  createWorkflowStepStartEvent,
+  createWorkflowStepSuccessEvent,
+  publishWorkflowEvent,
+} from "../event-utils";
 import type {
   InternalAnyWorkflowStep,
   InternalInferWorkflowStepsResult,
   InternalWorkflowStepConfig,
 } from "../internal/types";
 import { defaultStepConfig } from "../internal/utils";
-import {
-  createWorkflowStepStartEvent,
-  createWorkflowStepSuccessEvent,
-  createWorkflowStepErrorEvent,
-  publishWorkflowEvent,
-  createStepContext,
-  createParallelSubStepContext,
-} from "../event-utils";
 import { matchStep } from "./helpers";
 import type { WorkflowStepParallelRace } from "./types";
-import { getGlobalLogger } from "../../logger";
 
 /**
  * Creates a race execution step that runs multiple steps simultaneously and returns the first completed result
@@ -66,13 +66,14 @@ export function andRace<
   DATA,
   RESULT,
   STEPS extends ReadonlyArray<InternalAnyWorkflowStep<INPUT, DATA, RESULT>>,
-  INFERRED_RESULT = InternalInferWorkflowStepsResult<STEPS>[number],
 >({
   steps,
   ...config
 }: InternalWorkflowStepConfig<{
   steps: STEPS;
 }>) {
+  type INFERRED_RESULT = InternalInferWorkflowStepsResult<STEPS>[number];
+
   return {
     ...defaultStepConfig(config),
     type: "parallel-race",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

When you use `andAll` or `andRace` in `createWorkflows` it bypasses the inferred results and just uses the passed in `INPUT` type.

## What is the new behavior?

fixes: it uses the correct inferred type.

BONUS: We can now have a proper tuple (feature less fix) if you use the `as const` keyword in your steps:

```ts
andAll({
  ...config
  steps: [...] as const // will show as tuple
})
```

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
