### PR TITLE
docs: update Gurubase widget to handle SPA navigation

### DIFF
--- a/website/plugins/gurubase/index.js
+++ b/website/plugins/gurubase/index.js
@@ -54,13 +54,8 @@ module.exports = (_context) => ({
                     // Remove all widget-related DOM elements
                     // The widget creates elements with these patterns
                     var selectors = [
-                      '#guru-widget-id',
-                      '[class*="chat-widget"]',
-                      '[class*="chatWidget"]',
-                      '[id*="chat-widget"]',
-                      '[id*="chatWidget"]',
-                      '.guru-widget-container',
-                      '[style*="position: fixed"][style*="z-index: 2147483647"]'
+                      '#guru-widget-id',                    // The script tag
+                      '#gurubase-chat-widget-container'     // The widget container
                     ];
                     
                     selectors.forEach(function(selector) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

The Gurubase widget only initializes on initial page load. When navigating within the Docusaurus SPA (Single Page Application):
- Navigating from home (`/`) or other pages to docs (`/docs/...`) does not show the widget
- Navigating away from docs pages does not remove the widget
- Browser back/forward navigation does not properly show/hide the widget

This happens because Docusaurus uses client-side routing, and the widget initialization only runs once on page load, not on route changes.

## What is the new behavior?

The widget now properly handles SPA navigation:
- Widget appears when navigating to docs pages from any route (home, blog, etc.)
- Widget is removed when navigating away from docs pages
- Browser back/forward buttons correctly show/hide the widget

**Implementation details:**
- Added `initWidget()` and `destroyWidget()` functions with proper cleanup
- Hooked into History API (`pushState`, `replaceState`) to detect route changes
- Added `popstate` event listener for browser navigation
- Widget state tracking prevents duplicate initialization
- Comprehensive DOM cleanup removes all widget-related elements

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Gurubase widget handle SPA navigation in Docusaurus so it appears on /docs pages and is removed elsewhere. Fixes missing widget after in-app navigation and stale widget when leaving docs, including back/forward.

- **Bug Fixes**
  - Detect route changes via history.pushState, history.replaceState, and popstate.
  - Add initWidget and destroyWidget with full cleanup (script, DOM, globals).
  - Track widget state to prevent duplicate initialization.

<sup>Written for commit fc4b5d1db87e7d959a5c811821c1df293985dc6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

