### PR TITLE
chore: symlink CLAUDE.md to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-ALWAYS read the `AGENTS.md` in the root of the repository and apply the instructions to the current task.
+AGENTS.md


### PR DESCRIPTION
## Summary

- Replaces the `CLAUDE.md` file with a symlink pointing to `AGENTS.md`
- Previously `CLAUDE.md` just contained a one-liner telling Claude to read `AGENTS.md` — this removes that indirection
- Claude Code [follows symlinks](https://docs.anthropic.com/en/docs/claude-code/memory#project-memory) when resolving `CLAUDE.md` and `.claude/rules/`, so the symlink is treated identically to a regular file
- `AGENTS.md` remains the canonical source of truth for agent instructions, keeping the door open for other AI coding tools that may adopt `AGENTS.md` as their convention

## Test plan

- [ ] Verify Claude Code loads instructions from `AGENTS.md` via the symlink
- [ ] Confirm `AGENTS.md` content appears in Claude Code's project instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced CLAUDE.md with a symlink to AGENTS.md so Claude Code reads the canonical agent instructions directly. This removes the extra indirection and keeps AGENTS.md as the single source of truth while preserving the CLAUDE.md entrypoint.

<sup>Written for commit adcfdfd9b994a058562d5be23a3f9b1252648b46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation file to the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->