### PR TITLE
feat: expose workspace context

### DIFF
--- a/.changeset/four-frogs-tease.md
+++ b/.changeset/four-frogs-tease.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/core": patch
+---
+
+feat: expose workspace in tool execution context - #1046
+
+- Add `workspace?: Workspace` to `OperationContext`, so custom tools can access `options.workspace` during tool calls.
+- Wire agent operation context creation to attach the configured workspace automatically.
+- Add regression coverage showing a tool call can read workspace filesystem content and fetch sandbox output in the same execution.

--- a/packages/core/src/agent/agent.spec-d.ts
+++ b/packages/core/src/agent/agent.spec-d.ts
@@ -10,6 +10,7 @@ import type { StreamEventType } from "../utils/streams";
 import type { Voice } from "../voice";
 import type { VoltOpsClient } from "../voltops/client";
 import type { DynamicValue, DynamicValueOptions } from "../voltops/types";
+import type { Workspace } from "../workspace";
 import {
   Agent,
   type AgentHooks,
@@ -525,6 +526,10 @@ describe("Agent Type System", () => {
 
       expectTypeOf(context).toEqualTypeOf<UserContext>();
       expectTypeOf(context.get("key")).toEqualTypeOf<unknown>();
+    });
+
+    it("should expose optional workspace on OperationContext", () => {
+      expectTypeOf<OperationContext["workspace"]>().toEqualTypeOf<Workspace | undefined>();
     });
   });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3352,6 +3352,7 @@ export class Agent {
       abortController,
       userId: options?.userId,
       conversationId: options?.conversationId,
+      workspace: this.workspace,
       parentAgentId: options?.parentAgentId,
       traceContext,
       startTime: startTimeDate,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1130,6 +1130,9 @@ export type OperationContext = {
   /** Optional conversation identifier associated with this operation */
   conversationId?: string;
 
+  /** Workspace configured on the executing agent (if any). */
+  workspace?: Workspace;
+
   /** User-managed context map for this operation */
   readonly context: Map<string | symbol, unknown>;
 

--- a/website/docs/agents/context.md
+++ b/website/docs/agents/context.md
@@ -264,6 +264,7 @@ The `options` parameter in tool `execute` functions combines `ToolExecuteOptions
 - `operationId` - Unique operation identifier
 - `userId` - User identifier (if provided)
 - `conversationId` - Conversation identifier (if provided)
+- `workspace` - Workspace instance configured on the agent (if available)
 - `context` - User-defined context Map (read/write)
 - `systemContext` - Internal system context Map
 - `logger` - Operation-scoped logger with full context
@@ -420,6 +421,9 @@ interface OperationContext {
 
   // Optional conversation identifier
   conversationId?: string;
+
+  // Workspace configured on the agent (if any)
+  workspace?: Workspace;
 }
 ```
 
@@ -436,6 +440,7 @@ const response = await agent.generateText("Hello", {
 console.log(operationContext.userId); // "user-123"
 console.log(operationContext.conversationId); // "conv-456"
 console.log(operationContext.context.get("language")); // "en"
+console.log(operationContext.workspace?.id); // e.g. "demo-workspace"
 ```
 
 ### Operation Metadata (Read-Only)
@@ -819,7 +824,7 @@ async function demonstrateFlow() {
 
 The `OperationContext` contains:
 
-- **User-managed**: `context` (Map), `userId`, `conversationId`
+- **User-managed**: `context` (Map), `userId`, `conversationId`, `workspace`
 - **Metadata**: `operationId`, `startTime`, `isActive`, `parentAgentId`
 - **System**: `systemContext`, `logger`, `traceContext`, `conversationSteps`, `abortController`, `cancellationError`, `elicitation`
 - **Input/Output**: `input`, `output` (automatically set)

--- a/website/docs/workspaces/overview.md
+++ b/website/docs/workspaces/overview.md
@@ -83,6 +83,25 @@ const workspace = new Workspace({
 });
 ```
 
+## Workspace in custom tool calls
+
+When an agent has a workspace, custom tool `execute` handlers receive it through tool options (`options.workspace`).
+
+```ts
+const readWorkspaceFile = createTool({
+  name: "read_workspace_file",
+  description: "Read data from workspace inside a tool call",
+  parameters: z.object({ path: z.string() }),
+  execute: async ({ path }, options) => {
+    const workspace = options?.workspace;
+    if (!workspace) {
+      return "Workspace is not configured.";
+    }
+    return await workspace.filesystem.read(path);
+  },
+});
+```
+
 ## Workspace lifecycle + utilities
 
 You can initialize or tear down the workspace explicitly, and inspect runtime info:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

- #1046

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the agent’s workspace to tool execution and add tool-aware live-eval payloads with a deterministic tool-call accuracy scorer. Also introduce an onToolError hook to customize serialized tool errors. Addresses #1046.

- **New Features**
  - Added workspace on OperationContext and forwarded it to tool execute; the agent attaches its workspace automatically.
  - Added onToolError hook to override tool error payloads before serialization.
  - Live eval payload now includes messages, toolCalls, and toolResults; derives them from steps when not provided; exported AgentEvalToolCall and AgentEvalToolResult types.
  - Added createToolCallAccuracyScorerCode with single-tool and ordered-chain checks (strict or lenient).
  - Updated examples and docs to show options.workspace and tool-eval usage.

<sup>Written for commit 86be14113e7353b3b2d282b202daa9fbf6207189. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace is now accessible to tools via the operation context, enabling tools to read workspace filesystem content and execute sandbox commands during execution.

* **Tests**
  * Added test coverage for workspace functionality in tool execution.

* **Documentation**
  * Updated documentation with examples showing how to access workspace within custom tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->