### PR TITLE
feat: allow PlanAgent task tool to forward subagent stream events via…

### DIFF
--- a/.changeset/planagent-task-stream-forwarding.md
+++ b/.changeset/planagent-task-stream-forwarding.md
@@ -1,0 +1,22 @@
+---
+"@voltagent/core": patch
+---
+
+feat: allow PlanAgent task tool to forward subagent stream events via supervisorConfig
+
+Example:
+
+```ts
+const agent = new PlanAgent({
+  name: "Supervisor",
+  systemPrompt: "Delegate when helpful.",
+  model: "openai/gpt-4o",
+  task: {
+    supervisorConfig: {
+      fullStreamEventForwarding: {
+        types: ["tool-call", "tool-result", "text-delta"],
+      },
+    },
+  },
+});
+```

--- a/packages/core/src/planagent/plan-agent.ts
+++ b/packages/core/src/planagent/plan-agent.ts
@@ -8,7 +8,12 @@ import { FORCED_TOOL_CHOICE_CONTEXT_KEY } from "../agent/context-keys";
 import type { AgentHooks } from "../agent/hooks";
 import { SubAgentManager } from "../agent/subagent";
 import type { SubAgentConfig } from "../agent/subagent/types";
-import type { AgentOptions, InstructionsDynamicValue, OperationContext } from "../agent/types";
+import type {
+  AgentOptions,
+  InstructionsDynamicValue,
+  OperationContext,
+  SupervisorConfig,
+} from "../agent/types";
 import type { Tool, VercelTool } from "../tool";
 import { createTool } from "../tool";
 import type { Toolkit } from "../tool/toolkit";
@@ -113,6 +118,7 @@ export type TaskToolOptions = {
   systemPrompt?: string | null;
   taskDescription?: string | null;
   maxSteps?: number;
+  supervisorConfig?: SupervisorConfig;
 };
 
 export type PlanAgentOptions = Omit<
@@ -673,6 +679,7 @@ function createTaskToolkit(options: {
   const subAgentManager = new SubAgentManager(
     sourceAgent.name,
     subagents.map((s) => s.config),
+    taskOptions?.supervisorConfig,
   );
   const subagentDescriptions = subagents.map(
     (subagent) => `${subagent.name}: ${subagent.description}`,

--- a/website/docs/agents/plan-agent.md
+++ b/website/docs/agents/plan-agent.md
@@ -185,6 +185,23 @@ const agent = new PlanAgent({
 });
 ```
 
+To forward subagent stream events when you call `planAgent.streamText(...)`, configure the task's supervisor config:
+
+```ts
+const agent = new PlanAgent({
+  name: "Supervisor",
+  systemPrompt: "Delegate when helpful.",
+  model: "openai/gpt-4o",
+  task: {
+    supervisorConfig: {
+      fullStreamEventForwarding: {
+        types: ["tool-call", "tool-result", "text-delta"],
+      },
+    },
+  },
+});
+```
+
 PlanAgent also adds a default `general-purpose` subagent unless you disable it:
 
 ```ts


### PR DESCRIPTION
… supervisorConfig

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable forwarding of subagent stream events in PlanAgent via task.supervisorConfig. Calling planAgent.streamText can now emit subagent tool-call, tool-result, and text-delta events.

- **New Features**
  - Added task.supervisorConfig with fullStreamEventForwarding.types to pass through subagent events (e.g., ["tool-call", "tool-result", "text-delta"]).
  - Connected supervisorConfig to SubAgentManager and updated docs with usage example.

<sup>Written for commit 4f342645f36d9af1671fcacfb413435c7fd50f66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PlanAgent task tool now supports forwarding subagent stream events through supervisor configuration, with configurable event types (tool-call, tool-result, text-delta).

* **Documentation**
  * Added comprehensive guidance and examples showing how to enable stream event forwarding in PlanAgent initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->