### PR TITLE
fix SQL query to fetch latest messages instead of earliest

### DIFF
--- a/.changeset/icy-heads-invent.md
+++ b/.changeset/icy-heads-invent.md
@@ -1,0 +1,8 @@
+---
+"@voltagent/cloudflare-d1": major
+"@voltagent/postgres": major
+"@voltagent/supabase": major
+"@voltagent/libsql": major
+---
+
+The SQL statement has been modified. Previously, the query returned the earliest messages instead of the most recent ones.

--- a/.changeset/icy-heads-invent.md
+++ b/.changeset/icy-heads-invent.md
@@ -1,8 +1,8 @@
 ---
-"@voltagent/cloudflare-d1": major
-"@voltagent/postgres": major
-"@voltagent/supabase": major
-"@voltagent/libsql": major
+"@voltagent/cloudflare-d1": minor
+"@voltagent/postgres": minor
+"@voltagent/supabase": minor
+"@voltagent/libsql": minor
 ---
 
 The SQL statement has been modified. Previously, the query returned the earliest messages instead of the most recent ones.

--- a/packages/cloudflare-d1/src/memory-adapter.ts
+++ b/packages/cloudflare-d1/src/memory-adapter.ts
@@ -615,8 +615,9 @@ export class D1MemoryAdapter implements StorageAdapter {
     const messagesTable = `${this.tablePrefix}_messages`;
     const { limit, before, after, roles } = options || {};
 
-    let sql = `SELECT * FROM ${messagesTable}
-               WHERE conversation_id = ? AND user_id = ?`;
+    let sql = `SELECT * FROM (
+             SELECT * FROM ${messagesTable}
+             WHERE conversation_id = ? AND user_id = ?`;
     const args: unknown[] = [conversationId, userId];
 
     if (roles && roles.length > 0) {
@@ -635,11 +636,13 @@ export class D1MemoryAdapter implements StorageAdapter {
       args.push(after.toISOString());
     }
 
-    sql += " ORDER BY created_at ASC";
+    sql += " ORDER BY created_at DESC";
     if (limit && limit > 0) {
       sql += " LIMIT ?";
       args.push(limit);
     }
+
+    sql += " ) AS subq ORDER BY created_at ASC";
 
     const rows = await this.all<D1Row>(sql, args);
 

--- a/packages/postgres/src/memory-adapter.ts
+++ b/packages/postgres/src/memory-adapter.ts
@@ -515,8 +515,9 @@ export class PostgreSQLMemoryAdapter implements StorageAdapter {
       });
 
       // Build query with filters - use SELECT * to handle both old and new schemas safely
-      let sql = `SELECT * FROM ${messagesTable}
-                 WHERE conversation_id = $1 AND user_id = $2`;
+      let sql = `SELECT * FROM (
+             SELECT * FROM ${messagesTable}
+             WHERE conversation_id = $1 AND user_id = $2`;
       const params: any[] = [conversationId, userId];
       let paramCount = 3;
 
@@ -551,11 +552,13 @@ export class PostgreSQLMemoryAdapter implements StorageAdapter {
       }
 
       // Order by creation time and apply limit
-      sql += " ORDER BY created_at ASC";
+      sql += " ORDER BY created_at DESC";
       if (limit && limit > 0) {
         sql += ` LIMIT $${paramCount}`;
         params.push(limit);
       }
+
+      sql += " ) AS subq ORDER BY created_at ASC";
 
       // Debug: Final SQL and parameters
       this.log("Final SQL query:", sql);

--- a/packages/supabase/src/memory-adapter.ts
+++ b/packages/supabase/src/memory-adapter.ts
@@ -619,7 +619,7 @@ END OF MIGRATION SQL
     }
 
     // Order by creation time and apply limit
-    query = query.order("created_at", { ascending: true });
+    query = query.order("created_at", { ascending: false });
     if (limit && limit > 0) {
       query = query.limit(limit);
     }
@@ -631,7 +631,7 @@ END OF MIGRATION SQL
     }
 
     // Convert to UIMessages with on-the-fly migration for old format
-    return (data || []).map((row) => {
+    return (data || []).reverse().map((row) => {
       // Determine parts based on whether we have new format (parts) or old format (content)
       let parts: any;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?
When contextLimit is set to 2, the system incorrectly retrieves the oldest two messages from the conversation history instead of the most recent two. This causes the model to miss relevant context from the latest interactions.

For example, with the following sequence:
1. "hello, my name is tomoni"
2. "i like play game, recommand me some game"
3. "What is my name, and what I like to do"

The model correctly recalls the user's name (from message #1) but fails to recall the user's interest in games (from message #2), because only messages #1 and #2 are fetched—but due to incorrect SQL ordering, it actually fetches messages #1 and #2 as the first two, not the last two before the current query. In effect, when the third message arrives, the retrieved context should be messages #1 (the earliest message), but due to wrong sort order (ASC instead of DESC), it returns outdated or misordered context.

## What is the new behavior?
The SQL query used to fetch conversation history now correctly orders messages by timestamp in descending order and limits to the most recent contextLimit entries before the current message. This ensures that the model receives the latest relevant context.

Now, in the above example, the third query will correctly receive the second messages (in proper recency order), allowing the model to answer “what I like to do” not "What is my name"

fixes (issue)

## Notes for reviewers

The fix involves updating the ORDER BY clause in the SQL query used by memory adapters to sort by timestamp in DESC order before applying LIMIT.

Verified locally with SQLite and PostgreSQL adapters using the provided test sequence.

Note: The D1 and Supabase database adapters have been updated with the corrected query logic, but have not been manually tested due to environment constraints. The change is syntactically consistent with other adapters and follows the same pattern, so it should work as expected—but extra attention during review or CI validation is appreciated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes message fetching to return the most recent messages instead of the earliest, so contextLimit provides the latest context before the current message. Applies to Cloudflare D1, libsql, Postgres, and Supabase while keeping chronological output.

- **Bug Fixes**
  - Use ORDER BY created_at DESC with LIMIT in a subquery, then re-order ASC for response.
  - Updated adapters: Cloudflare D1, libsql, Postgres; Supabase orders DESC and reverses results.
  - Keeps roles, before, and after filters working as expected.

- **Migration**
  - Behavior change: context limits now return the latest messages; update tests or expectations that assumed oldest.
  - No schema changes.

<sup>Written for commit b98f8028afcc05b80407953a6ed31f66783b4f54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Revised message retrieval so recent messages are selected before final ordering — conversation lists now present messages in an updated chronological sequence (addresses inconsistent ordering across adapters).

* **Chores**
  * Minor version bumps for database adapter packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->