### PR TITLE
fix: remove with-xsai dead link in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -135,5 +135,4 @@ Create a multi-agent research workflow where different AI agents collaborate to 
 - [Managed Memory](./with-voltagent-managed-memory) — Production‑grade memory via VoltOps Managed Memory REST adapter.
 - [Workflow](./with-workflow) — Build multi‑step flows with createWorkflowChain and human‑in‑the‑loop.
 - [Working Memory](./with-working-memory) — Persist per‑conversation/user facts with built‑in read/update tools.
-- [xAI](./with-xsai) — Use xAI Grok models as an LLM provider.
 - [Zapier (MCP)](./with-zapier-mcp) — Trigger Zapier actions through MCP from your agents.


### PR DESCRIPTION
Remove `with-xsai` dead link to pre-v1 example which was removed in [#a2b492e](https://github.com/VoltAgent/voltagent/commit/a2b492e8ed4dba96fa76862bbddf156f3a1a5c93)

No changeset required for this, no version bump.
<details><summary>Click to expand (PR template)</summary>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

## Notes for reviewers

</details>