### PR TITLE
feat: planagent supports dynamic systemPrompt functions with prompt m…

### DIFF
--- a/.changeset/spicy-actors-study.md
+++ b/.changeset/spicy-actors-study.md
@@ -1,0 +1,45 @@
+---
+"@voltagent/core": patch
+---
+
+feat: PlanAgent supports dynamic systemPrompt functions with prompt merging
+
+### What's New
+
+- `systemPrompt` can now be a function that resolves per request (string or VoltOps prompt payload).
+- Base PlanAgent instructions and extension prompts are appended consistently for dynamic prompts.
+
+### Usage
+
+```ts
+import { PlanAgent } from "@voltagent/core";
+import { openai } from "@ai-sdk/openai";
+
+const agent = new PlanAgent({
+  name: "DynamicPlanner",
+  model: openai("gpt-4o"),
+  systemPrompt: async ({ context }) => {
+    const tenant = context.get("tenant") ?? "default";
+    return `Tenant: ${tenant}. Keep answers concise.`;
+  },
+});
+
+const context = new Map<string | symbol, unknown>();
+context.set("tenant", "acme");
+
+const result = await agent.generateText("Summarize the roadmap", { context });
+console.log(result.text);
+```
+
+Chat-style prompt support:
+
+```ts
+const agent = new PlanAgent({
+  name: "DynamicChatPlanner",
+  model: openai("gpt-4o"),
+  systemPrompt: async () => ({
+    type: "chat",
+    messages: [{ role: "system", content: "You are a precise planner." }],
+  }),
+});
+```

--- a/packages/core/src/planagent/plan-agent.spec.ts
+++ b/packages/core/src/planagent/plan-agent.spec.ts
@@ -12,6 +12,8 @@ const expectedTools = [
   "grep",
   "task",
 ];
+const basePromptSnippet =
+  "In order to complete the objective that the user asks of you, you have access to a number of standard tools.";
 
 describe("PlanAgent", () => {
   it("registers planning, filesystem, and task tools by default", () => {
@@ -36,5 +38,76 @@ describe("PlanAgent", () => {
 
     const toolNames = agent.getTools().map((tool) => tool.name);
     expect(toolNames).not.toContain("task");
+  });
+
+  it("resolves dynamic systemPrompt with base and extension prompts", async () => {
+    const extensionPrompt = "Extra system prompt.";
+    const agent = new PlanAgent({
+      name: "plan-agent-dynamic",
+      model: createMockLanguageModel(),
+      systemPrompt: ({ context }) => `Tenant: ${context.get("tenant")}`,
+      extensions: [
+        {
+          name: "extra-prompt",
+          apply: () => ({ systemPrompt: extensionPrompt }),
+        },
+      ],
+    });
+
+    expect(typeof agent.instructions).toBe("function");
+
+    const resolved = await (agent.instructions as any)({
+      context: new Map<string | symbol, unknown>([["tenant", "acme"]]),
+      prompts: {
+        getPrompt: async () => ({ type: "text", text: "unused" }),
+      },
+    });
+
+    expect(typeof resolved).toBe("string");
+    const resolvedText = resolved as string;
+
+    expect(resolvedText).toContain("Tenant: acme");
+    expect(resolvedText).toContain(basePromptSnippet);
+    expect(resolvedText).toContain(extensionPrompt);
+    expect(resolvedText.indexOf("Tenant: acme")).toBeLessThan(
+      resolvedText.indexOf(basePromptSnippet),
+    );
+    expect(resolvedText.indexOf(basePromptSnippet)).toBeLessThan(
+      resolvedText.indexOf(extensionPrompt),
+    );
+  });
+
+  it("appends base prompt to dynamic chat system messages", async () => {
+    const extensionPrompt = "Extra system prompt.";
+    const agent = new PlanAgent({
+      name: "plan-agent-dynamic-chat",
+      model: createMockLanguageModel(),
+      systemPrompt: async () => ({
+        type: "chat",
+        messages: [{ role: "system", content: "Core chat prompt." }],
+      }),
+      extensions: [
+        {
+          name: "extra-prompt",
+          apply: () => ({ systemPrompt: extensionPrompt }),
+        },
+      ],
+    });
+
+    const resolved = await (agent.instructions as any)({
+      context: new Map<string | symbol, unknown>(),
+      prompts: {
+        getPrompt: async () => ({ type: "text", text: "unused" }),
+      },
+    });
+
+    expect(resolved).toMatchObject({ type: "chat" });
+    const messages = (resolved as any).messages as Array<{ role: string; content: unknown }>;
+    const systemMessage = [...messages].reverse().find((message) => message.role === "system");
+
+    expect(systemMessage).toBeDefined();
+    expect(systemMessage?.content).toContain("Core chat prompt.");
+    expect(systemMessage?.content).toContain(basePromptSnippet);
+    expect(systemMessage?.content).toContain(extensionPrompt);
   });
 });

--- a/website/docs/agents/plan-agent.md
+++ b/website/docs/agents/plan-agent.md
@@ -65,6 +65,42 @@ const result = await agent.generateText("What is VoltAgent?");
 console.log(result.text);
 ```
 
+## Dynamic systemPrompt
+
+`systemPrompt` can be a function that resolves per request. It receives `{ context, prompts }` and can return a string or a VoltOps prompt payload.
+
+```ts
+const agent = new PlanAgent({
+  name: "DynamicPlanner",
+  model: openai("gpt-4o"),
+  systemPrompt: async ({ context }) => {
+    const tenant = context.get("tenant") ?? "default";
+    return `Tenant: ${tenant}. Keep answers concise.`;
+  },
+});
+
+const context = new Map<string | symbol, unknown>();
+context.set("tenant", "acme");
+
+const result = await agent.generateText("Summarize the roadmap", { context });
+console.log(result.text);
+```
+
+If you return a chat prompt:
+
+```ts
+const agent = new PlanAgent({
+  name: "DynamicChatPlanner",
+  model: openai("gpt-4o"),
+  systemPrompt: async () => ({
+    type: "chat",
+    messages: [{ role: "system", content: "You are a precise planner." }],
+  }),
+});
+```
+
+PlanAgent still appends its base prompt and any extension prompts.
+
 ## Built-in capabilities
 
 ### Planning with write_todos
@@ -230,6 +266,7 @@ const agent = new PlanAgent({
 
 ## Configuration reference (high-level)
 
+- `systemPrompt`: static string or dynamic function for per-request prompts
 - `planning`: configure or disable planning (`write_todos`)
 - `filesystem`: configure backend and tool prompts
 - `task`: configure task tool prompts and limits


### PR DESCRIPTION
…erging

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
PlanAgent now supports dynamic systemPrompt functions that resolve per request and merge correctly with base and extension prompts. This makes per-request customization easy and consistent for both text and chat prompts.

- **New Features**
  - systemPrompt can be a function returning a string or VoltOps prompt payload; base PlanAgent prompt and extension prompts are merged in order.
  - Chat prompts get the base and extension prompts appended to the last system message (or added if none).
  - Added tests, docs, and a changeset; no breaking changes.

<sup>Written for commit 3f42f7905fad2910a186c07a79e9b36d8f2c5920. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PlanAgent systemPrompt can now be dynamically defined as a per-request function, returning either a string or a VoltOps prompt payload. Base and extension prompts are automatically appended.

* **Documentation**
  * Added comprehensive examples and configuration guide for the new dynamic systemPrompt feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->