### PR TITLE
fix: allow constructing `VoltAgent` without passing an `agents` map s…

### DIFF
--- a/.changeset/cruel-lines-double.md
+++ b/.changeset/cruel-lines-double.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix: allow constructing `VoltAgent` without passing an `agents` map so workflows-only setups boot without boilerplate.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -169,7 +169,10 @@ export interface ServerApiResponse<T> {
  * VoltAgent constructor options
  */
 export type VoltAgentOptions = {
-  agents: Record<string, Agent>;
+  /**
+   * Optional agents to register when bootstrapping VoltAgent
+   */
+  agents?: Record<string, Agent>;
   /**
    * Optional workflows to register with VoltAgent
    * Can be either Workflow instances or WorkflowChain instances

--- a/packages/core/src/voltagent.ts
+++ b/packages/core/src/voltagent.ts
@@ -306,7 +306,11 @@ export class VoltAgent {
   /**
    * Register multiple agents
    */
-  public registerAgents(agents: Record<string, Agent>): void {
+  public registerAgents(agents?: Record<string, Agent>): void {
+    if (!agents) {
+      return;
+    }
+
     Object.values(agents).forEach((agent) => this.registerAgent(agent));
   }
 


### PR DESCRIPTION
…o workflows-only setups

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
