### PR TITLE
feat(core): support multi-step doWhile/doUntil loops

### DIFF
--- a/.changeset/giant-coins-twirl.md
+++ b/.changeset/giant-coins-twirl.md
@@ -1,0 +1,10 @@
+---
+"@voltagent/core": patch
+---
+
+Add multi-step loop bodies for `andDoWhile` and `andDoUntil`.
+
+- Loop steps now accept either a single `step` or a sequential `steps` array.
+- When `steps` is provided, each iteration runs the steps in order and feeds each output into the next step.
+- Workflow step serialization now includes loop `subSteps` when a loop has multiple steps.
+- Added runtime and type tests for chained loop steps.

--- a/packages/core/src/workflow/core.spec-d.ts
+++ b/packages/core/src/workflow/core.spec-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { andForEach, andThen } from "./";
+import { andDoWhile, andForEach, andThen } from "./";
 import type { WorkflowExecuteContext } from "./internal/types";
 import type { WorkflowStateStore, WorkflowStateUpdater } from "./types";
 
@@ -51,6 +51,44 @@ describe("non-chaining API type inference", () => {
           execute: async ({ data }) => data,
         }),
       });
+      expectTypeOf(step).not.toBeNever();
+    });
+  });
+
+  describe("andDoWhile", () => {
+    it("should infer condition data from the last chained loop step", () => {
+      const step = andDoWhile({
+        id: "loop",
+        steps: [
+          andThen({
+            id: "step-1",
+            execute: async (
+              context: WorkflowExecuteContext<
+                { input: string },
+                { value: number },
+                unknown,
+                unknown
+              >,
+            ) => ({ value: context.data.value + 1 }),
+          }),
+          andThen({
+            id: "step-2",
+            execute: async (
+              context: WorkflowExecuteContext<
+                { input: string },
+                { value: number },
+                unknown,
+                unknown
+              >,
+            ) => context.data.value,
+          }),
+        ],
+        condition: async (context) => {
+          expectTypeOf(context.data).toEqualTypeOf<number>();
+          return context.data < 3;
+        },
+      });
+
       expectTypeOf(step).not.toBeNever();
     });
   });

--- a/packages/core/src/workflow/steps/and-loop.spec.ts
+++ b/packages/core/src/workflow/steps/and-loop.spec.ts
@@ -41,4 +41,39 @@ describe("andLoop", () => {
 
     expect(result).toBe(2);
   });
+
+  it("supports multiple chained steps in each loop iteration", async () => {
+    const step = andDoWhile({
+      id: "loop",
+      steps: [
+        andThen({
+          id: "increment",
+          execute: async ({ data }) => data + 1,
+        }),
+        andThen({
+          id: "double",
+          execute: async ({ data }) => data * 2,
+        }),
+      ],
+      condition: async ({ data }) => data < 20,
+    });
+
+    const result = await step.execute(
+      createMockWorkflowExecuteContext({
+        data: 1,
+      }),
+    );
+
+    expect(result).toBe(22);
+  });
+
+  it("throws when loop steps array is empty", () => {
+    expect(() =>
+      andDoUntil({
+        id: "loop",
+        steps: [] as never,
+        condition: async () => true,
+      }),
+    ).toThrow("andDoWhile/andDoUntil requires at least one step");
+  });
 });

--- a/packages/core/src/workflow/steps/and-loop.ts
+++ b/packages/core/src/workflow/steps/and-loop.ts
@@ -2,21 +2,53 @@ import type { Span } from "@opentelemetry/api";
 import { defaultStepConfig } from "../internal/utils";
 import { matchStep } from "./helpers";
 import { throwIfAborted } from "./signal";
-import type { WorkflowStepLoop, WorkflowStepLoopConfig } from "./types";
+import type { WorkflowStepLoop, WorkflowStepLoopConfig, WorkflowStepLoopSteps } from "./types";
 
 type LoopType = "dowhile" | "dountil";
+type LoopStepMetadata = { id: string; name?: string; purpose?: string; retries?: number };
+
+function splitLoopConfig<INPUT, DATA, RESULT>(config: WorkflowStepLoopConfig<INPUT, DATA, RESULT>) {
+  if ("step" in config) {
+    const { step: _step, condition, ...stepConfig } = config;
+    return { condition, stepConfig: stepConfig as LoopStepMetadata };
+  }
+
+  const { steps: _steps, condition, ...stepConfig } = config;
+  return { condition, stepConfig: stepConfig as LoopStepMetadata };
+}
+
+function getLoopSteps<INPUT, DATA, RESULT>(
+  config: WorkflowStepLoopConfig<INPUT, DATA, RESULT>,
+): WorkflowStepLoopSteps<INPUT, DATA, RESULT> {
+  if ("steps" in config && config.steps) {
+    if (config.steps.length === 0) {
+      throw new Error("andDoWhile/andDoUntil requires at least one step");
+    }
+    return config.steps;
+  }
+
+  return [config.step];
+}
 
 const createLoopStep = <INPUT, DATA, RESULT>(
   loopType: LoopType,
-  { step, condition, ...config }: WorkflowStepLoopConfig<INPUT, DATA, RESULT>,
+  config: WorkflowStepLoopConfig<INPUT, DATA, RESULT>,
 ) => {
-  const finalStep = matchStep(step);
+  const { condition, stepConfig } = splitLoopConfig(config);
+  const loopSteps = getLoopSteps(config);
+  const resolvedSteps = loopSteps.map((loopStep) => matchStep(loopStep));
+  const firstStep = loopSteps[0];
+
+  if (!firstStep) {
+    throw new Error("andDoWhile/andDoUntil requires at least one step");
+  }
 
   return {
-    ...defaultStepConfig(config),
+    ...defaultStepConfig(stepConfig),
     type: "loop",
     loopType,
-    step,
+    step: firstStep,
+    steps: loopSteps,
     condition,
     execute: async (context) => {
       const { state } = context;
@@ -24,38 +56,46 @@ const createLoopStep = <INPUT, DATA, RESULT>(
       let currentData = context.data as DATA | RESULT;
       let iteration = 0;
 
-      while (true) {
-        throwIfAborted(state.signal);
+      const runResolvedStep = async (stepIndex: number) => {
+        const resolvedStep = resolvedSteps[stepIndex];
+        if (!resolvedStep) {
+          return;
+        }
 
         let childSpan: Span | undefined;
         if (traceContext) {
+          const isSingleLoopStep = resolvedSteps.length === 1;
           childSpan = traceContext.createStepSpan(
-            iteration,
-            finalStep.type,
-            finalStep.name || finalStep.id || `Loop ${iteration + 1}`,
+            iteration * resolvedSteps.length + stepIndex,
+            resolvedStep.type,
+            resolvedStep.name ||
+              resolvedStep.id ||
+              (isSingleLoopStep
+                ? `Loop ${iteration + 1}`
+                : `Loop ${iteration + 1}.${stepIndex + 1}`),
             {
-              parentStepId: config.id,
-              parallelIndex: iteration,
+              parentStepId: stepConfig.id,
+              parallelIndex: isSingleLoopStep ? iteration : stepIndex,
               input: currentData,
               attributes: {
                 "workflow.step.loop": true,
                 "workflow.step.parent_type": "loop",
                 "workflow.step.loop_type": loopType,
+                "workflow.step.loop_iteration": iteration,
+                "workflow.step.loop_step_index": stepIndex,
               },
             },
           );
         }
 
-        const subState = {
-          ...state,
-          workflowContext: undefined,
-        };
-
         const executeStep = () =>
-          finalStep.execute({
+          resolvedStep.execute({
             ...context,
-            data: currentData as DATA,
-            state: subState,
+            data: currentData as never,
+            state: {
+              ...state,
+              workflowContext: undefined,
+            },
           });
 
         try {
@@ -72,6 +112,15 @@ const createLoopStep = <INPUT, DATA, RESULT>(
             traceContext.endStepSpan(childSpan, "error", { error });
           }
           throw error;
+        }
+      };
+
+      while (true) {
+        throwIfAborted(state.signal);
+
+        for (let stepIndex = 0; stepIndex < resolvedSteps.length; stepIndex += 1) {
+          throwIfAborted(state.signal);
+          await runResolvedStep(stepIndex);
         }
 
         iteration += 1;

--- a/packages/core/src/workflow/steps/index.ts
+++ b/packages/core/src/workflow/steps/index.ts
@@ -32,6 +32,7 @@ export type {
   WorkflowStepForEachItemsFunc,
   WorkflowStepForEachMapFunc,
   WorkflowStepLoopConfig,
+  WorkflowStepLoopSteps,
   WorkflowStepBranchConfig,
   WorkflowStepMapConfig,
   WorkflowStepMapEntry,

--- a/packages/core/src/workflow/steps/types.ts
+++ b/packages/core/src/workflow/steps/types.ts
@@ -195,16 +195,44 @@ export interface WorkflowStepForEach<INPUT, DATA, ITEM, RESULT, MAP_DATA = ITEM>
   map?: WorkflowStepForEachMapFunc<INPUT, DATA, ITEM, MAP_DATA>;
 }
 
-export type WorkflowStepLoopConfig<INPUT, DATA, RESULT> = InternalWorkflowStepConfig<{
-  step: InternalAnyWorkflowStep<INPUT, DATA, RESULT>;
+export type WorkflowStepLoopSteps<INPUT, DATA, RESULT> =
+  | readonly [InternalAnyWorkflowStep<INPUT, DATA, RESULT>]
+  | readonly [
+      InternalAnyWorkflowStep<INPUT, DATA, DangerouslyAllowAny>,
+      ...InternalAnyWorkflowStep<INPUT, DangerouslyAllowAny, DangerouslyAllowAny>[],
+      InternalAnyWorkflowStep<INPUT, DangerouslyAllowAny, RESULT>,
+    ];
+
+type WorkflowStepLoopBaseConfig<INPUT, RESULT> = InternalWorkflowStepConfig<{
   condition: InternalWorkflowFunc<INPUT, RESULT, boolean, any, any>;
 }>;
+
+type WorkflowStepLoopSingleStepConfig<INPUT, DATA, RESULT> = WorkflowStepLoopBaseConfig<
+  INPUT,
+  RESULT
+> & {
+  step: InternalAnyWorkflowStep<INPUT, DATA, RESULT>;
+  steps?: never;
+};
+
+type WorkflowStepLoopMultiStepConfig<INPUT, DATA, RESULT> = WorkflowStepLoopBaseConfig<
+  INPUT,
+  RESULT
+> & {
+  steps: WorkflowStepLoopSteps<INPUT, DATA, RESULT>;
+  step?: never;
+};
+
+export type WorkflowStepLoopConfig<INPUT, DATA, RESULT> =
+  | WorkflowStepLoopSingleStepConfig<INPUT, DATA, RESULT>
+  | WorkflowStepLoopMultiStepConfig<INPUT, DATA, RESULT>;
 
 export interface WorkflowStepLoop<INPUT, DATA, RESULT>
   extends InternalBaseWorkflowStep<INPUT, DATA, RESULT, any, any> {
   type: "loop";
   loopType: "dowhile" | "dountil";
-  step: InternalAnyWorkflowStep<INPUT, DATA, RESULT>;
+  step: InternalAnyWorkflowStep<INPUT, DATA, DangerouslyAllowAny>;
+  steps: WorkflowStepLoopSteps<INPUT, DATA, RESULT>;
   condition: InternalWorkflowFunc<INPUT, RESULT, boolean, any, any>;
 }
 

--- a/website/docs/workflows/steps/and-loop.md
+++ b/website/docs/workflows/steps/and-loop.md
@@ -1,6 +1,6 @@
 # andLoop
 
-> Repeat a step with do-while or do-until semantics.
+> Repeat one or more steps with do-while or do-until semantics.
 
 ## Quick Start
 
@@ -15,10 +15,16 @@ const workflow = createWorkflowChain({
   input: z.number(),
 }).andDoWhile({
   id: "increment-until-3",
-  step: andThen({
-    id: "increment",
-    execute: async ({ data }) => data + 1,
-  }),
+  steps: [
+    andThen({
+      id: "increment",
+      execute: async ({ data }) => data + 1,
+    }),
+    andThen({
+      id: "double",
+      execute: async ({ data }) => data * 2,
+    }),
+  ],
   condition: ({ data }) => data < 3,
 });
 ```
@@ -47,7 +53,8 @@ const workflow = createWorkflowChain({
 ```typescript
 .andDoWhile({
   id: string,
-  step: Step,
+  step?: Step,
+  steps?: Step[],
   condition: (ctx) => boolean | Promise<boolean>,
   retries?: number,
   name?: string,
@@ -56,7 +63,8 @@ const workflow = createWorkflowChain({
 
 .andDoUntil({
   id: string,
-  step: Step,
+  step?: Step,
+  steps?: Step[],
   condition: (ctx) => boolean | Promise<boolean>,
   retries?: number,
   name?: string,
@@ -66,5 +74,7 @@ const workflow = createWorkflowChain({
 
 ## Notes
 
-- The step runs at least once.
+- Provide either `step` (single step) or `steps` (multiple sequential steps).
+- The configured step(s) run at least once.
+- When `steps` is provided, steps run in order on each iteration.
 - The loop continues until the condition fails (do-while) or succeeds (do-until).


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`andDoWhile` and `andDoUntil` only accept a single `step`. For multi-step loop bodies, users have to place all logic in one `andThen(...).execute` block.

## What is the new behavior?

`andDoWhile` and `andDoUntil` now accept either:

- `step` (existing behavior, backward compatible)
- `steps` (new) for sequential multi-step loop bodies

Each iteration runs the configured steps in order and pipes each output into the next step.

Also updated loop step serialization to include `subSteps` when a loop has multiple steps.

fixes (issue)

N/A

## Notes for reviewers

- No breaking runtime API change for existing `step` usage.
- Added runtime tests in `and-loop.spec.ts` and type tests in `core.spec-d.ts`.
- Docs updated at `website/docs/workflows/steps/and-loop.md`.
- Changeset included at `.changeset/giant-coins-twirl.md`.

Validation run:

- `pnpm --filter @voltagent/core exec vitest run src/workflow/steps/and-loop.spec.ts src/workflow/core.spec-d.ts --typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable multi-step loop bodies for andDoWhile/andDoUntil. Each iteration can run multiple steps in order and pass outputs between them; single-step usage stays the same.

- New Features
  - Accepts steps array in addition to step (backward compatible); condition uses the last step’s output; throws if steps is empty.
  - Executes steps sequentially per iteration, piping each step’s result into the next.
  - Adds subSteps to loop serialization and improves tracing for nested loop steps; docs and tests updated.

<sup>Written for commit b55cd0ac5a7a49fcdba092181c89227e9ae2ff58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * andDoWhile and andDoUntil now support multiple steps per loop iteration. Provide either a single step or an array of steps; within each iteration, step outputs automatically chain into the next step.

* **Documentation**
  * Updated documentation for andDoWhile and andDoUntil with examples of multi-step loop configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->