### PR TITLE
fix: surface resolved model ids for dynamic models in execution logs …

### DIFF
--- a/.changeset/bright-singers-fold.md
+++ b/.changeset/bright-singers-fold.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix: surface resolved model ids for dynamic models in execution logs and spans.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -561,7 +561,7 @@ export class Agent {
           options,
         );
 
-        const modelName = this.getModelName();
+        const modelName = this.getModelName(model);
         const contextLimit = options?.contextLimit;
 
         // Add model attributes and all options
@@ -960,7 +960,7 @@ export class Agent {
           options,
         );
 
-        const modelName = this.getModelName();
+        const modelName = this.getModelName(model);
         const contextLimit = options?.contextLimit;
 
         // Add model attributes to root span if TraceContext exists
@@ -1102,7 +1102,7 @@ export class Agent {
             methodLogger.error("Stream error occurred", {
               error: actualError,
               agentName: this.name,
-              modelName: this.getModelName(),
+              modelName,
             });
 
             finalizeLLMSpan(SpanStatusCode.ERROR, { message: (actualError as Error)?.message });
@@ -1683,7 +1683,7 @@ export class Agent {
           options,
         );
 
-        const modelName = this.getModelName();
+        const modelName = this.getModelName(model);
         const schemaName = schema.description || "unknown";
 
         // Add model attributes and all options
@@ -1918,7 +1918,7 @@ export class Agent {
           options,
         );
 
-        const modelName = this.getModelName();
+        const modelName = this.getModelName(model);
         const schemaName = schema.description || "unknown";
 
         // Add model attributes and all options
@@ -2010,7 +2010,7 @@ export class Agent {
             methodLogger.error("Stream object error occurred", {
               error: actualError,
               agentName: this.name,
-              modelName: this.getModelName(),
+              modelName,
               schemaName: schemaName,
             });
 
@@ -4169,9 +4169,16 @@ export class Agent {
   }
 
   /**
-   * Get the model name
+   * Get the model name.
+   * Pass a resolved model to return its modelId (useful for dynamic models).
    */
-  public getModelName(): string {
+  public getModelName(model?: LanguageModel | string): string {
+    if (model) {
+      if (typeof model === "string") {
+        return model;
+      }
+      return model.modelId || "unknown";
+    }
     if (typeof this.model === "function") {
       return "dynamic";
     }


### PR DESCRIPTION
…and spans

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure execution logs and tracing spans show the resolved model ID for dynamic models instead of the generic "dynamic", improving observability and error context.

- **Bug Fixes**
  - Pass the resolved model to getModelName to surface modelId in logs and spans.
  - getModelName now accepts a model or string and returns model.modelId (falls back to "unknown").
  - Error logs use the computed modelName to avoid the "dynamic" placeholder.

<sup>Written for commit 2035c5ecfac1f54ea8265bd81a7a9a65c3a7883f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution logs and spans to display resolved model IDs for dynamic models, enhancing observability and debugging visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->