### PR TITLE
fix: make workspace toolkit schemas compatible with Zod v4 record han…

### DIFF
--- a/.changeset/khaki-worms-wave.md
+++ b/.changeset/khaki-worms-wave.md
@@ -1,0 +1,19 @@
+---
+"@voltagent/core": patch
+---
+
+fix: make workspace toolkit schemas compatible with Zod v4 record handling - #1043
+
+### What Changed
+
+- Updated workspace toolkit input schemas to avoid single-argument `z.record(...)` usage that can fail in Zod v4 JSON schema conversion paths.
+- `workspace_sandbox.execute_command` now uses `z.record(z.string(), z.string())` for `env`.
+- `workspace_index_content` now uses `z.record(z.string(), z.unknown())` for `metadata`.
+
+### Why
+
+With `@voltagent/core` + `zod@4`, some workspace toolkit flows could fail at runtime with:
+
+`Cannot read properties of undefined (reading '_zod')`
+
+This patch ensures built-in workspace toolkits (such as sandbox and search indexing) work reliably across supported Zod versions.

--- a/packages/core/src/workspace/sandbox/toolkit.ts
+++ b/packages/core/src/workspace/sandbox/toolkit.ts
@@ -192,7 +192,7 @@ export const createWorkspaceSandboxToolkit = (
       args: z.array(z.string()).optional().describe("Command arguments"),
       cwd: z.string().optional().describe("Working directory for the command"),
       timeout_ms: z.coerce.number().optional().describe("Timeout in milliseconds"),
-      env: z.record(z.string()).optional().describe("Environment variables to set"),
+      env: z.record(z.string(), z.string()).optional().describe("Environment variables to set"),
       stdin: z.string().optional().describe("Optional stdin input for the command"),
       max_output_bytes: z.coerce
         .number()

--- a/packages/core/src/workspace/search/index.ts
+++ b/packages/core/src/workspace/search/index.ts
@@ -797,7 +797,7 @@ export const createWorkspaceSearchToolkit = (
     parameters: z.object({
       path: z.string().describe("Path identifier for the content"),
       content: z.string().describe("Raw content to index"),
-      metadata: z.record(z.unknown()).optional().describe("Optional metadata"),
+      metadata: z.record(z.string(), z.unknown()).optional().describe("Optional metadata"),
     }),
     execute: async (input, executeOptions) =>
       withOperationTimeout(


### PR DESCRIPTION
…dling - #1043

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)
- #1043 

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates workspace toolkit schemas to align with Zod v4 record handling, fixing runtime errors in sandbox and search indexing flows. Fixes #1043 and prevents “Cannot read properties of undefined (reading '_zod')”.

- **Bug Fixes**
  - Sandbox toolkit: env schema now uses z.record(z.string(), z.string()).
  - Search indexing: metadata schema now uses z.record(z.string(), z.unknown()).

<sup>Written for commit b4267e92b3c8617a615410793e8f94379eb0ea0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed runtime errors in workspace sandbox execution and search indexing features to ensure stable, reliable operation across all supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->