### PR TITLE
fix: export workflow step and hook types from the core entrypoint - #939

### DIFF
--- a/.changeset/bright-dingos-grab.md
+++ b/.changeset/bright-dingos-grab.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix: export workflow step and hook types from the core entrypoint - #939

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,7 +25,12 @@ export type {
 export type {
   Workflow,
   WorkflowConfig,
+  WorkflowHookContext,
+  WorkflowHookStatus,
+  WorkflowHooks,
   WorkflowStats,
+  WorkflowStepData,
+  WorkflowStepStatus,
   WorkflowTimelineEvent,
   RegisteredWorkflow,
 } from "./workflow";

--- a/packages/core/src/workflow/index.ts
+++ b/packages/core/src/workflow/index.ts
@@ -26,6 +26,7 @@ export type {
   Workflow,
   WorkflowHookContext,
   WorkflowHookStatus,
+  WorkflowHooks,
   WorkflowRetryConfig,
   WorkflowRunOptions,
   WorkflowResumeOptions,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)
- #939 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export missing workflow step and hook types from @voltagent/core’s entrypoint so consumers can import them directly. Fixes #939.

- **Bug Fixes**
  - Added exports for WorkflowHookContext, WorkflowHookStatus, WorkflowHooks, WorkflowStepData, and WorkflowStepStatus from the core index.

<sup>Written for commit 4b4dcca4d7e217d3b60c701e65dead83a189cb7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow-related type definitions are now exported from the core package, including hook context, hook status, hooks configuration, step data, and step status types. This provides enhanced type support for developers integrating workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->