### PR TITLE
fix: preserve request correlation with root workflow and agent spans

### DIFF
--- a/.changeset/friendly-feedback-state.md
+++ b/.changeset/friendly-feedback-state.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/core": patch
+---
+
+fix: preserve request correlation with root workflow and agent spans
+
+- Keep workflow and agent root spans as real roots when no explicit parent is provided.
+- Add OpenTelemetry span links to the active ambient span so request-level correlation is preserved without reintroducing pending/running root-state issues.
+- Keep existing workflow resume links and combine them with the new ambient link when both are available.

--- a/packages/core/src/agent/open-telemetry/trace-context.spec.ts
+++ b/packages/core/src/agent/open-telemetry/trace-context.spec.ts
@@ -1,0 +1,78 @@
+import { SpanKind, context, trace } from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NodeVoltAgentObservability } from "../../observability";
+import { AgentTraceContext } from "./trace-context";
+
+async function waitForSpan(
+  observability: NodeVoltAgentObservability,
+  traceId: string,
+  spanId: string,
+) {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await observability.forceFlush();
+    const traceSpans = await observability.getTraceFromStorage(traceId);
+    const span = traceSpans.find((candidate: any) => candidate.spanId === spanId);
+    if (span) {
+      return span;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  return undefined;
+}
+
+describe.sequential("AgentTraceContext", () => {
+  let observability: NodeVoltAgentObservability;
+
+  beforeEach(() => {
+    observability = new NodeVoltAgentObservability();
+  });
+
+  afterEach(async () => {
+    await observability.shutdown();
+  });
+
+  it("keeps agent root spans root while linking active request spans", async () => {
+    const tracer = observability.getTracer();
+    const requestSpan = tracer.startSpan("http.request", { kind: SpanKind.SERVER });
+
+    let traceContext: AgentTraceContext | undefined;
+    context.with(trace.setSpan(context.active(), requestSpan), () => {
+      traceContext = new AgentTraceContext(observability, "agent.test", {
+        agentId: "agent-1",
+        agentName: "agent-test",
+        operationId: "op-1",
+        inheritParentSpan: true,
+      });
+      traceContext.end("completed");
+    });
+
+    requestSpan.end();
+
+    expect(traceContext).toBeDefined();
+    if (!traceContext) {
+      throw new Error("Agent trace context was not created");
+    }
+
+    const rootSpanContext = traceContext.getRootSpan().spanContext();
+    const storedRoot = await waitForSpan(
+      observability,
+      rootSpanContext.traceId,
+      rootSpanContext.spanId,
+    );
+
+    expect(storedRoot).toBeDefined();
+    expect(storedRoot.parentSpanId).toBeUndefined();
+    expect(storedRoot.links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          traceId: requestSpan.spanContext().traceId,
+          spanId: requestSpan.spanContext().spanId,
+          attributes: expect.objectContaining({
+            "link.type": "ambient-parent",
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/core/src/workflow/open-telemetry/trace-context.spec.ts
+++ b/packages/core/src/workflow/open-telemetry/trace-context.spec.ts
@@ -1,0 +1,134 @@
+import { SpanKind, context, trace } from "@opentelemetry/api";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NodeVoltAgentObservability } from "../../observability";
+import { WorkflowTraceContext } from "./trace-context";
+
+async function waitForSpan(
+  observability: NodeVoltAgentObservability,
+  traceId: string,
+  spanId: string,
+) {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await observability.forceFlush();
+    const traceSpans = await observability.getTraceFromStorage(traceId);
+    const span = traceSpans.find((candidate: any) => candidate.spanId === spanId);
+    if (span) {
+      return span;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  return undefined;
+}
+
+describe.sequential("WorkflowTraceContext", () => {
+  let observability: NodeVoltAgentObservability;
+
+  beforeEach(() => {
+    observability = new NodeVoltAgentObservability();
+  });
+
+  afterEach(async () => {
+    await observability.shutdown();
+  });
+
+  it("keeps workflow root spans root while linking active request spans", async () => {
+    const tracer = observability.getTracer();
+    const requestSpan = tracer.startSpan("http.request", { kind: SpanKind.SERVER });
+
+    let traceContext: WorkflowTraceContext | undefined;
+    context.with(trace.setSpan(context.active(), requestSpan), () => {
+      traceContext = new WorkflowTraceContext(observability, "workflow.test", {
+        workflowId: "wf-1",
+        workflowName: "workflow-test",
+        executionId: "exec-1",
+      });
+      traceContext.end("completed");
+    });
+
+    requestSpan.end();
+
+    expect(traceContext).toBeDefined();
+    if (!traceContext) {
+      throw new Error("Workflow trace context was not created");
+    }
+
+    const rootSpanContext = traceContext.getRootSpan().spanContext();
+    const storedRoot = await waitForSpan(
+      observability,
+      rootSpanContext.traceId,
+      rootSpanContext.spanId,
+    );
+
+    expect(storedRoot).toBeDefined();
+    expect(storedRoot.parentSpanId).toBeUndefined();
+    expect(storedRoot.links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          traceId: requestSpan.spanContext().traceId,
+          spanId: requestSpan.spanContext().spanId,
+          attributes: expect.objectContaining({
+            "link.type": "ambient-parent",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("preserves resume links while also linking active request spans", async () => {
+    const tracer = observability.getTracer();
+    const requestSpan = tracer.startSpan("http.request", { kind: SpanKind.SERVER });
+    const previousSpan = tracer.startSpan("workflow.previous");
+    const previousContext = previousSpan.spanContext();
+    previousSpan.end();
+
+    let traceContext: WorkflowTraceContext | undefined;
+    let rootLinks:
+      | Array<{
+          context: {
+            traceId: string;
+            spanId: string;
+          };
+          attributes?: Record<string, unknown>;
+        }>
+      | undefined;
+    context.with(trace.setSpan(context.active(), requestSpan), () => {
+      traceContext = new WorkflowTraceContext(observability, "workflow.resume", {
+        workflowId: "wf-2",
+        workflowName: "workflow-resume",
+        executionId: "exec-2",
+        resumedFrom: {
+          traceId: previousContext.traceId,
+          spanId: previousContext.spanId,
+        },
+      });
+      rootLinks = (traceContext.getRootSpan() as any).links;
+      traceContext.end("completed");
+    });
+
+    requestSpan.end();
+    expect(traceContext).toBeDefined();
+    expect(rootLinks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          context: expect.objectContaining({
+            traceId: requestSpan.spanContext().traceId,
+            spanId: requestSpan.spanContext().spanId,
+          }),
+          attributes: expect.objectContaining({
+            "link.type": "ambient-parent",
+          }),
+        }),
+        expect.objectContaining({
+          context: expect.objectContaining({
+            traceId: previousContext.traceId,
+            spanId: previousContext.spanId,
+          }),
+          attributes: expect.objectContaining({
+            "link.type": "resume",
+          }),
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

## What is the new behavior?

fixes (issue)

## Notes for reviewers

<!-- Add any notes/questions you may have for reviewers -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves request-level correlation while keeping workflow and agent root spans as true roots. Root spans now link to the active request span instead of being parented.

- **Bug Fixes**
  - Create workflow and agent root spans without a parent when none is provided, and link the ambient request span for correlation.
  - Keep workflow resume links and combine them with the new ambient link.
  - Add tests to verify root spans have no parentSpanId and include the expected links.

<sup>Written for commit c5c448c6041dfe439c30ddf3bab2d7d0c38ba081. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved request correlation in distributed traces**: Enhanced OpenTelemetry span linking to preserve request-level correlation across workflow and agent operations while ensuring root spans remain truly independent when no explicit parent is specified.
* **Enhanced workflow resume tracing**: Workflow resume operations now correctly maintain both resume links and request context links in trace spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->