### PR TITLE
fix: deduplicate conversation step rows before Supabase upsert

### DIFF
--- a/.changeset/odd-ants-guess.md
+++ b/.changeset/odd-ants-guess.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/supabase": patch
+---
+
+fix: deduplicate conversation step rows before Supabase upsert
+
+`saveConversationSteps` now deduplicates rows by `id` in a batch before calling Supabase `upsert`.
+
+This prevents Postgres errors like `ON CONFLICT DO UPDATE command cannot affect row a second time` when multiple step records with the same `id` are present in one persistence batch, while preserving current last-write-wins behavior.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates conversation step rows by id before Supabase upsert to prevent Postgres conflict errors. Preserves last-write-wins behavior for steps.

- **Bug Fixes**
  - Deduplicate by id in saveConversationSteps; upsert receives one row per id (latest wins).
  - Upsert continues with onConflict: "id" and ignoreDuplicates: false.
  - Added a test to confirm only the latest duplicate is persisted and a single upsert occurs.

<sup>Written for commit 7936e419087f01fe6663de2183c40210f3e3c8dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where storing multiple conversation steps with the same identifier in a single batch would cause database errors. The system now properly deduplicates entries while maintaining the last-write-wins behavior, ensuring reliable persistence of conversation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->