### PR TITLE
fix: mcp listResources now returns the raw MCP `resources/list` response

### DIFF
--- a/.changeset/two-crabs-smoke.md
+++ b/.changeset/two-crabs-smoke.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix: MCPClient.listResources now returns the raw MCP `resources/list` response.

--- a/packages/core/src/mcp/client/index.spec.ts
+++ b/packages/core/src/mcp/client/index.spec.ts
@@ -616,7 +616,20 @@ describe("MCPClient", () => {
       });
 
       mockRequest.mockResolvedValue({
-        resources: [{ id: "resource1" }, { id: "resource2" }, { id: 3 }],
+        resources: [
+          {
+            uri: "mcp://resource/1",
+            name: "resource1",
+            description: "Resource 1",
+            mimeType: "text/plain",
+          },
+          {
+            uri: "mcp://resource/2",
+            name: "resource2",
+            description: "Resource 2",
+            mimeType: "text/plain",
+          },
+        ],
       });
     });
 
@@ -624,8 +637,25 @@ describe("MCPClient", () => {
       const resources = await client.listResources();
 
       expect(mockConnect).toHaveBeenCalled();
-      expect(mockRequest).toHaveBeenCalledWith({ method: "resources/list" }, expect.any(Object));
-      expect(resources).toEqual(["resource1", "resource2", "3"]);
+      expect(mockRequest).toHaveBeenCalledWith({ method: "resources/list" }, expect.any(Object), {
+        timeout: expect.any(Number),
+      });
+      expect(resources).toEqual({
+        resources: [
+          {
+            uri: "mcp://resource/1",
+            name: "resource1",
+            description: "Resource 1",
+            mimeType: "text/plain",
+          },
+          {
+            uri: "mcp://resource/2",
+            name: "resource2",
+            description: "Resource 2",
+            mimeType: "text/plain",
+          },
+        ],
+      });
     });
 
     it("should handle errors when listing resources", async () => {

--- a/packages/core/src/mcp/client/index.ts
+++ b/packages/core/src/mcp/client/index.ts
@@ -12,6 +12,7 @@ import {
   ElicitRequestSchema,
   ListResourcesResultSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import type { ListResourcesResult } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "@voltagent/internal";
 import { z } from "zod";
 import { convertJsonSchemaToZod } from "zod-from-json-schema";
@@ -516,22 +517,17 @@ export class MCPClient extends SimpleEventEmitter {
   }
 
   /**
-   * Retrieves a list of resource identifiers available on the server.
-   * @returns A promise resolving to an array of resource ID strings.
+   * Retrieves a list of resources available on the server.
+   * @returns A promise resolving to the MCP resources list response.
    */
-  async listResources(): Promise<string[]> {
+  async listResources(): Promise<ListResourcesResult> {
     // Renamed back from fetchAvailableResourceIds
     await this.ensureConnected(); // Use original connection check name
 
     try {
-      const result = await this.client.request(
-        { method: "resources/list" },
-        ListResourcesResultSchema,
-      );
-
-      return result.resources.map((resource: Record<string, unknown>) =>
-        typeof resource.id === "string" ? resource.id : String(resource.id),
-      );
+      return await this.client.request({ method: "resources/list" }, ListResourcesResultSchema, {
+        timeout: this.timeout,
+      });
     } catch (error) {
       this.emitError(error);
       throw error;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
MCPClient.listResources now returns the raw MCP resources/list response with full resource metadata instead of an array of IDs. This aligns with the MCP spec and supports clients needing uri, name, description, and mimeType.

- **Bug Fixes**
  - Return type changed to ListResourcesResult (raw response) and request now uses the configured timeout.
  - Updated tests to assert the full response structure; removed ID mapping.
  - Added a changeset to release a patch for @voltagent/core.

- **Migration**
  - Update callers to read result.resources and use fields like uri, name, description, and mimeType instead of string IDs.

<sup>Written for commit 88f3223a7f45853229bfff463f74058c9707b436. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* MCPClient.listResources now returns the complete MCP resource list response with full resource objects including uri, name, description, and mimeType properties, instead of just resource identifiers. This provides applications with comprehensive resource metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->