### PR TITLE
feat(core): enable workflow to stream UIMessages to conform with useChat

### DIFF
--- a/.changeset/tangy-houses-repeat.md
+++ b/.changeset/tangy-houses-repeat.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/core": patch
+---
+
+Workflows can be streamed directly into `useChat` by converting raw events
+(`workflow-start`, `workflow-complete`, etc.) into `data-*` UI messages via
+`toUIMessageStreamResponse`.
+
+Related to #589

--- a/packages/core/src/workflow/core.ts
+++ b/packages/core/src/workflow/core.ts
@@ -11,7 +11,11 @@ import { AgentRegistry } from "../registries/agent-registry";
 import type { WorkflowExecutionContext } from "./context";
 import { createWorkflowStateManager } from "./internal/state";
 import type { InternalBaseWorkflowInputSchema } from "./internal/types";
-import { convertWorkflowStateToParam, createStepExecutionContext } from "./internal/utils";
+import {
+  convertWorkflowStateToParam,
+  createStepExecutionContext,
+  eventToUIMessageStreamResponse,
+} from "./internal/utils";
 import { WorkflowTraceContext } from "./open-telemetry/trace-context";
 import { WorkflowRegistry } from "./registry";
 import type { WorkflowStep } from "./steps";
@@ -1765,6 +1769,8 @@ export function createWorkflow<
         cancellation: resultPromise.then((r) => r.cancellation),
         error: resultPromise.then((r) => r.error),
         usage: resultPromise.then((r) => r.usage),
+        toUIMessageStreamResponse: eventToUIMessageStreamResponse(streamController),
+
         resume: async (input: z.infer<RESUME_SCHEMA>, opts?: { stepId?: string }) => {
           const execResult = await resultPromise;
           if (execResult.status !== "suspended") {
@@ -1869,6 +1875,7 @@ export function createWorkflow<
               suspendController.cancel(reason);
             },
             abort: () => streamController.abort(),
+            toUIMessageStreamResponse: eventToUIMessageStreamResponse(streamController),
             // Continue using the same stream iterator
             [Symbol.asyncIterator]: () => streamController.getStream(),
           };

--- a/packages/core/src/workflow/internal/utils.spec.ts
+++ b/packages/core/src/workflow/internal/utils.spec.ts
@@ -1,0 +1,104 @@
+import { createUIMessageStream } from "ai";
+import { createUIMessageStreamResponse } from "ai";
+import { describe, expect, it } from "vitest";
+import type { WorkflowStreamController } from "../stream";
+import type { WorkflowStreamEvent } from "../types";
+import { convertWorkflowStreamEventToUIMessage, eventToUIMessageStreamResponse } from "./utils";
+
+vi.mock("ai", async () => {
+  // Import the original module
+  const actual = await vi.importActual<object>("ai");
+
+  return {
+    ...actual,
+    createUIMessageStream: vi.fn().mockReturnValue("mocked-ui-stream"),
+    createUIMessageStreamResponse: vi.fn().mockReturnValue("mocked-response"),
+  };
+});
+
+function baseEvent(overrides: Partial<WorkflowStreamEvent>): WorkflowStreamEvent {
+  return {
+    type: "workflow-start",
+    executionId: "exec-1",
+    from: "workflow",
+    status: "running",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  } as WorkflowStreamEvent;
+}
+
+describe("convertWorkflowStreamEventToUIMessages", () => {
+  it("converts workflow-start to data-workflow-start", () => {
+    const event = baseEvent({
+      type: "workflow-start",
+      input: { foo: "bar" },
+    });
+
+    const chunk = convertWorkflowStreamEventToUIMessage(event);
+
+    expect(chunk).toEqual({
+      type: "data-workflow-start",
+      data: expect.objectContaining({
+        executionId: "exec-1",
+        status: "running",
+        from: "workflow",
+        input: { foo: "bar" },
+      }),
+    });
+  });
+
+  it("converts step-start to data-step-start", () => {
+    const event = baseEvent({
+      type: "step-start",
+      from: "step-1",
+      input: { a: 1 },
+      stepType: "func",
+      stepIndex: 0,
+      metadata: { k: "v" },
+    });
+
+    const chunk = convertWorkflowStreamEventToUIMessage(event);
+
+    expect(chunk).toEqual({
+      type: "data-step-start",
+      data: expect.objectContaining({
+        executionId: "exec-1",
+        status: "running",
+        from: "step-1",
+        input: { a: 1 },
+        stepType: "func",
+        stepIndex: 0,
+        metadata: { k: "v" },
+      }),
+    });
+  });
+
+  describe("eventToUIMessageStreamResponse", () => {
+    it("should build a UI message stream response", async () => {
+      // Mock WorkflowStreamController
+      const mockStreamController = {
+        getStream: vi.fn(async function* () {
+          yield { type: "workflow-start", timestamp: 123 };
+          yield { type: "workflow-complete", timestamp: 456 };
+        }),
+      } as unknown as WorkflowStreamController;
+
+      const resultFunction = eventToUIMessageStreamResponse(mockStreamController);
+      const result = resultFunction({ customOption: true });
+
+      expect(createUIMessageStream).toHaveBeenCalledTimes(1);
+      expect(createUIMessageStream).toHaveBeenCalledWith({
+        execute: expect.any(Function),
+        onError: expect.any(Function),
+      });
+
+      expect(createUIMessageStreamResponse).toHaveBeenCalledTimes(1);
+      expect(createUIMessageStreamResponse).toHaveBeenCalledWith({
+        stream: "mocked-ui-stream",
+        customOption: true,
+      });
+
+      expect(result).toBe("mocked-response");
+    });
+  });
+});

--- a/packages/core/src/workflow/stream.ts
+++ b/packages/core/src/workflow/stream.ts
@@ -159,6 +159,8 @@ export class WorkflowStreamWriterImpl implements WorkflowStreamWriter {
         continue;
       }
 
+      const type: WorkflowStreamEvent["type"] =
+        `${prefix}${part.type}` as WorkflowStreamEvent["type"];
       // Convert StreamPart to WorkflowStreamEvent with proper field mapping
       const metadata: Record<string, DangerouslyAllowAny> = {
         originalType: part.type,
@@ -319,7 +321,7 @@ export class WorkflowStreamWriterImpl implements WorkflowStreamWriter {
       }
 
       this.write({
-        type: `${prefix}${part.type}`,
+        type,
         from: options?.agentId || part.subAgentId || part.subAgentName || this.stepName,
         input,
         output,

--- a/packages/core/src/workflow/types.ts
+++ b/packages/core/src/workflow/types.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "@voltagent/internal";
 import type { DangerouslyAllowAny } from "@voltagent/internal/types";
-import type { UIMessage } from "ai";
+import type { StreamTextResult, UIMessage } from "ai";
 import type * as TF from "type-fest";
 import type { z } from "zod";
 import type { BaseMessage } from "../agent/providers";
@@ -173,6 +173,7 @@ export interface WorkflowStreamResult<
   cancellation: Promise<WorkflowCancellationMetadata | undefined>;
   error: Promise<unknown | undefined>;
   usage: Promise<UsageInfo>;
+  toUIMessageStreamResponse: StreamTextResult<any, any>["toUIMessageStreamResponse"];
   /**
    * Resume a suspended workflow execution
    * @param input - Optional new input data for resuming (validated against resumeSchema if provided)
@@ -569,7 +570,14 @@ export interface WorkflowStreamEvent {
   /**
    * Type of the event (e.g., "step-start", "step-complete", "custom", "agent-stream")
    */
-  type: string;
+  type:
+    | "workflow-start"
+    | "workflow-suspended"
+    | "workflow-complete"
+    | "workflow-cancelled"
+    | "workflow-error"
+    | "step-start"
+    | "step-complete";
   /**
    * Unique execution ID for this workflow run
    */

--- a/website/docs/workflows/streaming.md
+++ b/website/docs/workflows/streaming.md
@@ -31,6 +31,7 @@ Workflows emit these event types during execution:
 | -------------------- | ---------- | ------------------------------ |
 | `workflow-start`     | Workflow   | Before first step executes     |
 | `workflow-complete`  | Workflow   | After final step completes     |
+| `workflow-cancelled` | Workflow   | When workflow is cancelled     |
 | `workflow-error`     | Workflow   | When workflow fails            |
 | `workflow-suspended` | Workflow   | When workflow suspends         |
 | `step-start`         | Step       | Before step executes           |
@@ -645,6 +646,31 @@ async function executeWithLiveUpdates(workflow, input, ws) {
   }
 
   return await stream.result;
+}
+```
+
+## Streaming to the AI SDK `useChat` hook
+
+Workflows can stream as **AI SDK–compatible `UIMessage` chunks**, which can be consumed directly by [`useChat`](https://sdk.vercel.ai/docs/api-reference/use-chat).
+
+All workflow events are converted into `data-*` messages, for example:
+
+- `workflow-start` → `data-workflow-start`
+- `workflow-complete` → `data-workflow-complete`
+
+### Backend
+
+```ts
+import { workflow } from "./workflow";
+
+export async function POST(req: Request) {
+  const streamResult = workflow.stream({
+    text: req.text,
+    conversationId,
+    userId,
+  });
+
+  return streamResult.toUIMessageStreamResponse();
 }
 ```
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features
Related to #589 

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
- Workflow stream is not compatible with `useChat` react hook.
- You can pipe raw SSE events like workflow-start into useChat, but useChat only understands the AI SDK UI Message Stream protocol (the “text-start / text-delta / …” chunks and data-* parts that the SDK generates).

## What is the new behavior?
- Workflows can now stream data as UIMessage chunks, ensuring compatibility with useChat hook. 
- Converts raw workflow events into `data-*` prefixed UIMessages in the `toUIMessageStreamResponse` function.
- UIMessages can be streamed for workflows by server via `streamResult.toUIMessageStreamResponse()` 

fixes #589 

## Notes for reviewers
All workflow events types will be prefixed with `data-*` to follow [AI SDK requirements](https://ai-sdk.dev/docs/reference/ai-sdk-core/ui-message) when streaming via `toUIMessageStreamResponse` -> `useChat`

<img width="749" height="355" alt="Screenshot 2025-09-25 at 19 17 16" src="https://github.com/user-attachments/assets/d63876bd-137b-4dd7-9ea5-adedc8193002" />


