### PR TITLE
feat(core): Improve typing of workflow state parameter

### DIFF
--- a/packages/core/src/workflow/chain.ts
+++ b/packages/core/src/workflow/chain.ts
@@ -31,6 +31,7 @@ import type {
   WorkflowExecutionResult,
   WorkflowInput,
   WorkflowRunOptions,
+  WorkflowStepState,
   WorkflowStreamResult,
   WorkflowStreamWriter,
 } from "./types";
@@ -179,7 +180,7 @@ export class WorkflowChain<
     resumeSchema?: RS;
     execute: (context: {
       data: z.infer<IS>;
-      state: any;
+      state: WorkflowStepState<WorkflowInput<INPUT_SCHEMA>>;
       getStepData: (stepId: string) => { input: any; output: any } | undefined;
       suspend: (
         reason?: string,
@@ -211,7 +212,7 @@ export class WorkflowChain<
     resumeSchema?: RS;
     execute: (context: {
       data: z.infer<IS>;
-      state: any;
+      state: WorkflowStepState<WorkflowInput<INPUT_SCHEMA>>;
       getStepData: (stepId: string) => { input: any; output: any } | undefined;
       suspend: (
         reason?: string,
@@ -242,7 +243,7 @@ export class WorkflowChain<
     resumeSchema?: RS;
     execute: (context: {
       data: CURRENT_DATA;
-      state: any;
+      state: WorkflowStepState<WorkflowInput<INPUT_SCHEMA>>;
       getStepData: (stepId: string) => { input: any; output: any } | undefined;
       suspend: (
         reason?: string,
@@ -273,7 +274,7 @@ export class WorkflowChain<
     resumeSchema: RS;
     execute: (context: {
       data: CURRENT_DATA;
-      state: any;
+      state: WorkflowStepState<WorkflowInput<INPUT_SCHEMA>>;
       getStepData: (stepId: string) => { input: any; output: any } | undefined;
       suspend: (
         reason?: string,
@@ -316,7 +317,7 @@ export class WorkflowChain<
   andThen<NEW_DATA>(config: {
     execute: (context: {
       data: CURRENT_DATA;
-      state: any;
+      state: WorkflowStepState<WorkflowInput<INPUT_SCHEMA>>;
       getStepData: (stepId: string) => { input: any; output: any } | undefined;
       suspend: (reason?: string, suspendData?: z.infer<SUSPEND_SCHEMA>) => Promise<never>;
       resumeData?: z.infer<RESUME_SCHEMA>;
@@ -362,7 +363,7 @@ export class WorkflowChain<
       resumeSchema?: RS;
       condition: (context: {
         data: z.infer<IS>;
-        state: any;
+        state: WorkflowStepState<WorkflowInput<INPUT_SCHEMA>>;
         getStepData: (stepId: string) => { input: any; output: any } | undefined;
         suspend: (
           reason?: string,
@@ -455,7 +456,7 @@ export class WorkflowChain<
     resumeSchema?: RS;
     execute: (context: {
       data: z.infer<IS>;
-      state: any;
+      state: WorkflowStepState<WorkflowInput<INPUT_SCHEMA>>;
       getStepData: (stepId: string) => { input: any; output: any } | undefined;
       suspend: (
         reason?: string,
@@ -497,7 +498,7 @@ export class WorkflowChain<
   andTap<_NEW_DATA>(config: {
     execute: (context: {
       data: CURRENT_DATA;
-      state: any;
+      state: WorkflowStepState<WorkflowInput<INPUT_SCHEMA>>;
       getStepData: (stepId: string) => { input: any; output: any } | undefined;
       suspend: (reason?: string, suspendData?: z.infer<SUSPEND_SCHEMA>) => Promise<never>;
       resumeData?: z.infer<RESUME_SCHEMA>;

--- a/packages/core/src/workflow/internal/utils.ts
+++ b/packages/core/src/workflow/internal/utils.ts
@@ -41,6 +41,7 @@ export function convertWorkflowStateToParam<INPUT>(
     error: state.error,
     usage: state.usage,
     suspension: state.suspension,
+    cancellation: state.cancellation,
     workflowContext: executionContext,
     signal,
   };

--- a/packages/core/src/workflow/types.ts
+++ b/packages/core/src/workflow/types.ts
@@ -8,6 +8,7 @@ import type { UsageInfo } from "../agent/providers";
 import type { UserContext } from "../agent/types";
 import type { Memory } from "../memory";
 import type { VoltAgentObservability } from "../observability";
+import type { WorkflowExecutionContext } from "./context";
 import type { WorkflowState } from "./internal/state";
 import type { InternalBaseWorkflowInputSchema } from "./internal/types";
 import type { WorkflowStep } from "./steps";
@@ -712,6 +713,19 @@ export interface UpdateWorkflowStepOptions {
   agentExecutionId?: string;
   metadata?: Record<string, unknown>;
 }
+
+/**
+ * The state parameter passed to workflow steps
+ */
+export type WorkflowStepState<INPUT> = Omit<
+  WorkflowState<INPUT, DangerouslyAllowAny>,
+  "data" | "result"
+> & {
+  /** Workflow execution context for event tracking */
+  workflowContext?: WorkflowExecutionContext;
+  /** AbortSignal for checking suspension during step execution */
+  signal?: AbortSignal;
+};
 
 /**
  * Workflow memory storage interface - provides abstraction for different storage backends


### PR DESCRIPTION
Closes #645

## Description

This pull request addresses the lack of strict typing for the `state` parameter in workflow step handlers (`andThen`, `andWhen`, `andTap`), which was previously typed as `any`. This change significantly improves type safety and the overall developer experience when building workflows.

## Changes Made

1.  **Introduced `WorkflowStepState` Type**: A new, more specific type, `WorkflowStepState`, was added to `packages/core/src/workflow/types.ts`. This type accurately represents the state object passed to each workflow step, including properties like `executionId`, `context`, `suspension`, `cancellation`, and `workflowContext`.

2.  **Updated Workflow Chain**: The `andThen`, `andWhen`, and `andTap` methods in `packages/core/src/workflow/chain.ts` have been updated to use the new `WorkflowStepState` type instead of `any`.

3.  **Corrected State Creation**: The `convertWorkflowStateToParam` utility in `packages/core/src/workflow/internal/utils.ts` was updated to ensure all relevant properties from the main workflow state, including `cancellation`, are correctly passed to each step's `state` object.

## Benefits

-   **Improved Type Safety**: Prevents runtime errors by ensuring the `state` object is used correctly.
-   **Enhanced Developer Experience**: Provides better autocompletion and inline documentation for developers working with workflow steps.
-   **Increased Robustness**: Makes the workflow system more predictable and easier to debug.