### PR TITLE
fix: allow experiment scorer configs to declare their own `id`

### DIFF
--- a/.changeset/hip-hotels-occur.md
+++ b/.changeset/hip-hotels-occur.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/evals": patch
+---
+
+fix: allow experiment scorer configs to declare their own `id`, so `passCriteria` entries that target `scorerId` work reliably and scorer summaries use the caller-provided identifiers.

--- a/packages/evals/src/experiment/scorers.ts
+++ b/packages/evals/src/experiment/scorers.ts
@@ -49,7 +49,10 @@ export function resolveExperimentScorers<
       const metadata = entry.metadata;
 
       const fallbackName = entry.name ?? scorer.name ?? scorer.id ?? `scorer-${index + 1}`;
-      return createBundleFromDefinition(scorer, fallbackName, threshold, metadata);
+      return createBundleFromDefinition(scorer, fallbackName, threshold, metadata, {
+        id: entry.id,
+        name: entry.name,
+      });
     }
 
     throw new Error("Invalid experiment scorer configuration entry.");
@@ -61,9 +64,13 @@ function createBundleFromDefinition<Item extends ExperimentDatasetItem>(
   fallbackName: string,
   threshold?: number,
   metadata?: Record<string, unknown>,
+  overrides?: {
+    id?: string;
+    name?: string;
+  },
 ): ExperimentRuntimeScorerBundle<Item> {
-  const id = definition.id ?? fallbackName;
-  const name = definition.name ?? id;
+  const id = overrides?.id ?? definition.id ?? fallbackName;
+  const name = overrides?.name ?? definition.name ?? fallbackName ?? id;
   const mergedMetadata = mergeMetadata(
     definition.metadata,
     buildVoltAgentMetadata(name, threshold, metadata),

--- a/packages/evals/src/experiment/types.ts
+++ b/packages/evals/src/experiment/types.ts
@@ -161,6 +161,7 @@ export interface ExperimentScorerConfigEntry<
   Payload extends Record<string, unknown> = Record<string, unknown>,
   Params extends Record<string, unknown> = Record<string, unknown>,
 > extends ExperimentScorerAdapterOptions<Item, Payload, Params> {
+  id?: string;
   scorer: LocalScorerDefinition<Payload, Params>;
   name?: string;
   threshold?: number;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
