### PR TITLE
fix(core): duplicate static tools provided to llm

### DIFF
--- a/.changeset/sharp-coats-repair.md
+++ b/.changeset/sharp-coats-repair.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Fix duplicate tool registration during agent preparation.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [-] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

When preparing agent execution, both static and dynamic tools are merged and passed to toolManager.prepareToolsForGeneration. This causes each tool (e.g., getWeather) to appear twice, since dynamic clones are added even for non-dynamic tools.

## What is the new behavior?

Only dynamic tools should be passed to prepareToolsForGeneration

fixes (issue)
#668 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
