### PR TITLE
fix(server-hono): add hostname configuration option for IPv6 support

### DIFF
--- a/.changeset/fix-hono-hostname-config.md
+++ b/.changeset/fix-hono-hostname-config.md
@@ -1,0 +1,29 @@
+---
+"@voltagent/server-hono": patch
+---
+
+Add hostname configuration option to honoServer() to support IPv6 and dual-stack networking.
+
+The honoServer() function now accepts a `hostname` option that allows configuring which network interface the server binds to. This fixes deployment issues on platforms like Railway that require IPv6 binding for private networking.
+
+**Example usage:**
+
+```typescript
+import { honoServer } from "@voltagent/server-hono";
+
+new VoltAgent({
+  agents,
+  server: honoServer({
+    port: 8080,
+    hostname: "::", // Binds to IPv6/dual-stack
+  }),
+});
+```
+
+**Options:**
+
+- `"0.0.0.0"` - Binds to all IPv4 interfaces (default, maintains backward compatibility)
+- `"::"` - Binds to all IPv6 interfaces (dual-stack on most systems)
+- `"localhost"` or `"127.0.0.1"` - Only localhost access
+
+Fixes #694

--- a/packages/server-hono/src/hono-server-provider.ts
+++ b/packages/server-hono/src/hono-server-provider.ts
@@ -35,7 +35,7 @@ export class HonoServerProvider extends BaseServerProvider {
         const server = serve({
           fetch: app.fetch.bind(app),
           port,
-          hostname: "0.0.0.0",
+          hostname: this.honoConfig.hostname || "0.0.0.0",
         });
 
         // Check if server started successfully

--- a/packages/server-hono/src/types.ts
+++ b/packages/server-hono/src/types.ts
@@ -3,6 +3,17 @@ import type { OpenAPIHonoType } from "./zod-openapi-compat";
 
 export interface HonoServerConfig {
   port?: number;
+
+  /**
+   * Hostname to bind the server to
+   * - "0.0.0.0" - Binds to all IPv4 interfaces (default)
+   * - "::" - Binds to all IPv6 interfaces (dual-stack on most systems)
+   * - "localhost" or "127.0.0.1" - Only localhost access
+   *
+   * @default "0.0.0.0"
+   */
+  hostname?: string;
+
   enableSwaggerUI?: boolean;
 
   /**


### PR DESCRIPTION
## Summary
Adds a configurable `hostname` option to `honoServer()` to support IPv6 and dual-stack networking, fixing deployment issues on platforms like Railway that require IPv6 binding for private networking.

## Changes
- Add `hostname` option to `HonoServerConfig` interface in [types.ts](packages/server-hono/src/types.ts)
- Update `HonoServerProvider` to use configurable hostname in [hono-server-provider.ts](packages/server-hono/src/hono-server-provider.ts)
- Default to `"0.0.0.0"` for backward compatibility
- Support `"::"` for IPv6/dual-stack binding
- Added comprehensive JSDoc documentation

## Example Usage
```typescript
import { honoServer } from "@voltagent/server-hono";

new VoltAgent({
  agents,
  server: honoServer({
    port: 8080,
    hostname: "::",  // Binds to IPv6/dual-stack
  }),
});
```

## Hostname Options
- `"0.0.0.0"` - Binds to all IPv4 interfaces (default)
- `"::"` - Binds to all IPv6 interfaces (dual-stack on most systems)
- `"localhost"` or `"127.0.0.1"` - Only localhost access

## Testing
- ✅ TypeScript compilation verified
- ✅ Backward compatibility maintained (default behavior unchanged)
- ✅ Pre-commit hooks passed

## Fixes
Closes #694