### PR TITLE
fix(docs-mcp): update JSON Schema target to draft-7 for tool compatib…

### DIFF
--- a/.changeset/light-days-play.md
+++ b/.changeset/light-days-play.md
@@ -1,5 +1,5 @@
 ---
-"@voltagent/docs-mcp": patch"@voltagent/docs-mcp": patch
+"@voltagent/docs-mcp": patch
 ---
 
 fix(docs-mcp): update JSON Schema target to draft-7 for tool compatibilityfix(docs): update JSON Schema target to draft-7 for tool compatibility

--- a/.changeset/light-days-play.md
+++ b/.changeset/light-days-play.md
@@ -1,9 +1,5 @@
-------
-
-"@voltagent/docs-mcp": patch"@voltagent/docs-mcp": patch
-
 ---
-
+"@voltagent/docs-mcp": patch"@voltagent/docs-mcp": patch
 ---
 
 fix(docs-mcp): update JSON Schema target to draft-7 for tool compatibilityfix(docs): update JSON Schema target to draft-7 for tool compatibility

--- a/.changeset/light-days-play.md
+++ b/.changeset/light-days-play.md
@@ -1,0 +1,19 @@
+------
+
+"@voltagent/docs-mcp": patch"@voltagent/docs-mcp": patch
+
+---
+
+---
+
+fix(docs-mcp): update JSON Schema target to draft-7 for tool compatibilityfix(docs): update JSON Schema target to draft-7 for tool compatibility
+
+The MCP tool schemas were using JSON Schema draft-2020-12 features that weren't supported by the current validator. Updated to explicitly use draft-7 format for better compatibility.The MCP tool schemas were using JSON Schema draft-2020-12 features that weren't supported by the current validator. Updated to explicitly use draft-7 format for better compatibility.
+
+- Changed z.toJSONSchema() to use draft-7 target- Changed z.toJSONSchema() to use draft-7 target
+
+- Fixed tool registration failures due to schema validation errors- Fixed tool registration failures due to schema validation errors
+
+- Removed dependency on unsupported $dynamicRef feature- Removed dependency on unsupported $dynamicRef feature
+
+Fixes #626

--- a/packages/docs-mcp/src/index.ts
+++ b/packages/docs-mcp/src/index.ts
@@ -10,7 +10,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprot
 const mcpTools = voltAgentDocsTools.map((tool) => ({
   name: tool.name,
   description: tool.description,
-  inputSchema: z.toJSONSchema(tool.parameters),
+  inputSchema: z.toJSONSchema(tool.parameters, { target: "draft-7" }),
 }));
 
 console.error("=== VoltAgent Docs MCP Server Starting ===");


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added (not required - configuration change only)
- [x] Docs have been added / updated (not required - internal tool fix)
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

The MCP tool schemas are using JSON Schema draft-2020-12 features (specifically `$dynamicRef`) that are not supported by the current validator. This causes tool registration to fail with errors about unsupported meta-schema features.

Tool registration fails with errors like:
`Schema uses meta-schema features ($dynamicRef) that are not yet supported by the validator`

## What is the new behavior?

- Schema validation now works correctly by explicitly targeting draft-7
- Tool registration succeeds without schema validation errors
- Removed dependency on unsupported draft-2020-12 features
- No changes to tool functionality, just updated schema compatibility

fixes #626

## Notes for reviewers

- The change is isolated to the schema generation in 
- Only modifies the  call to explicitly use draft-7
- No functional changes to the tools themselves
- All existing tool parameters and validation rules remain the same