### PR TITLE
feat: expose Cloudflare Workers `env` bindings in serverless contexts

### DIFF
--- a/.changeset/puny-cameras-open.md
+++ b/.changeset/puny-cameras-open.md
@@ -1,0 +1,42 @@
+---
+"@voltagent/serverless-hono": patch
+"@voltagent/server-core": patch
+"@voltagent/core": patch
+---
+
+feat: expose Cloudflare Workers `env` bindings in serverless contexts
+
+When using `@voltagent/serverless-hono` on Cloudflare Workers, the runtime `env` is now injected into the
+context map for agent requests, workflow runs, and tool executions. `@voltagent/core` exports
+`SERVERLESS_ENV_CONTEXT_KEY` so you can access bindings like D1 from `options.context` (tools) or
+`state.context` (workflow steps). Tool execution also accepts `context` as a `Map`, preserving
+`userId`/`conversationId` when provided that way.
+
+`@voltagent/core` is also marked as side-effect free so edge bundlers can tree-shake the PlanAgent
+filesystem backend, avoiding Node-only dependency loading when it is not used.
+
+Usage:
+
+```ts
+import { createTool, SERVERLESS_ENV_CONTEXT_KEY } from "@voltagent/core";
+import type { D1Database } from "@cloudflare/workers-types";
+import { z } from "zod";
+
+type Env = { DB: D1Database };
+
+export const listUsers = createTool({
+  name: "list-users",
+  description: "Fetch users from D1",
+  parameters: z.object({}),
+  execute: async (_args, options) => {
+    const env = options?.context?.get(SERVERLESS_ENV_CONTEXT_KEY) as Env | undefined;
+    const db = env?.DB;
+    if (!db) {
+      throw new Error("D1 binding is missing (env.DB)");
+    }
+
+    const { results } = await db.prepare("SELECT id, name FROM users").all();
+    return results;
+  },
+});
+```

--- a/examples/with-cloudflare-workers/wrangler.toml
+++ b/examples/with-cloudflare-workers/wrangler.toml
@@ -9,3 +9,8 @@ compatibility_flags = [
   "nodejs_compat_populate_process_env",
   "no_handle_cross_request_promise_resolution",
 ]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "my-db-name"
+database_id = "b4712095-3b98-4834-ad03-edf70aef9eb3"

--- a/packages/core/src/context-keys.ts
+++ b/packages/core/src/context-keys.ts
@@ -1,0 +1,1 @@
+export const SERVERLESS_ENV_CONTEXT_KEY = Symbol.for("voltagent.serverless.env");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,6 +102,7 @@ export {
   context,
 } from "./observability";
 export { TRIGGER_CONTEXT_KEY } from "./observability/context-keys";
+export { SERVERLESS_ENV_CONTEXT_KEY } from "./context-keys";
 export { createTriggers } from "./triggers/dsl";
 
 // Memory V2 - Export with aliases to avoid conflicts

--- a/packages/serverless-hono/src/routes.ts
+++ b/packages/serverless-hono/src/routes.ts
@@ -1,4 +1,8 @@
-import type { A2AServerRegistry, ServerProviderDeps } from "@voltagent/core";
+import {
+  type A2AServerRegistry,
+  SERVERLESS_ENV_CONTEXT_KEY,
+  type ServerProviderDeps,
+} from "@voltagent/core";
 import type { Logger } from "@voltagent/internal";
 import { safeStringify } from "@voltagent/internal";
 import {
@@ -96,6 +100,72 @@ function extractHeaders(
   return result;
 }
 
+type ServerlessEnv = Record<string, unknown>;
+
+function getServerlessEnv(c: { env?: unknown }): ServerlessEnv | undefined {
+  const env = c?.env;
+  if (!env || typeof env !== "object" || Array.isArray(env)) {
+    return undefined;
+  }
+  return env as ServerlessEnv;
+}
+
+function mergeContextWithServerlessEnv(
+  context: unknown,
+  env: ServerlessEnv | undefined,
+): Map<string | symbol, unknown> | undefined {
+  if (!env) {
+    return context instanceof Map ? context : undefined;
+  }
+
+  const contextMap =
+    context instanceof Map
+      ? context
+      : context && typeof context === "object" && !Array.isArray(context)
+        ? new Map(Object.entries(context as Record<string, unknown>))
+        : new Map<string | symbol, unknown>();
+
+  if (!contextMap.has(SERVERLESS_ENV_CONTEXT_KEY)) {
+    contextMap.set(SERVERLESS_ENV_CONTEXT_KEY, env);
+  }
+
+  return contextMap;
+}
+
+function withServerlessEnvInOptions(body: any, env: ServerlessEnv | undefined) {
+  if (!env || !body || typeof body !== "object") {
+    return body;
+  }
+
+  const options =
+    body.options && typeof body.options === "object" && !Array.isArray(body.options)
+      ? body.options
+      : {};
+
+  const context = mergeContextWithServerlessEnv(options.context, env);
+
+  return {
+    ...body,
+    options: {
+      ...options,
+      context: context ?? options.context,
+    },
+  };
+}
+
+function withServerlessEnvInContext(body: any, env: ServerlessEnv | undefined) {
+  if (!env || !body || typeof body !== "object") {
+    return body;
+  }
+
+  const context = mergeContextWithServerlessEnv(body.context, env);
+
+  return {
+    ...body,
+    context: context ?? body.context,
+  };
+}
+
 function parseContextCandidate(candidate: unknown): A2ARequestContext | undefined {
   if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
     return undefined;
@@ -164,7 +234,14 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
     const signal = c.req.raw.signal;
-    const response = await handleGenerateText(agentId, body, deps, logger, signal);
+    const runtimeEnv = getServerlessEnv(c);
+    const response = await handleGenerateText(
+      agentId,
+      withServerlessEnvInOptions(body, runtimeEnv),
+      deps,
+      logger,
+      signal,
+    );
     return c.json(response, response.success ? 200 : 500);
   });
 
@@ -175,7 +252,14 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       return c.json({ error: "Invalid JSON body" }, 400);
     }
     const signal = c.req.raw.signal;
-    const response = await handleStreamText(agentId, body, deps, logger, signal);
+    const runtimeEnv = getServerlessEnv(c);
+    const response = await handleStreamText(
+      agentId,
+      withServerlessEnvInOptions(body, runtimeEnv),
+      deps,
+      logger,
+      signal,
+    );
     return response;
   });
 
@@ -186,7 +270,14 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       return c.json({ error: "Invalid JSON body" }, 400);
     }
     const signal = c.req.raw.signal;
-    return handleChatStream(agentId, body, deps, logger, signal);
+    const runtimeEnv = getServerlessEnv(c);
+    return handleChatStream(
+      agentId,
+      withServerlessEnvInOptions(body, runtimeEnv),
+      deps,
+      logger,
+      signal,
+    );
   });
 
   app.post(AGENT_ROUTES.generateObject.path, async (c) => {
@@ -196,7 +287,14 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
     const signal = c.req.raw.signal;
-    const response = await handleGenerateObject(agentId, body, deps, logger, signal);
+    const runtimeEnv = getServerlessEnv(c);
+    const response = await handleGenerateObject(
+      agentId,
+      withServerlessEnvInOptions(body, runtimeEnv),
+      deps,
+      logger,
+      signal,
+    );
     return c.json(response, response.success ? 200 : 500);
   });
 
@@ -207,7 +305,14 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       return c.json({ error: "Invalid JSON body" }, 400);
     }
     const signal = c.req.raw.signal;
-    return handleStreamObject(agentId, body, deps, logger, signal);
+    const runtimeEnv = getServerlessEnv(c);
+    return handleStreamObject(
+      agentId,
+      withServerlessEnvInOptions(body, runtimeEnv),
+      deps,
+      logger,
+      signal,
+    );
   });
 
   app.get(AGENT_ROUTES.getAgentHistory.path, async (c) => {
@@ -237,7 +342,13 @@ export function registerWorkflowRoutes(app: Hono, deps: ServerProviderDeps, logg
     if (!body) {
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
-    const response = await handleExecuteWorkflow(workflowId, body, deps, logger);
+    const runtimeEnv = getServerlessEnv(c);
+    const response = await handleExecuteWorkflow(
+      workflowId,
+      withServerlessEnvInOptions(body, runtimeEnv),
+      deps,
+      logger,
+    );
     return c.json(response, response.success ? 200 : 500);
   });
 
@@ -248,7 +359,13 @@ export function registerWorkflowRoutes(app: Hono, deps: ServerProviderDeps, logg
       return c.json({ error: "Invalid JSON body" }, 400);
     }
 
-    const response = await handleStreamWorkflow(workflowId, body, deps, logger);
+    const runtimeEnv = getServerlessEnv(c);
+    const response = await handleStreamWorkflow(
+      workflowId,
+      withServerlessEnvInOptions(body, runtimeEnv),
+      deps,
+      logger,
+    );
 
     if (isErrorResponse(response)) {
       return c.json(response, 500);
@@ -312,7 +429,13 @@ export function registerToolRoutes(app: Hono, deps: ServerProviderDeps, logger: 
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
 
-    const response = await handleExecuteTool(toolName, body, deps, logger);
+    const runtimeEnv = getServerlessEnv(c);
+    const response = await handleExecuteTool(
+      toolName,
+      withServerlessEnvInContext(body, runtimeEnv),
+      deps,
+      logger,
+    );
     const status = response.success ? 200 : response.httpStatus || 500;
     return c.json(response, status);
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Cloudflare Workers env bindings in serverless routes so agents, workflows, and tools can access D1/KV/R2 via the execution context. Also reduce edge bundle size by making core tree-shakable and avoiding Node-only deps.

- **New Features**
  - Inject Worker env into request context using SERVERLESS_ENV_CONTEXT_KEY across agent, workflow, and tool endpoints.
  - Support Map-based tool context while preserving userId and conversationId.
  - Added D1 binding example in wrangler.toml and docs showing how to use env bindings in tools and workflow steps.

- **Refactors**
  - Dynamically import fast-glob in the filesystem backend to prevent Node-only deps from loading in edge builds; mark core as side-effect free for better tree-shaking.

<sup>Written for commit a985b3ab5acc82e5efd4d2646ff8d05e4ad4bf79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

