### PR TITLE
fix: prevent delegated sub-agent messages from polluting supervisor m…

### DIFF
--- a/.changeset/cruel-trains-cut.md
+++ b/.changeset/cruel-trains-cut.md
@@ -1,0 +1,20 @@
+---
+"@voltagent/core": patch
+---
+
+fix: prevent delegated sub-agent messages from polluting supervisor memory context
+
+When a supervisor delegated work via `delegate_task`, the sub-agent used the same `conversationId` and persisted its own delegated input/output into that shared thread. On later turns, supervisor memory reads could include those delegated sub-agent messages, which could lead to duplicate/phantom prompts in the parent conversation context.
+
+### Previous behavior
+
+- Sub-agent delegated messages were persisted into the same conversation thread as the supervisor.
+- Supervisor memory reads could load those delegated messages back into the parent prompt context.
+
+### New behavior
+
+- Delegated sub-agent messages are tagged with sub-agent metadata (`subAgentId`, `subAgentName`, `parentAgentId`).
+- Parent memory reads now filter delegated sub-agent records from supervisor conversation context.
+- `conversationId` behavior remains shared (no child/derived conversation IDs introduced).
+
+This keeps supervisor context clean in multi-turn handoff flows while preserving delegated records with metadata for observability/debugging.

--- a/packages/core/src/agent/subagent/index.ts
+++ b/packages/core/src/agent/subagent/index.ts
@@ -377,6 +377,11 @@ ${task}\n\nContext: ${safeStringify(contextObj, { indentation: 2 })}`;
         id: crypto.randomUUID(),
         role: "user",
         parts: [{ type: "text", text: taskContent }],
+        metadata: {
+          subAgentId: targetAgent.id,
+          subAgentName: targetAgent.name,
+          parentAgentId: sourceAgent?.id || parentAgentId,
+        },
       };
 
       // Combine shared context with the new task message

--- a/website/docs/agents/memory/overview.md
+++ b/website/docs/agents/memory/overview.md
@@ -131,6 +131,8 @@ const agent3 = new Agent({
 
 For stateless sub-agents, set `memory: false` on each sub-agent explicitly.
 
+When a supervisor delegates to sub-agents, delegated messages are tagged with sub-agent metadata so supervisor memory reads can filter sub-agent records from parent conversation context.
+
 ### Global Defaults (VoltAgent)
 
 Set default memory instances once at the VoltAgent entrypoint. Defaults apply only when an agent or workflow does not specify `memory`. If nothing is configured, VoltAgent still falls back to built-in in-memory storage. An explicit `memory: false` on an agent disables memory and bypasses defaults.

--- a/website/docs/agents/subagents.md
+++ b/website/docs/agents/subagents.md
@@ -484,6 +484,7 @@ This tool is automatically added to supervisor agents and handles delegation.
 - **Execution**:
   - Finds the sub-agent instances based on the provided names
   - Calls the `handoffTask` (or `handoffToMultiple`) method internally
+  - Tags delegated sub-agent messages with metadata so supervisor memory reads can exclude sub-agent records
   - Passes the supervisor's agent ID (`parentAgentId`) and history entry ID (`parentHistoryEntryId`) for observability
 - **Returns**:
   - **Always returns an array** of result objects (even for single agent):


### PR DESCRIPTION
…emory context

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)
- #1026 
## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents delegated sub-agent messages from showing up in the supervisor’s memory, keeping parent prompts clean while preserving sub-agent records for debugging. Fixes Linear #1026.

- **Bug Fixes**
  - Tag delegated sub-agent messages with metadata: subAgentId, subAgentName, parentAgentId.
  - Filter memory reads (getMessages/search/fetch) to exclude delegated sub-agent records not from the current agent.
  - Keep shared conversationId behavior unchanged.
  - Add tests for metadata + filtering and update memory/subagent docs.

<sup>Written for commit 9a259c64aee276905a473730965384f8b4cc9631. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Delegated sub-agent messages now automatically tagged with metadata to support observability and debugging across multi-turn handoffs.
  * Supervisor conversation context automatically filtered to exclude delegated sub-agent messages, maintaining cleaner context during delegation workflows.

* **Documentation**
  * Updated memory and sub-agent documentation to reflect new message tagging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->