### PR TITLE
fix: allow `andAgent` schema to accept `Output.*` specs (arrays, choi…

### DIFF
--- a/.changeset/tall-dryers-run.md
+++ b/.changeset/tall-dryers-run.md
@@ -1,0 +1,32 @@
+---
+"@voltagent/core": patch
+---
+
+fix: allow `andAgent` schema to accept `Output.*` specs (arrays, choices, json, text)
+
+`andAgent` now supports the same output flexibility as `agent.generateText`, so you can return non-object
+structures from workflow steps.
+
+Usage:
+
+```ts
+import { Output } from "ai";
+import { z } from "zod";
+import { Agent, createWorkflowChain } from "@voltagent/core";
+
+const agent = new Agent({
+  name: "Tagger",
+  model: "openai/gpt-4o-mini",
+  instructions: "Return tags only.",
+});
+
+const workflow = createWorkflowChain({
+  id: "tag-workflow",
+  input: z.object({ topic: z.string() }),
+}).andAgent(async ({ data }) => `List tags for ${data.topic}`, agent, {
+  schema: Output.array({ element: z.string() }),
+});
+
+const result = await workflow.run({ topic: "workflows" });
+// result: string[]
+```

--- a/packages/core/src/workflow/chain.spec-d.ts
+++ b/packages/core/src/workflow/chain.spec-d.ts
@@ -1,3 +1,4 @@
+import { Output } from "ai";
 import { describe, expectTypeOf, it } from "vitest";
 import { z } from "zod";
 import type { Agent } from "../agent/agent";
@@ -437,6 +438,27 @@ describe("workflow chain - type inference", () => {
               keywords: string[];
             }>();
             return { analysis: `${data.sentiment}: ${data.keywords.join(", ")}` };
+          },
+        });
+
+      expectTypeOf(workflow).not.toBeNever();
+    });
+
+    it("should infer andAgent output from output specs", () => {
+      const workflow = createWorkflowChain({
+        id: "test-agent-output",
+        name: "Test Agent Output",
+        input: z.object({ prompt: z.string() }),
+        result: z.array(z.string()),
+      })
+        .andAgent(async ({ data }) => `List: ${data.prompt}`, mockAgent, {
+          schema: Output.array({ element: z.string() }),
+        })
+        .andThen({
+          id: "ensure-array",
+          execute: async ({ data }) => {
+            expectTypeOf(data).toEqualTypeOf<string[]>();
+            return data;
           },
         });
 


### PR DESCRIPTION
…ces, json, text)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

- #964 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
andAgent now accepts ai-sdk Output.* specs (array, choice, json, text) as schemas, not just Zod objects. This fixes #964 and enables non-object step outputs with correct type inference.

- **Bug Fixes**
  - Accept Output.* directly; Zod schemas are wrapped with Output.object automatically.
  - Added AgentOutputSchema, InferAgentOutput, and updated AgentConfig to preserve types across the chain and map.
  - Tests cover non-object outputs; docs include array/choice examples.

<sup>Written for commit 087f722f4a6e93dd63795a68c84b2e91a0fc6660. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * andAgent now supports Output.* specs (arrays, choices, json, text) alongside Zod schemas, enabling flexible non-object output structures in workflow steps and matching agent.generateText flexibility

* **Documentation**
  * Updated andAgent documentation with expanded examples demonstrating arrays, choices, and Output.* specification patterns for structured workflow outputs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->