### PR TITLE
fix: keep streaming message ids consistent with memory by emitting `m…

### DIFF
--- a/.changeset/quiet-rockets-work.md
+++ b/.changeset/quiet-rockets-work.md
@@ -1,0 +1,6 @@
+---
+"@voltagent/ag-ui": patch
+"@voltagent/core": patch
+---
+
+fix: keep streaming message ids consistent with memory by emitting `messageId` on start/start-step chunks and using it for UI stream mapping (leaving text-part ids intact).

--- a/packages/ag-ui/src/voltagent-agent.ts
+++ b/packages/ag-ui/src/voltagent-agent.ts
@@ -85,6 +85,9 @@ export class VoltAgentAGUI extends AbstractAgent {
 
           for await (const part of result.fullStream) {
             debugLog("fullStream part", { partType: part.type, id: (part as any).id });
+            if ((part.type === "start" || part.type === "start-step") && part.messageId) {
+              currentMessageId = part.messageId;
+            }
             const events = convertVoltStreamPartToEvents(part, currentMessageId);
             if (!events) continue;
 
@@ -393,10 +396,11 @@ function convertVoltStreamPartToEvents(
       return null;
     }
     case "text-delta": {
+      const messageId = part.messageId ?? fallbackMessageId;
       const event: TextMessageChunkEvent = {
         type: EventType.TEXT_MESSAGE_CHUNK,
         delta: part.text ?? "",
-        messageId: part.id ?? fallbackMessageId,
+        messageId,
         role: "assistant",
       };
       return [event];

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -682,6 +682,9 @@ describe("Agent", () => {
         })(),
         fullStream: (async function* () {
           yield {
+            type: "start" as const,
+          };
+          yield {
             type: "text-delta" as const,
             id: "text-1",
             delta: "Streamed response",
@@ -731,6 +734,14 @@ describe("Agent", () => {
       expect(typeof generatedId).toBe("string");
       expect(generatedId).not.toBe("");
       expect(callArgs?.generateMessageId()).toBe(generatedId);
+
+      const parts: any[] = [];
+      for await (const part of result.fullStream) {
+        parts.push(part);
+      }
+      expect(parts).toHaveLength(2);
+      expect(parts[0]).toEqual(expect.objectContaining({ type: "start", messageId: generatedId }));
+      expect(parts[1]).toEqual(expect.objectContaining({ type: "text-delta", id: "text-1" }));
     });
 
     it("uses last-step usage for finish events when provider is anthropic", async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1852,6 +1852,27 @@ export class Agent {
             generateMessageId: () => responseMessageId,
           };
         };
+        const applyResponseMessageIdToStream = (
+          baseStream: AsyncIterable<VoltAgentTextStreamPart>,
+        ): AsyncIterable<VoltAgentTextStreamPart> => {
+          if (!responseMessageId) {
+            return baseStream;
+          }
+          return (async function* () {
+            for await (const part of baseStream) {
+              if (part.type !== "start" && part.type !== "start-step") {
+                yield part;
+                continue;
+              }
+              const currentMessageId = (part as { messageId?: string }).messageId;
+              if (currentMessageId === responseMessageId) {
+                yield part;
+                continue;
+              }
+              yield { ...part, messageId: responseMessageId };
+            }
+          })();
+        };
 
         const createBaseFullStream = (): AsyncIterable<VoltAgentTextStreamPart> => {
           // Wrap the base stream with abort handling
@@ -1896,7 +1917,9 @@ export class Agent {
             }
           };
 
-          const parentStream = normalizeFinishUsageStream(wrapWithAbortHandling(result.fullStream));
+          const parentStream = applyResponseMessageIdToStream(
+            normalizeFinishUsageStream(wrapWithAbortHandling(result.fullStream)),
+          );
 
           if (agent.subAgentManager.hasSubAgents()) {
             const createMergedFullStream =

--- a/packages/core/src/agent/subagent/types.ts
+++ b/packages/core/src/agent/subagent/types.ts
@@ -140,6 +140,11 @@ export function createSubagent<TAgent extends Agent>(
 export type VoltAgentTextStreamPart<TOOLS extends Record<string, any> = Record<string, any>> =
   TextStreamPart<TOOLS> & {
     /**
+     * Optional response message identifier (carried on start/step chunks).
+     */
+    messageId?: string;
+
+    /**
      * Optional identifier for the subagent that generated this event
      */
     subAgentId?: string;

--- a/packages/core/src/workflow/stream.ts
+++ b/packages/core/src/workflow/stream.ts
@@ -175,6 +175,10 @@ export class WorkflowStreamWriterImpl implements WorkflowStreamWriter {
         metadata.partId = part.id;
       }
 
+      if ("messageId" in part && part.messageId !== undefined) {
+        metadata.messageId = part.messageId;
+      }
+
       if ("providerMetadata" in part && part.providerMetadata !== undefined) {
         metadata.providerMetadata = part.providerMetadata;
       }

--- a/website/docs/agents/message-types.md
+++ b/website/docs/agents/message-types.md
@@ -176,6 +176,11 @@ See [Feedback](/observability-docs/feedback) for the full flow and API examples.
 type VoltAgentTextStreamPart<TOOLS extends Record<string, any> = Record<string, any>> =
   TextStreamPart<TOOLS> & {
     /**
+     * Optional response message identifier (carried on start/step chunks).
+     */
+    messageId?: string;
+
+    /**
      * Optional identifier for the subagent that generated this event
      */
     subAgentId?: string;

--- a/website/docs/api/streaming.md
+++ b/website/docs/api/streaming.md
@@ -77,7 +77,7 @@ while (true) {
   for (const line of lines) {
     if (line.startsWith("data: ")) {
       const event = JSON.parse(line.slice(6));
-      // Handle event.type: 'text-delta', 'tool-call', 'tool-result', 'finish'
+      // Handle event.type: 'start' (includes messageId), 'text-delta', 'tool-call', 'tool-result', 'finish'
     }
   }
 }


### PR DESCRIPTION
…essageId`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)
- #1021

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures streaming message IDs stay consistent with memory by emitting messageId on start/start-step parts and using it for UI stream mapping. Fixes #1021 to prevent mismatched messages during live updates.

- **Bug Fixes**
  - Core agent adds response messageId to start/start-step stream parts (text-part ids unchanged).
  - AG UI tracks current messageId and applies it to text-delta events for correct message mapping.
  - Workflow stream includes messageId in metadata; types, docs, and tests updated.

<sup>Written for commit 259d2077c3f26830d0c385b91e5e36228e6e7633. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message ID propagation in streaming responses; messageId now properly emitted on start/step chunks to enable improved UI stream mapping while maintaining text element IDs intact.

* **Documentation**
  * Updated API documentation and type definitions to reflect new messageId field support in streaming types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->