### PR TITLE
feat(testimonials): add ResizeObserver for dynamic height adjustment and improve layout stability

### DIFF
--- a/website/src/components/testimonials/Testimonials.tsx
+++ b/website/src/components/testimonials/Testimonials.tsx
@@ -301,12 +301,14 @@ export function Testimonials() {
   const [isDiscordRowPaused, setIsDiscordRowPaused] = useState(false);
   const [isArticlesRowPaused, setIsArticlesRowPaused] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+  const [lockedHeight, setLockedHeight] = useState<number | null>(null);
 
   // Refs for each scrolling row
   const tweetsRowRef = useRef<HTMLDivElement>(null);
   const discordRowRef = useRef<HTMLDivElement>(null);
   const articlesRowRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   // Intersection Observer to pause animations when not visible
   useEffect(() => {
@@ -323,6 +325,26 @@ export function Testimonials() {
 
     return () => observer.disconnect();
   }, []);
+
+  // ResizeObserver to monitor content height changes
+  useEffect(() => {
+    if (!contentRef.current || !isVisible) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const height = entry.contentRect.height;
+        if (height > 0) {
+          setLockedHeight(height);
+        }
+      }
+    });
+
+    resizeObserver.observe(contentRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [isVisible]);
 
   // Create mixed content for seamless scrolling
   const mixedContent = [];
@@ -469,115 +491,15 @@ export function Testimonials() {
       </div>
       <style>{scrollAnimation}</style>
 
-      {/* Only render animations if component is visible */}
-      {isVisible && (
-        <>
-          {/* Tweets Row - Scrolling Left */}
-          <div className="relative mb-1">
-            <div
-              ref={tweetsRowRef}
-              className="flex overflow-hidden"
-              style={{
-                width: "100%",
-                maxWidth: "100%",
-                scrollbarWidth: "none",
-                msOverflowStyle: "none",
-                WebkitOverflowScrolling: "touch",
-                WebkitMaskImage:
-                  "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
-                maskImage:
-                  "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
-              }}
-              onMouseEnter={handleTweetsRowMouseEnter}
-              onMouseLeave={handleTweetsRowMouseLeave}
-            >
+      {/* Use locked height to preserve layout space and prevent layout shifts when the content is unmounted */}
+      <div style={{ height: lockedHeight ? `${lockedHeight}px` : "800px" }}>
+        {/* Only render animations if component is visible */}
+        {isVisible && (
+          <div ref={contentRef}>
+            {/* Tweets Row - Scrolling Left */}
+            <div className="relative mb-1">
               <div
-                className={`flex space-x-6 py-4 seamless-scroll-left ${
-                  isTweetsRowPaused ? "animation-paused" : ""
-                }`}
-              >
-                {seamlessMixedContent
-                  .filter((item) => {
-                    // Filter out tweets that don't exist or are missing required data
-                    if (item.type === "tweet") {
-                      const tweet = tweetsData?.[item.id];
-                      return tweet?.id_str && tweet.user;
-                    }
-                    return true;
-                  })
-                  .map((item, index) => (
-                    <div key={`${item.key}-${index}`} className="flex-shrink-0 w-80">
-                      {item.type === "tweet" ? (
-                        <StaticTweet tweet={tweetsData?.[item.id]} />
-                      ) : (
-                        <LinkedInPost
-                          profileImage={item.data.profileImage}
-                          name={item.data.name}
-                          title={item.data.title}
-                          content={item.data.content}
-                          url={item.data.url}
-                        />
-                      )}
-                    </div>
-                  ))}
-              </div>
-            </div>
-          </div>
-
-          {/* Discord Messages Row - Scrolling Right */}
-          <div className="relative mb-1">
-            <div
-              ref={discordRowRef}
-              className="flex overflow-hidden"
-              style={{
-                width: "100%",
-                maxWidth: "100%",
-                scrollbarWidth: "none",
-                msOverflowStyle: "none",
-                WebkitOverflowScrolling: "touch",
-                WebkitMaskImage:
-                  "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
-                maskImage:
-                  "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
-              }}
-              onMouseEnter={handleDiscordRowMouseEnter}
-              onMouseLeave={handleDiscordRowMouseLeave}
-            >
-              <div
-                className={`flex space-x-6 py-4 seamless-scroll-right ${
-                  isDiscordRowPaused ? "animation-paused" : ""
-                }`}
-              >
-                {seamlessMixedDiscordContent.map((item, index) => (
-                  <div key={`${item.key}-${index}`} className="flex-shrink-0 w-80">
-                    {item.type === "discord" ? (
-                      <DiscordMessage
-                        username={item.data.username}
-                        discriminator={item.data.discriminator}
-                        message={item.data.message}
-                        timestamp={item.data.timestamp}
-                      />
-                    ) : (
-                      <LinkedInMessage
-                        username={item.data.username}
-                        title={item.data.title}
-                        message={item.data.message}
-                        timestamp={item.data.timestamp}
-                        avatar={item.data.avatar}
-                        url={item.data.url}
-                      />
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          {/* Articles Section */}
-          <div className="mt-1">
-            <div className="relative">
-              <div
-                ref={articlesRowRef}
+                ref={tweetsRowRef}
                 className="flex overflow-hidden"
                 style={{
                   width: "100%",
@@ -590,42 +512,145 @@ export function Testimonials() {
                   maskImage:
                     "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
                 }}
-                onMouseEnter={handleArticlesRowMouseEnter}
-                onMouseLeave={handleArticlesRowMouseLeave}
+                onMouseEnter={handleTweetsRowMouseEnter}
+                onMouseLeave={handleTweetsRowMouseLeave}
               >
                 <div
-                  className={`flex space-x-6 py-4 seamless-scroll-articles ${
-                    isArticlesRowPaused ? "animation-paused" : ""
+                  className={`flex space-x-6 py-4 seamless-scroll-left ${
+                    isTweetsRowPaused ? "animation-paused" : ""
                   }`}
                 >
-                  {seamlessArticles.map((article, index) => (
-                    <div
-                      key={`article-${article.title.replace(/\s+/g, "-").toLowerCase()}-${index}`}
-                      className="flex-shrink-0 w-80"
-                    >
-                      <ArticleCard
-                        title={article.title}
-                        coverImage={article.coverImage}
-                        excerpt={article.excerpt}
-                        author={article.author}
-                        publication={(article as any).publication}
-                        date={(article as any).date}
-                        readTime={(article as any).readTime}
-                        url={article.url}
-                        type={article.type}
-                        videoId={article.videoId}
-                        channel={(article as any).channel}
-                        views={(article as any).views}
-                        duration={(article as any).duration}
-                      />
+                  {seamlessMixedContent
+                    .filter((item) => {
+                      // Filter out tweets that don't exist or are missing required data
+                      if (item.type === "tweet") {
+                        const tweet = tweetsData?.[item.id];
+                        return tweet?.id_str && tweet.user;
+                      }
+                      return true;
+                    })
+                    .map((item, index) => (
+                      <div key={`${item.key}-${index}`} className="flex-shrink-0 w-80">
+                        {item.type === "tweet" ? (
+                          <StaticTweet tweet={tweetsData?.[item.id]} />
+                        ) : (
+                          <LinkedInPost
+                            profileImage={item.data.profileImage}
+                            name={item.data.name}
+                            title={item.data.title}
+                            content={item.data.content}
+                            url={item.data.url}
+                          />
+                        )}
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Discord Messages Row - Scrolling Right */}
+            <div className="relative mb-1">
+              <div
+                ref={discordRowRef}
+                className="flex overflow-hidden"
+                style={{
+                  width: "100%",
+                  maxWidth: "100%",
+                  scrollbarWidth: "none",
+                  msOverflowStyle: "none",
+                  WebkitOverflowScrolling: "touch",
+                  WebkitMaskImage:
+                    "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
+                  maskImage:
+                    "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
+                }}
+                onMouseEnter={handleDiscordRowMouseEnter}
+                onMouseLeave={handleDiscordRowMouseLeave}
+              >
+                <div
+                  className={`flex space-x-6 py-4 seamless-scroll-right ${
+                    isDiscordRowPaused ? "animation-paused" : ""
+                  }`}
+                >
+                  {seamlessMixedDiscordContent.map((item, index) => (
+                    <div key={`${item.key}-${index}`} className="flex-shrink-0 w-80">
+                      {item.type === "discord" ? (
+                        <DiscordMessage
+                          username={item.data.username}
+                          discriminator={item.data.discriminator}
+                          message={item.data.message}
+                          timestamp={item.data.timestamp}
+                        />
+                      ) : (
+                        <LinkedInMessage
+                          username={item.data.username}
+                          title={item.data.title}
+                          message={item.data.message}
+                          timestamp={item.data.timestamp}
+                          avatar={item.data.avatar}
+                          url={item.data.url}
+                        />
+                      )}
                     </div>
                   ))}
                 </div>
               </div>
             </div>
+
+            {/* Articles Section */}
+            <div className="mt-1">
+              <div className="relative">
+                <div
+                  ref={articlesRowRef}
+                  className="flex overflow-hidden"
+                  style={{
+                    width: "100%",
+                    maxWidth: "100%",
+                    scrollbarWidth: "none",
+                    msOverflowStyle: "none",
+                    WebkitOverflowScrolling: "touch",
+                    WebkitMaskImage:
+                      "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
+                    maskImage:
+                      "linear-gradient(90deg, transparent 0%, black 5%, black 95%, transparent 100%)",
+                  }}
+                  onMouseEnter={handleArticlesRowMouseEnter}
+                  onMouseLeave={handleArticlesRowMouseLeave}
+                >
+                  <div
+                    className={`flex space-x-6 py-4 seamless-scroll-articles ${
+                      isArticlesRowPaused ? "animation-paused" : ""
+                    }`}
+                  >
+                    {seamlessArticles.map((article, index) => (
+                      <div
+                        key={`article-${article.title.replace(/\s+/g, "-").toLowerCase()}-${index}`}
+                        className="flex-shrink-0 w-80"
+                      >
+                        <ArticleCard
+                          title={article.title}
+                          coverImage={article.coverImage}
+                          excerpt={article.excerpt}
+                          author={article.author}
+                          publication={(article as any).publication}
+                          date={(article as any).date}
+                          readTime={(article as any).readTime}
+                          url={article.url}
+                          type={article.type}
+                          videoId={article.videoId}
+                          channel={(article as any).channel}
+                          views={(article as any).views}
+                          duration={(article as any).duration}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-        </>
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
add ResizeObserver for dynamic height adjustment and improve layout stability

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

The Testimonials component causes layout shift when scrolling. When the component enters the viewport, the conditional rendering (`{isVisible && ...}`) suddenly renders a large amount of content (50-60 testimonial cards), causing the document height to change abruptly. This creates a poor user experience with:
- Page jumping/shifting during scroll
- Inconsistent scrollbar position
- Jarring visual experience for users

## What is the new behavior?

- **Height preservation**: Added a placeholder container with locked height to maintain layout space
- **Dynamic height measurement**: Uses `ResizeObserver` to measure and cache the actual content height when it first becomes visible
- **Performance optimization**: Content is only mounted when visible (using `isVisible` conditional rendering), and unmounted when not visible
- **Smooth user experience**: The placeholder container maintains the measured height, preventing layout shifts when content is unmounted

The implementation:
- Measures content height on first render using `ResizeObserver`
- Stores the height in `lockedHeight` state
- Uses the locked height as a placeholder container height
- Only renders content when `isVisible` is true (via `IntersectionObserver`)

fixes (issue)

## Notes for reviewers

This PR focuses on maintaining layout stability while keeping performance optimizations. The content is conditionally rendered based on viewport visibility, but the layout space is preserved using a locked height placeholder.

Key changes:
- Added `lockedHeight` state and `contentRef` for height measurement
- Implemented `ResizeObserver` to monitor content height changes
- Wrapped content in a placeholder div with locked height
- Content remains conditionally rendered based on `isVisible` state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes layout shift in the Testimonials section by locking container height based on measured content. Prevents page jumps while keeping conditional rendering for performance.

- **Bug Fixes**
  - Measure content height with ResizeObserver and cache it in lockedHeight.
  - Wrap content in a placeholder container using the locked height (with a fallback) to preserve layout.
  - Keep IntersectionObserver-based conditional rendering to only mount when visible and unmount when not.

<sup>Written for commit e5383b98f1caf9e92b85d0e42bba864bbb660306. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

