### PR TITLE
feat(auth): make custom routes public or private by default as per isPrivate param

### DIFF
--- a/packages/server-core/src/auth/defaults.ts
+++ b/packages/server-core/src/auth/defaults.ts
@@ -97,9 +97,15 @@ export function pathMatches(path: string, pattern: string): boolean {
  * @param method The HTTP method
  * @param path The request path
  * @param publicRoutes Additional public routes from config
+ * @param isPrivate Whether the default route protection is private (default: false)
  * @returns True if the route requires authentication
  */
-export function requiresAuth(method: string, path: string, publicRoutes?: string[]): boolean {
+export function requiresAuth(
+  method: string,
+  path: string,
+  publicRoutes?: string[],
+  isPrivate = false,
+): boolean {
   const fullRoute = `${method.toUpperCase()} ${path}`;
 
   // Check if it's a default public route
@@ -152,5 +158,5 @@ export function requiresAuth(method: string, path: string, publicRoutes?: string
 
   // Default: don't require auth for unknown routes
   // This allows custom endpoints to work without auth by default
-  return false;
+  return isPrivate;
 }

--- a/packages/server-core/src/auth/types.ts
+++ b/packages/server-core/src/auth/types.ts
@@ -35,4 +35,13 @@ export interface AuthProvider<TRequest = any> {
    * These are added to the default public routes
    */
   publicRoutes?: string[];
+
+  /**
+   * Whether the default route protection is private (default: false)
+   * If true, all routes will require authentication by default (except for public routes)
+   * If false, only routes that are explicitly protected will require authentication
+   * These are defined in the PROTECTED_ROUTES constant
+   * This is useful for cases where you want to add additional protected routes via configureApp
+   */
+  isPrivate?: boolean;
 }

--- a/packages/server-hono/src/auth/middleware.ts
+++ b/packages/server-hono/src/auth/middleware.ts
@@ -14,7 +14,7 @@ export function createAuthMiddleware(authProvider: AuthProvider<Request>) {
     const method = c.req.method;
 
     // Check if this route requires authentication
-    if (!requiresAuth(method, path, authProvider.publicRoutes)) {
+    if (!requiresAuth(method, path, authProvider.publicRoutes, authProvider.isPrivate)) {
       // Public route, no auth needed
       return next();
     }


### PR DESCRIPTION
Previously, all custom routes (routes not explicitly defined in DEFAULT_PUBLIC_ROUTES or PROTECTED_ROUTES) were public by default. Now, developers can control this behavior via the isPrivate parameter in the AuthProvider configuration.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
