### PR TITLE
fix: infer structured output types for `generateText`

### DIFF
--- a/.changeset/sixty-humans-move.md
+++ b/.changeset/sixty-humans-move.md
@@ -1,0 +1,7 @@
+---
+"@voltagent/core": patch
+---
+
+fix: infer structured output types for `generateText`
+
+`generateText` now propagates the provided `Output.*` spec into the return type, so `result.output` is no longer `unknown` when using `Output.object`, `Output.array`, etc.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix structured output types for generateText so result.output and experimental_output are inferred from the provided Output.* spec. Improves type safety and DX without changing runtime behavior.

- **Bug Fixes**
  - Propagate the Output.* spec via a generic OUTPUT in GenerateTextOptions and Agent.generateText; return fields use InferGenerateOutput<OUTPUT>.
  - Update test utils to match the new signature and add a changeset.

<sup>Written for commit c1c0682565c6e74b3f2fac10f480bbbaf6f6dd4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

