### PR TITLE
fix: pass complete OperationContext to retrievers when used as object…

### DIFF
--- a/.changeset/cruel-tables-repeat.md
+++ b/.changeset/cruel-tables-repeat.md
@@ -1,0 +1,36 @@
+---
+"@voltagent/core": patch
+---
+
+fix: pass complete OperationContext to retrievers when used as object instances
+
+## The Problem
+
+When a retriever was assigned directly to an agent as an object instance (e.g., `retriever: myRetriever`), it wasn't receiving the `userId` and `conversationId` from the OperationContext. This prevented user-specific and conversation-aware retrieval when retrievers were used in this way, even though these fields were correctly passed when retrievers were used as tools.
+
+## The Solution
+
+Updated the `getRetrieverContext` method in the Agent class to pass the complete OperationContext to retrievers, ensuring consistency between tool-based and object-based retriever usage.
+
+## What Changed
+
+```typescript
+// Before - only partial context was passed
+return await this.retriever.retrieve(retrieverInput, {
+  context: oc.context,
+  logger: retrieverLogger,
+});
+
+// After - complete OperationContext is passed
+return await this.retriever.retrieve(retrieverInput, {
+  ...oc,
+  logger: retrieverLogger,
+});
+```
+
+## Impact
+
+- **Consistent behavior:** Retrievers now receive `userId` and `conversationId` regardless of how they're configured
+- **User-specific retrieval:** Enables filtering results by user in multi-tenant scenarios
+- **Conversation awareness:** Retrievers can now access conversation context when used as object instances
+- **No breaking changes:** This is a backward-compatible fix that adds missing context fields

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3047,7 +3047,7 @@ export class Agent {
       const retrievedContent = await oc.traceContext.withSpan(retrieverSpan, async () => {
         if (!this.retriever) return null;
         return await this.retriever.retrieve(retrieverInput, {
-          context: oc.context,
+          ...oc,
           logger: retrieverLogger,
         });
       });


### PR DESCRIPTION
… instances

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->
