### PR TITLE
fix: expose step-level retries typing in workflow chains

### DIFF
--- a/.changeset/stupid-pens-create.md
+++ b/.changeset/stupid-pens-create.md
@@ -1,0 +1,29 @@
+---
+"@voltagent/core": patch
+---
+
+fix: expose step-level retries typing in workflow chains
+
+Type definitions now include `retries` and `retryCount` for `andThen` and `andTap`, matching the runtime behavior.
+
+```ts
+import { createWorkflowChain } from "@voltagent/core";
+
+createWorkflowChain({ id: "retry-demo" })
+  .andThen({
+    id: "fetch-user",
+    retries: 2,
+    execute: async ({ data, retryCount }) => {
+      if (retryCount && retryCount < 2) {
+        throw new Error("transient");
+      }
+      return { ...data, ok: true };
+    },
+  })
+  .andTap({
+    id: "audit",
+    execute: async ({ data, retryCount }) => {
+      console.log("tap", retryCount, data);
+    },
+  });
+```

--- a/packages/core/src/workflow/chain.ts
+++ b/packages/core/src/workflow/chain.ts
@@ -217,12 +217,14 @@ export class WorkflowChain<
         suspendData?: SS extends z.ZodTypeAny ? z.infer<SS> : z.infer<SUSPEND_SCHEMA>,
       ) => Promise<never>;
       resumeData?: RS extends z.ZodTypeAny ? z.infer<RS> : z.infer<RESUME_SCHEMA>;
+      retryCount?: number;
       logger: Logger;
       writer: WorkflowStreamWriter;
     }) => Promise<z.infer<OS>>;
     id: string;
     name?: string;
     purpose?: string;
+    retries?: number;
   }): WorkflowChain<INPUT_SCHEMA, RESULT_SCHEMA, z.infer<OS>, SUSPEND_SCHEMA, RESUME_SCHEMA>;
 
   /**
@@ -249,12 +251,14 @@ export class WorkflowChain<
         suspendData?: SS extends z.ZodTypeAny ? z.infer<SS> : z.infer<SUSPEND_SCHEMA>,
       ) => Promise<never>;
       resumeData?: RS extends z.ZodTypeAny ? z.infer<RS> : z.infer<RESUME_SCHEMA>;
+      retryCount?: number;
       logger: Logger;
       writer: WorkflowStreamWriter;
     }) => Promise<NEW_DATA>;
     id: string;
     name?: string;
     purpose?: string;
+    retries?: number;
   }): WorkflowChain<INPUT_SCHEMA, RESULT_SCHEMA, NEW_DATA, SUSPEND_SCHEMA, RESUME_SCHEMA>;
 
   /**
@@ -280,12 +284,14 @@ export class WorkflowChain<
         suspendData?: SS extends z.ZodTypeAny ? z.infer<SS> : z.infer<SUSPEND_SCHEMA>,
       ) => Promise<never>;
       resumeData?: RS extends z.ZodTypeAny ? z.infer<RS> : z.infer<RESUME_SCHEMA>;
+      retryCount?: number;
       logger: Logger;
       writer: WorkflowStreamWriter;
     }) => Promise<z.infer<OS>>;
     id: string;
     name?: string;
     purpose?: string;
+    retries?: number;
   }): WorkflowChain<INPUT_SCHEMA, RESULT_SCHEMA, z.infer<OS>, SUSPEND_SCHEMA, RESUME_SCHEMA>;
 
   /**
@@ -311,12 +317,14 @@ export class WorkflowChain<
         suspendData?: SS extends z.ZodTypeAny ? z.infer<SS> : z.infer<SUSPEND_SCHEMA>,
       ) => Promise<never>;
       resumeData?: z.infer<RS>;
+      retryCount?: number;
       logger: Logger;
       writer: WorkflowStreamWriter;
     }) => Promise<NEW_DATA>;
     id: string;
     name?: string;
     purpose?: string;
+    retries?: number;
   }): WorkflowChain<INPUT_SCHEMA, RESULT_SCHEMA, NEW_DATA, SUSPEND_SCHEMA, RESUME_SCHEMA>;
 
   /**
@@ -351,12 +359,14 @@ export class WorkflowChain<
       getStepData: (stepId: string) => WorkflowStepData | undefined;
       suspend: (reason?: string, suspendData?: z.infer<SUSPEND_SCHEMA>) => Promise<never>;
       resumeData?: z.infer<RESUME_SCHEMA>;
+      retryCount?: number;
       logger: Logger;
       writer: WorkflowStreamWriter;
     }) => Promise<NEW_DATA>;
     id: string;
     name?: string;
     purpose?: string;
+    retries?: number;
     inputSchema?: never;
     outputSchema?: never;
     suspendSchema?: z.ZodTypeAny;
@@ -493,12 +503,14 @@ export class WorkflowChain<
         suspendData?: SS extends z.ZodTypeAny ? z.infer<SS> : z.infer<SUSPEND_SCHEMA>,
       ) => Promise<never>;
       resumeData?: RS extends z.ZodTypeAny ? z.infer<RS> : z.infer<RESUME_SCHEMA>;
+      retryCount?: number;
       logger: Logger;
       writer: WorkflowStreamWriter;
     }) => Promise<void>;
     id: string;
     name?: string;
     purpose?: string;
+    retries?: number;
   }): WorkflowChain<INPUT_SCHEMA, RESULT_SCHEMA, CURRENT_DATA, SUSPEND_SCHEMA, RESUME_SCHEMA>;
 
   /**
@@ -532,12 +544,14 @@ export class WorkflowChain<
       getStepData: (stepId: string) => WorkflowStepData | undefined;
       suspend: (reason?: string, suspendData?: z.infer<SUSPEND_SCHEMA>) => Promise<never>;
       resumeData?: z.infer<RESUME_SCHEMA>;
+      retryCount?: number;
       logger: Logger;
       writer: WorkflowStreamWriter;
     }) => Promise<void>;
     id: string;
     name?: string;
     purpose?: string;
+    retries?: number;
     inputSchema?: never;
     suspendSchema?: z.ZodTypeAny;
     resumeSchema?: z.ZodTypeAny;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposed step-level retries in TypeScript for workflow chains. andThen/andTap now type retryCount in the execute context and retries in step config, matching runtime behavior.

- **Bug Fixes**
  - Added retryCount?: number to the execute context for andThen/andTap.
  - Added retries?: number to step definitions.
  - Updated WorkflowChain overloads to propagate these types; no runtime changes.

<sup>Written for commit 03cad16c95d1ea91ddf0507d1e5d5ab62f250c81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added step-level retry configuration to workflow chains. Developers can now specify retry behavior for individual workflow steps using the new `retries` and `retryCount` properties. Retry functionality is available across all step types, enabling more resilient and flexible workflow definitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->