### PR TITLE
fix: avoid TS4053 declaration emit errors when exporting `generateTex…

### DIFF
--- a/.changeset/small-months-sort.md
+++ b/.changeset/small-months-sort.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix: avoid TS4053 declaration emit errors when exporting `generateText` wrappers by decoupling ai-sdk `Output` types from public results

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -137,12 +137,7 @@ const STEP_PERSIST_COUNT_KEY = Symbol("persistedStepCount");
 // Types
 // ============================================================================
 
-type OutputSpec =
-  | ReturnType<typeof Output.text>
-  | ReturnType<typeof Output.object>
-  | ReturnType<typeof Output.array>
-  | ReturnType<typeof Output.choice>
-  | ReturnType<typeof Output.json>;
+type OutputSpec = Output.Output;
 
 /**
  * Context input type that accepts both Map and plain object
@@ -167,26 +162,26 @@ function toContextMap(context?: ContextInput): Map<string | symbol, unknown> | u
 /**
  * Extended StreamTextResult that includes context
  */
-export interface StreamTextResultWithContext<
+export type StreamTextResultWithContext<
   TOOLS extends ToolSet = Record<string, any>,
-  OUTPUT extends OutputSpec = OutputSpec,
-> {
+  OUTPUT = unknown,
+> = {
   // All methods from AIStreamTextResult
-  readonly text: AIStreamTextResult<TOOLS, OUTPUT>["text"];
-  readonly textStream: AIStreamTextResult<TOOLS, OUTPUT>["textStream"];
+  readonly text: AIStreamTextResult<TOOLS, any>["text"];
+  readonly textStream: AIStreamTextResult<TOOLS, any>["textStream"];
   readonly fullStream: AsyncIterable<VoltAgentTextStreamPart<TOOLS>>;
-  readonly usage: AIStreamTextResult<TOOLS, OUTPUT>["usage"];
-  readonly finishReason: AIStreamTextResult<TOOLS, OUTPUT>["finishReason"];
+  readonly usage: AIStreamTextResult<TOOLS, any>["usage"];
+  readonly finishReason: AIStreamTextResult<TOOLS, any>["finishReason"];
   // Partial output stream for streaming structured objects
-  readonly partialOutputStream?: AIStreamTextResult<TOOLS, OUTPUT>["partialOutputStream"];
-  toUIMessageStream: AIStreamTextResult<TOOLS, OUTPUT>["toUIMessageStream"];
-  toUIMessageStreamResponse: AIStreamTextResult<TOOLS, OUTPUT>["toUIMessageStreamResponse"];
-  pipeUIMessageStreamToResponse: AIStreamTextResult<TOOLS, OUTPUT>["pipeUIMessageStreamToResponse"];
-  pipeTextStreamToResponse: AIStreamTextResult<TOOLS, OUTPUT>["pipeTextStreamToResponse"];
-  toTextStreamResponse: AIStreamTextResult<TOOLS, OUTPUT>["toTextStreamResponse"];
+  readonly partialOutputStream?: AIStreamTextResult<TOOLS, any>["partialOutputStream"];
+  toUIMessageStream: AIStreamTextResult<TOOLS, any>["toUIMessageStream"];
+  toUIMessageStreamResponse: AIStreamTextResult<TOOLS, any>["toUIMessageStreamResponse"];
+  pipeUIMessageStreamToResponse: AIStreamTextResult<TOOLS, any>["pipeUIMessageStreamToResponse"];
+  pipeTextStreamToResponse: AIStreamTextResult<TOOLS, any>["pipeTextStreamToResponse"];
+  toTextStreamResponse: AIStreamTextResult<TOOLS, any>["toTextStreamResponse"];
   // Additional context field
   context: Map<string | symbol, unknown>;
-}
+} & Record<never, OUTPUT>;
 
 /**
  * Extended StreamObjectResult that includes context
@@ -209,13 +204,24 @@ export interface StreamObjectResultWithContext<T> {
 /**
  * Extended GenerateTextResult that includes context
  */
-export type GenerateTextResultWithContext<
+type BaseGenerateTextResult<TOOLS extends ToolSet = Record<string, any>> = Omit<
+  GenerateTextResult<TOOLS, any>,
+  "experimental_output" | "output"
+> & {
+  experimental_output: unknown;
+  output: unknown;
+};
+
+export interface GenerateTextResultWithContext<
   TOOLS extends ToolSet = Record<string, any>,
-  OUTPUT extends OutputSpec = OutputSpec,
-> = GenerateTextResult<TOOLS, OUTPUT> & {
+  OUTPUT = unknown,
+> extends BaseGenerateTextResult<TOOLS> {
   // Additional context field
   context: Map<string | symbol, unknown>;
-};
+  // Typed structured output override if provided by callers
+  experimental_output: OUTPUT;
+  output: OUTPUT;
+}
 
 type LLMOperation = "streamText" | "generateText" | "streamObject" | "generateObject";
 

--- a/packages/core/src/agent/subagent/types.ts
+++ b/packages/core/src/agent/subagent/types.ts
@@ -1,4 +1,3 @@
-import type { Output } from "ai";
 import type { StreamTextResult, TextStreamPart } from "ai";
 import type { z } from "zod";
 import type { Agent } from "../agent";
@@ -174,26 +173,18 @@ export type VoltAgentTextStreamPart<TOOLS extends Record<string, any> = Record<s
     agentPath?: string[];
   };
 
-type OutputSpec =
-  | ReturnType<typeof Output.text>
-  | ReturnType<typeof Output.object>
-  | ReturnType<typeof Output.array>
-  | ReturnType<typeof Output.choice>
-  | ReturnType<typeof Output.json>;
-
 /**
  * Extended StreamTextResult that uses VoltAgentTextStreamPart for fullStream.
  * This maintains compatibility with ai-sdk while adding subagent metadata support.
  *
  * @template TOOLS - The tool set type parameter
- * @template OUTPUT - The output spec type parameter
  */
-export interface VoltAgentStreamTextResult<
+export type VoltAgentStreamTextResult<
   TOOLS extends Record<string, any> = Record<string, any>,
-  OUTPUT extends OutputSpec = OutputSpec,
-> extends Omit<StreamTextResult<TOOLS, OUTPUT>, "fullStream"> {
+  OUTPUT = unknown,
+> = Omit<StreamTextResult<TOOLS, any>, "fullStream"> & {
   /**
    * Full stream with subagent metadata support
    */
   readonly fullStream: AsyncIterable<VoltAgentTextStreamPart<TOOLS>>;
-}
+} & Record<never, OUTPUT>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,10 @@ export {
   type StreamTextOptions,
   type GenerateObjectOptions,
   type StreamObjectOptions,
+  type GenerateTextResultWithContext,
+  type StreamTextResultWithContext,
+  type GenerateObjectResultWithContext,
+  type StreamObjectResultWithContext,
 } from "./agent/agent";
 export * from "./planagent";
 export * from "./agent/hooks";


### PR DESCRIPTION
…t` wrappers

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TS4053 declaration emit errors by decoupling ai-sdk Output types from our exported generateText/stream result types. Structured outputs stay opt-in via generics; defaults now use unknown for safe d.ts emission.

- **Bug Fixes**
  - Replaced OutputSpec unions with internal any and public OUTPUT = unknown.
  - Added GenerateTextResultWithContext, StreamTextResultWithContext, GenerateObjectResultWithContext, StreamObjectResultWithContext with a typed OUTPUT override.
  - Simplified VoltAgentStreamTextResult to drop hard Output dependency and keep custom fullStream.
  - Re-exported the new result types from core index.
  - Added a changeset patch for @voltagent/core.

<sup>Written for commit f4fbf8ffdef080540756d316a153ee54ca8c0785. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

