### PR TITLE
feat: allow `runExperiment` to accept a `VoltOpsClient` directly

### DIFF
--- a/.changeset/clear-signs-cry.md
+++ b/.changeset/clear-signs-cry.md
@@ -1,0 +1,21 @@
+---
+"@voltagent/evals": patch
+---
+
+feat: allow `runExperiment` to accept a `VoltOpsClient` directly by adapting it for dataset resolution when needed.
+
+```ts
+import { VoltOpsClient } from "@voltagent/sdk";
+import { runExperiment } from "@voltagent/evals";
+import experiment from "./experiments/support-nightly.experiment";
+
+const voltOpsClient = new VoltOpsClient({
+  publicKey: process.env.VOLTAGENT_PUBLIC_KEY,
+  secretKey: process.env.VOLTAGENT_SECRET_KEY,
+});
+
+const result = await runExperiment(experiment, {
+  voltOpsClient,
+  concurrency: 4,
+});
+```

--- a/examples/with-offline-evals/src/index.ts
+++ b/examples/with-offline-evals/src/index.ts
@@ -1,3 +1,4 @@
+import { VoltOpsClient } from "@voltagent/core";
 import { runExperiment } from "@voltagent/evals";
 import experiment from "./experiments/offline.experiment.js";
 
@@ -8,6 +9,7 @@ async function main() {
         const label = total !== undefined ? `${completed}/${total}` : `${completed}`;
         console.log(`[with-offline-evals] processed ${label} items`);
       },
+      voltOpsClient: new VoltOpsClient({}),
     });
 
     console.log(

--- a/website/evaluation-docs/offline-evaluations.md
+++ b/website/evaluation-docs/offline-evaluations.md
@@ -254,19 +254,19 @@ console.log("Summary:", {
 
 - `concurrency` - Number of items processed in parallel (default: 1)
 - `signal` - AbortSignal to cancel the run
-- `voltOpsClient` - VoltOps SDK instance for telemetry and cloud datasets
+- `voltOpsClient` - VoltOps client instance for telemetry and cloud datasets (VoltOpsClient or VoltOpsRestClient)
 - `onProgress` - Callback invoked after each item with `{ completed, total? }`
 - `onItem` - Callback invoked after each item with `{ index, item, result, summary }`
 
 Example with all options:
 
 ```ts
-import { VoltOpsRestClient } from "@voltagent/sdk";
+import { VoltOpsClient } from "@voltagent/sdk";
 
 const result = await runExperiment(experiment, {
   concurrency: 4,
   signal: abortController.signal,
-  voltOpsClient: new VoltOpsRestClient({
+  voltOpsClient: new VoltOpsClient({
     publicKey: process.env.VOLTAGENT_PUBLIC_KEY,
     secretKey: process.env.VOLTAGENT_SECRET_KEY,
   }),

--- a/website/evaluation-docs/overview.md
+++ b/website/evaluation-docs/overview.md
@@ -100,11 +100,11 @@ npm run volt eval run \
 ```
 
 ```ts title="Node script"
-import { VoltOpsRestClient } from "@voltagent/sdk";
+import { VoltOpsClient } from "@voltagent/core";
 import { runExperiment } from "@voltagent/evals";
 import experiment from "./experiments/support-nightly.experiment";
 
-const voltOpsClient = new VoltOpsRestClient({
+const voltOpsClient = new VoltOpsClient({
   publicKey: process.env.VOLTAGENT_PUBLIC_KEY,
   secretKey: process.env.VOLTAGENT_SECRET_KEY,
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow runExperiment to accept a VoltOpsClient directly for cloud dataset resolution and telemetry, so you don’t need to initialize a separate REST client. Docs and examples updated to show the new usage.

- **New Features**
  - Accepts VoltOpsClient or VoltOpsRestClient via voltOpsClient.
  - Automatically adapts the client to resolve cloud datasets when a dataset id/name is provided.
  - Updated docs and examples to use VoltOpsClient in offline and overview guides.

- **Refactors**
  - Introduced VoltOpsDatasetClient interface and a type guard for dataset clients.
  - Centralized client coercion and dataset resolver attachment in runExperiment.

<sup>Written for commit 61cee96ea2a006110adb8adebbce67e4c0b7a72f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `runExperiment` now accepts an optional `voltOpsClient` parameter in the configuration object, enabling direct dataset resolution.

* **Documentation**
  * Updated examples and guides demonstrating the new `voltOpsClient` configuration option for offline evaluations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->