### PR TITLE
feat(core): improve providerOptions IntelliSense and docs

### DIFF
--- a/.changeset/yellow-cars-smile.md
+++ b/.changeset/yellow-cars-smile.md
@@ -1,0 +1,33 @@
+---
+"@voltagent/core": patch
+---
+
+feat: improve `providerOptions` IntelliSense for provider-specific model settings
+
+- `ProviderOptions` now includes typed option buckets for `openai`, `anthropic`, `google`, and `xai`.
+- Existing top-level call option fields (`temperature`, `maxTokens`, `topP`, `frequencyPenalty`, `presencePenalty`, etc.) remain supported for backward compatibility.
+- Added type-level coverage for provider-scoped options in the agent type tests.
+- Updated docs to show provider-scoped `providerOptions` usage in agent, API endpoint, and UI integration examples.
+
+```ts
+await agent.generateText("Draft a summary", {
+  temperature: 0.3,
+  providerOptions: {
+    openai: {
+      reasoningEffort: "medium",
+      textVerbosity: "low",
+    },
+    anthropic: {
+      sendReasoning: true,
+    },
+    google: {
+      thinkingConfig: {
+        thinkingBudget: 1024,
+      },
+    },
+    xai: {
+      reasoningEffort: "medium",
+    },
+  },
+});
+```

--- a/packages/core/src/agent/agent.spec-d.ts
+++ b/packages/core/src/agent/agent.spec-d.ts
@@ -454,9 +454,29 @@ describe("Agent Type System", () => {
         onError: async (error) => {
           expectTypeOf(error).toEqualTypeOf<unknown>();
         },
+        openai: {
+          reasoningEffort: "medium",
+          textVerbosity: "high",
+        },
+        anthropic: {
+          sendReasoning: true,
+          cacheControl: { type: "ephemeral" },
+        },
+        google: {
+          thinkingConfig: {
+            thinkingBudget: 1024,
+          },
+        },
+        xai: {
+          reasoningEffort: "medium",
+        },
       };
 
       expectTypeOf(providerOptions).toMatchTypeOf<ProviderOptions>();
+      expectTypeOf(providerOptions.openai).not.toBeAny();
+      expectTypeOf(providerOptions.anthropic).not.toBeAny();
+      expectTypeOf(providerOptions.google).not.toBeAny();
+      expectTypeOf(providerOptions.xai).not.toBeAny();
     });
 
     it("should validate SupervisorConfig", () => {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,3 +1,7 @@
+import type { AnthropicProviderOptions } from "@ai-sdk/anthropic";
+import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
+import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
+import type { XaiProviderOptions, XaiResponsesProviderOptions } from "@ai-sdk/xai";
 import type { Span } from "@opentelemetry/api";
 import type { z } from "zod";
 import type {
@@ -270,7 +274,7 @@ export type ToolsDynamicValue =
 /**
  * Provider options type for LLM configurations
  */
-export type ProviderOptions = {
+type LegacyProviderCallOptions = {
   // Controls randomness (0-1)
   temperature?: number;
   // Maximum tokens to generate
@@ -296,7 +300,16 @@ export type ProviderOptions = {
 
   // Callback when an error occurs during generation
   onError?: (error: unknown) => Promise<void>;
+};
 
+export type ProviderOptions = LegacyProviderCallOptions & {
+  // Common provider-specific option buckets with IntelliSense
+  anthropic?: AnthropicProviderOptions & Record<string, unknown>;
+  google?: GoogleGenerativeAIProviderOptions & Record<string, unknown>;
+  openai?: OpenAIResponsesProviderOptions & Record<string, unknown>;
+  xai?: (XaiProviderOptions | XaiResponsesProviderOptions) & Record<string, unknown>;
+
+  // Allow other providers / future options without breaking changes
   [key: string]: unknown;
 };
 

--- a/website/docs/agents/providers.md
+++ b/website/docs/agents/providers.md
@@ -38,6 +38,37 @@ const agent = new Agent({
 });
 ```
 
+## Provider Options (IntelliSense)
+
+Use `providerOptions` for provider-specific settings in `generateText`, `streamText`, `generateObject`, and `streamObject` calls.
+
+```ts
+await agent.generateText("Draft a summary", {
+  temperature: 0.3,
+  maxOutputTokens: 300,
+  providerOptions: {
+    openai: {
+      reasoningEffort: "medium",
+      textVerbosity: "low",
+    },
+    anthropic: {
+      sendReasoning: true,
+      cacheControl: { type: "ephemeral" },
+    },
+    google: {
+      thinkingConfig: {
+        thinkingBudget: 1024,
+      },
+    },
+    xai: {
+      reasoningEffort: "medium",
+    },
+  },
+});
+```
+
+TypeScript IntelliSense is available for `openai`, `anthropic`, `google`, and `xai` option objects.
+
 ## Provider Selection
 
 Use any ai-sdk provider package you have configured (OpenAI, Anthropic, Google, Groq, Mistral, Vertex, Bedrock, etc.), or use model strings.

--- a/website/docs/api/endpoints/agents.md
+++ b/website/docs/api/endpoints/agents.md
@@ -98,7 +98,9 @@ Generate a text response from an agent synchronously.
     "seed": 42,
     "stopSequences": ["\n\n"],
     "providerOptions": {
-      "reasoningEffort": "medium"
+      "openai": {
+        "reasoningEffort": "medium"
+      }
     },
     "context": {
       "role": "admin",

--- a/website/docs/ui/ai-sdk-integration.md
+++ b/website/docs/ui/ai-sdk-integration.md
@@ -366,14 +366,16 @@ export function ChatInterface() {
 
 ### Provider-Specific Options
 
-| Option                            | Type     | Description                            |
-| --------------------------------- | -------- | -------------------------------------- |
-| `providerOptions`                 | object   | Provider-specific settings             |
-| `providerOptions.temperature`     | number   | Fallback temperature                   |
-| `providerOptions.maxTokens`       | number   | Fallback max tokens                    |
-| `providerOptions.reasoningEffort` | string   | For o1 models: 'low', 'medium', 'high' |
-| `providerOptions.extraOptions`    | object   | Additional provider-specific options   |
-| `providerOptions.onStepFinish`    | function | Callback when a step completes         |
+| Option                                    | Type     | Description                                        |
+| ----------------------------------------- | -------- | -------------------------------------------------- |
+| `providerOptions`                         | object   | Provider-specific settings                         |
+| `providerOptions.openai.reasoningEffort`  | string   | OpenAI reasoning effort (e.g. `"low"`, `"medium"`) |
+| `providerOptions.openai.textVerbosity`    | string   | OpenAI verbosity (`"low"`, `"medium"`, `"high"`)   |
+| `providerOptions.anthropic.sendReasoning` | boolean  | Include Anthropic reasoning metadata               |
+| `providerOptions.google.thinkingConfig`   | object   | Gemini thinking budget/configuration               |
+| `providerOptions.xai.reasoningEffort`     | string   | xAI reasoning effort                               |
+| `providerOptions.extraOptions`            | object   | Additional provider-specific options               |
+| `providerOptions.onStepFinish`            | function | Callback when a step completes                     |
 
 ### Semantic Memory Options
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

- `providerOptions` typing in core is mostly generic, so provider-specific keys/options (e.g. `openai.reasoningEffort`, `anthropic.sendReasoning`) do not provide strong IntelliSense guidance.
- Docs/examples still show some non-provider-scoped `providerOptions` shapes (e.g. `providerOptions.reasoningEffort`).

## What is the new behavior?

- `ProviderOptions` now includes provider-scoped typed buckets for:
  - `openai`
  - `anthropic`
  - `google`
  - `xai`
- Existing top-level fallback fields remain supported for backward compatibility.
- Type coverage added in `agent.spec-d.ts` for provider-scoped usage.
- Docs updated to show provider-scoped structure:
  - `website/docs/agents/providers.md`
  - `website/docs/api/endpoints/agents.md`
  - `website/docs/ui/ai-sdk-integration.md`
- Changeset added:
  - `.changeset/yellow-cars-smile.md`

fixes (issue)
- N/A

## Notes for reviewers

- Validation run:
  - `pnpm --filter @voltagent/core typecheck`
  - `pnpm --filter @voltagent/core test -- agent.spec-d.ts`
- No runtime behavior changes intended; this is primarily type-safety + docs alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider-specific options now available with structured configuration for OpenAI, Anthropic, Google, and Xai, including settings such as reasoningEffort, textVerbosity, sendReasoning, and thinkingConfig.

* **Documentation**
  * Updated API documentation and integration examples to demonstrate provider-scoped options usage across agent endpoints and UI implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->