### PR TITLE
chore(docs): update next.js example to match template

### DIFF
--- a/website/docs/integrations/nextjs.md
+++ b/website/docs/integrations/nextjs.md
@@ -33,7 +33,7 @@ Follow the prompts, selecting TypeScript and App Router.
 Install the necessary VoltAgent packages and dependencies:
 
 ```bash
-npm install @voltagent/core @ai-sdk/openai @ai-sdk/react ai zod@^3.25.0
+npm install @voltagent/core @ai-sdk/openai @ai-sdk/react ai zod@^3.25.76
 ```
 
 - `@voltagent/core`: The core VoltAgent library.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Next.js docs at: https://voltagent.dev/docs/integrations/nextjs/ don't match the example scaffold for the command listed on the docs:
`npm create voltagent-app@latest -- --example with-nextjs`

Code located here: https://github.com/VoltAgent/voltagent/tree/main/examples/with-nextjs

## What is the new behavior?

Updated docs to reflect better initialization of the agent in a Next.js environment.

fixes #592 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
