### PR TITLE
feat(workflow): Support dynamic output schemas for agents

### DIFF
--- a/examples/with-workflow/src/index.ts
+++ b/examples/with-workflow/src/index.ts
@@ -321,6 +321,42 @@ const contentAnalysisWorkflow = createWorkflowChain({
     },
   });
 
+// ==============================================================================
+// Example 4: Article Summarization with Dynamic Schema
+// Concepts: Dynamic schema generation based on workflow input
+// ==============================================================================
+const articleSummarizationWorkflow = createWorkflowChain({
+  id: "article-summarizer",
+  name: "Article Summarization Workflow",
+  purpose: "Summarize an article with a dynamically specified length",
+  input: z.object({
+    article: z.string(),
+    min: z.number().default(50),
+    max: z.number().default(150),
+  }),
+  result: z.object({
+    summary: z.string(),
+  }),
+}).andAgent(
+  async ({ data }) =>
+    `Summarize the following article in ${data.min} to ${data.max} characters:
+  
+  Article: ${data.article}`,
+  contentAgent,
+  {
+    // Dynamically generate the schema based on the input data
+    schema: ({ data }) => {
+      console.log(`Generating schema with min: ${data.min}, max: ${data.max}`);
+      return z.object({
+        summary: z
+          .string()
+          .min(data.min, `Summary must be at least ${data.min} characters`)
+          .max(data.max, `Summary must be at most ${data.max} characters`),
+      });
+    },
+  },
+);
+
 // Register workflows with VoltAgent
 
 // Create logger
@@ -340,5 +376,6 @@ new VoltAgent({
     orderProcessingWorkflow,
     expenseApprovalWorkflow,
     contentAnalysisWorkflow,
+    articleSummarizationWorkflow,
   },
 });


### PR DESCRIPTION
Closes #644

This PR adds support for dynamic Zod schemas in workflow agents.

Now you can create validation schemas on the fly based on the workflow's input. This is super handy when validation rules, like the min/max length of a summary, depend on the parameters passed into the workflow.

### What's new?

You can now pass a function to the `schema` property in `.andAgent()`:

```typescript
//...
.andAgent(
  //...
  {
    // The schema is now a function that gets the workflow's input data
    schema: ({ data }) =>
      z.object({
        // Dynamic validation based on input!
        summary: z.string().min(data.min).max(data.max),
      }),
  },
);
```

### How to see it in action

I've added a new `articleSummarizationWorkflow` to the `with-workflow` example. Just run the example to start the server, and you can trigger the workflow to see the dynamic schema in action.