### PR TITLE
fix: prevent workflow failures from observability flush concurrency l…

### DIFF
--- a/.changeset/fancy-bears-show.md
+++ b/.changeset/fancy-bears-show.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix: prevent workflow failures from observability flush concurrency limits by serializing flushes and defaulting to serverless-only flush in auto mode

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -25,6 +25,13 @@ export interface ObservabilityConfig {
   logger?: Logger;
   resourceAttributes?: Record<string, any>;
   spanFilters?: SpanFilterConfig;
+  /**
+   * Controls whether flushOnFinish() runs automatically.
+   * - "auto": flush only in serverless (default)
+   * - "always": always flush
+   * - "never": never flush
+   */
+  flushOnFinishStrategy?: "auto" | "always" | "never";
   voltOpsSync?: {
     sampling?: ObservabilitySamplingConfig;
     // BatchSpanProcessor configuration


### PR DESCRIPTION
…imits by serializing flushes

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize observability flushes and default to serverless-only flush in auto mode to prevent workflow failures caused by exporter concurrency limits. Flush errors no longer fail workflows.

- **Bug Fixes**
  - Serialize flush operations with a lock in node and serverless observability to avoid concurrency violations.
  - Wrap workflow flush calls with safeFlushOnFinish to swallow flush errors and keep executions stable.

- **New Features**
  - Added ObservabilityConfig.flushOnFinishStrategy: "auto" (default, serverless-only), "always", "never".
  - In "auto", use platform waitUntil to flush in the background when available; otherwise flush synchronously.

<sup>Written for commit 43379cd0f43c34b02374438308642dfc11cb2957. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable flush strategy option ("auto", "always", "never") for observability behavior.

* **Bug Fixes**
  * Serialized observability flushes to prevent workflow failures due to concurrency limits.
  * Made flush errors non-critical to prevent workflow interruptions.
  * Defaulted to serverless-only flush in auto mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->