### PR TITLE
fix: Switch logger to use `globalThis` instead of package var

### DIFF
--- a/packages/logger/src/base.ts
+++ b/packages/logger/src/base.ts
@@ -2,24 +2,29 @@ import { PinoLoggerProvider } from "./providers";
 import type { LoggerProvider, LoggerWithProvider } from "./providers";
 import type { LogBuffer, LoggerOptions } from "./types";
 
-// Global logger provider instance
-let globalLoggerProvider: LoggerProvider | null = null;
-
 /**
  * Get or create the global logger provider
  */
 export function getGlobalLoggerProvider(): LoggerProvider {
+  // @ts-expect-error - globalThis is not typed
+  const globalLoggerProvider = globalThis.___voltagent_logger_provider as
+    | LoggerProvider
+    | undefined;
+
   if (!globalLoggerProvider) {
-    globalLoggerProvider = new PinoLoggerProvider();
+    // @ts-expect-error - globalThis is not typed
+    globalThis.___voltagent_logger_provider = new PinoLoggerProvider();
   }
-  return globalLoggerProvider;
+
+  return globalLoggerProvider as LoggerProvider;
 }
 
 /**
  * Set a custom logger provider
  */
 export function setGlobalLoggerProvider(provider: LoggerProvider): void {
-  globalLoggerProvider = provider;
+  // @ts-expect-error - globalThis is not typed
+  globalThis.___voltagent_logger_provider = provider;
 }
 
 /**
@@ -48,8 +53,10 @@ export function createPinoLogger(
     undefined, // No longer using external buffer
     options?.pinoOptions,
   );
+
+  const globalLoggerProvider = getGlobalLoggerProvider();
   if (!globalLoggerProvider) {
-    globalLoggerProvider = provider;
+    setGlobalLoggerProvider(provider);
   }
   return provider.createLogger(options);
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
