### PR TITLE
feat(voice): add scribe_v2 to eleventlabs models and change to default

### DIFF
--- a/.changeset/wild-regions-kneel.md
+++ b/.changeset/wild-regions-kneel.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/voice": minor
+---
+
+feat(voice): add scribe_v2 to eleventlabs models and change to default
+
+Added scribe_v2 elevenlabs model
+
+Resolves #1004

--- a/examples/with-voice-elevenlabs/src/index.ts
+++ b/examples/with-voice-elevenlabs/src/index.ts
@@ -17,7 +17,7 @@ const voiceProvider = new ElevenLabsVoiceProvider({
   apiKey: process.env.ELEVENLABS_API_KEY || "",
   voice: "Adam", // Default voice, you can change to any available voice
   ttsModel: "eleven_multilingual_v2",
-  speechModel: "scribe_v1",
+  speechModel: "scribe_v2",
   options: {
     stability: 0.5,
     similarityBoost: 0.75,

--- a/packages/voice/src/providers/elevenlabs/index.ts
+++ b/packages/voice/src/providers/elevenlabs/index.ts
@@ -14,7 +14,7 @@ export class ElevenLabsVoiceProvider extends BaseVoiceProvider {
 
   constructor(options: ElevenLabsVoiceOptions) {
     super(options);
-    this.speechModel = options.speechModel || "scribe_v1";
+    this.speechModel = options.speechModel || "scribe_v2";
     this.ttsModel = options.ttsModel || "eleven_multilingual_v2";
     this.voice = options.voice || "Callum";
     this.voiceSettings = {

--- a/packages/voice/src/providers/elevenlabs/types.ts
+++ b/packages/voice/src/providers/elevenlabs/types.ts
@@ -7,6 +7,7 @@ export const ELEVENLABS_MODELS = [
   "eleven_multilingual_sts_v2",
   "eleven_english_sts_v2",
   "scribe_v1",
+  "scribe_v2",
 ] as const;
 
 export type ElevenLabsModel = (typeof ELEVENLABS_MODELS)[number];
@@ -22,7 +23,7 @@ export type ElevenLabsVoiceOptions = BaseVoiceProviderOptions & {
 
   /**
    * Model to use for speech recognition
-   * @default "scribe_v1"
+   * @default "scribe_v2"
    */
   speechModel?: ElevenLabsModel;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scribe_v2 to ElevenLabs models and makes it the default speech recognition model to improve transcription. Updates the ElevenLabs example to use scribe_v2 and resolves #1004.

<sup>Written for commit 8dd47d643cac694c1b2c4e7960f337d75238f5c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the scribe_v2 ElevenLabs voice model, now set as the default option for voice synthesis.

* **Documentation**
  * Updated documentation reflecting the new model availability.

* **Chores**
  * Bumped minor version for the voice package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->