### PR TITLE
fix: align OpenAI reasoning metadata handling with AI SDK

### DIFF
--- a/.changeset/large-meals-create.md
+++ b/.changeset/large-meals-create.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/core": patch
+---
+
+fix: align OpenAI reasoning metadata handling with AI SDK
+
+- preserve non-reasoning OpenAI itemIds (e.g. msg*/fc*) when reasoning parts are absent
+- only strip reasoning-linked OpenAI metadata (rs\_/reasoning_trace_id/reasoning) when no reasoning context exists
+- include OpenAI reasoning itemId in ConversationBuffer signatures to avoid dropping distinct reasoning parts during merge

--- a/packages/core/src/agent/message-normalizer.spec.ts
+++ b/packages/core/src/agent/message-normalizer.spec.ts
@@ -189,7 +189,7 @@ describe("message-normalizer", () => {
       {
         type: "text",
         text: "final answer",
-        providerMetadata: { openai: { itemId: "msg_123" }, other: { keep: true } },
+        providerMetadata: { openai: { itemId: "rs_123" }, other: { keep: true } },
       } as any,
     ]);
 
@@ -206,7 +206,7 @@ describe("message-normalizer", () => {
       {
         type: "text",
         text: "final answer",
-        providerMetadata: { openai: { itemId: "msg_123" } },
+        providerMetadata: { openai: { itemId: "rs_123" } },
       } as any,
     ]);
     sanitized = sanitizeMessageForModel(message);
@@ -214,6 +214,25 @@ describe("message-normalizer", () => {
     expect(part).toEqual({
       type: "text",
       text: "final answer",
+    });
+  });
+
+  it("keeps non-reasoning OpenAI itemIds when no reasoning parts exist", () => {
+    const message = baseMessage([
+      {
+        type: "text",
+        text: "final answer",
+        providerMetadata: { openai: { itemId: "msg_123" } },
+      } as any,
+    ]);
+
+    const sanitized = sanitizeMessageForModel(message);
+    expect(sanitized).not.toBeNull();
+    const part = (sanitized as UIMessage).parts[0];
+    expect(part).toEqual({
+      type: "text",
+      text: "final answer",
+      providerMetadata: { openai: { itemId: "msg_123" } },
     });
   });
 
@@ -244,7 +263,7 @@ describe("message-normalizer", () => {
     expect(parts[0]).toEqual({ type: "text", text: "summary" });
   });
 
-  it("removes OpenAI metadata from tool parts when reasoning is absent", () => {
+  it("keeps non-reasoning OpenAI metadata on tool parts when reasoning is absent", () => {
     const message = baseMessage([
       {
         type: "tool-weather_lookup",
@@ -259,7 +278,10 @@ describe("message-normalizer", () => {
     const sanitized = sanitizeMessageForModel(message);
     expect(sanitized).not.toBeNull();
     const part = (sanitized as UIMessage).parts[0] as any;
-    expect(part.callProviderMetadata).toEqual({ other: { keep: true } });
+    expect(part.callProviderMetadata).toEqual({
+      openai: { itemId: "fc_123" },
+      other: { keep: true },
+    });
   });
 
   it("keeps OpenAI metadata on tool parts when reasoning is present", () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns OpenAI reasoning metadata handling with the AI SDK to prevent losing non-reasoning metadata and to keep distinct reasoning parts during merges. ConversationBuffer now includes the OpenAI reasoning itemId in part signatures, and the normalizer only strips reasoning-linked metadata when no reasoning context exists.

- **Bug Fixes**
  - Preserve non-reasoning OpenAI itemIds (msg*/fc*) when no reasoning parts exist.
  - Strip only reasoning-linked OpenAI fields (rs_*, reasoning_trace_id, reasoning) when reasoning is absent.
  - Include OpenAI reasoning itemId in ConversationBuffer signatures to avoid merging distinct reasoning parts.

<sup>Written for commit f7fd0ef37a68f030f401be62d23d0154df5efb5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenAI reasoning metadata to preserve distinct reasoning parts with unique identifiers during message processing and merging.
  * Enhanced preservation of non-reasoning provider identifiers when reasoning context is absent.
  * Refined metadata cleanup logic to maintain data integrity across reasoning and non-reasoning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->