### PR TITLE
fix(core): persist step history incrementally during multi-step runs

### DIFF
--- a/.changeset/four-drinks-rush.md
+++ b/.changeset/four-drinks-rush.md
@@ -1,0 +1,13 @@
+---
+"@voltagent/core": patch
+---
+
+fix: persist conversation progress incrementally during multi-step runs
+
+- Added step-level conversation persistence checkpoints so completed steps are no longer only saved at turn finish.
+- Tool completion steps (`tool-result` / `tool-error`) now trigger immediate persistence flushes in step mode.
+- Added configurable agent persistence options:
+  - `conversationPersistence.mode` (`"step"` or `"finish"`)
+  - `conversationPersistence.debounceMs`
+  - `conversationPersistence.flushOnToolResult`
+- Added global VoltAgent default `agentConversationPersistence` and wiring to registered agents.

--- a/packages/core/src/agent/step-persistence.spec.ts
+++ b/packages/core/src/agent/step-persistence.spec.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Agent } from "./agent";
+import type { AgentConversationPersistenceOptions } from "./types";
+
+type QueueMock = {
+  scheduleSave: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+};
+
+const createOperationContext = () =>
+  ({
+    operationId: "op-step-persist",
+    systemContext: new Map<string | symbol, unknown>(),
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+    },
+    abortController: new AbortController(),
+    userId: "user-1",
+    conversationId: "conv-1",
+  }) as any;
+
+const createStepEvent = (content: any[]) =>
+  ({
+    content,
+    response: {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "checkpoint" }],
+        },
+      ],
+    },
+  }) as any;
+
+const createHarness = (overrides: AgentConversationPersistenceOptions) => {
+  const agent = new Agent({
+    name: "step-persistence-agent",
+    instructions: "Test",
+    model: "openai/gpt-4o-mini",
+  });
+
+  const queue: QueueMock = {
+    scheduleSave: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const buffer = {
+    addModelMessages: vi.fn(),
+  };
+
+  const oc = createOperationContext();
+
+  const persistence = {
+    mode: "step" as const,
+    debounceMs: 200,
+    flushOnToolResult: true,
+    ...overrides,
+  };
+
+  vi.spyOn(agent as any, "getConversationBuffer").mockReturnValue(buffer);
+  vi.spyOn(agent as any, "getMemoryPersistQueue").mockReturnValue(queue);
+  vi.spyOn(agent as any, "getConversationPersistenceOptionsForContext").mockReturnValue(
+    persistence,
+  );
+  const recordStepResultsSpy = vi
+    .spyOn(agent as any, "recordStepResults")
+    .mockResolvedValue(undefined);
+
+  const handler = (agent as any).createStepHandler(oc, undefined) as (event: any) => Promise<void>;
+
+  return {
+    queue,
+    oc,
+    handler,
+    recordStepResultsSpy,
+  };
+};
+
+describe("Step-level persistence", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("schedules debounced persistence for non-tool steps in step mode", async () => {
+    const { handler, queue, oc, recordStepResultsSpy } = createHarness({ mode: "step" });
+
+    await handler(createStepEvent([{ type: "text", text: "hello" }]));
+
+    expect(queue.scheduleSave).toHaveBeenCalledTimes(1);
+    expect(queue.scheduleSave).toHaveBeenCalledWith(expect.anything(), oc);
+    expect(queue.flush).not.toHaveBeenCalled();
+    expect(recordStepResultsSpy).toHaveBeenCalledWith(undefined, oc, {
+      awaitPersistence: false,
+    });
+  });
+
+  it("flushes immediately when a tool result arrives in step mode", async () => {
+    const { handler, queue, oc, recordStepResultsSpy } = createHarness({ mode: "step" });
+
+    await handler(
+      createStepEvent([
+        {
+          type: "tool-result",
+          toolName: "search",
+          toolCallId: "call-1",
+          output: { ok: true },
+        },
+      ]),
+    );
+
+    expect(queue.flush).toHaveBeenCalledTimes(1);
+    expect(queue.flush).toHaveBeenCalledWith(expect.anything(), oc);
+    expect(queue.scheduleSave).not.toHaveBeenCalled();
+    expect(recordStepResultsSpy).toHaveBeenCalledWith(undefined, oc, {
+      awaitPersistence: true,
+    });
+  });
+
+  it("keeps finish mode behavior without incremental checkpoints", async () => {
+    const { handler, queue, recordStepResultsSpy } = createHarness({ mode: "finish" });
+
+    await handler(createStepEvent([{ type: "text", text: "hello" }]));
+
+    expect(queue.scheduleSave).not.toHaveBeenCalled();
+    expect(queue.flush).not.toHaveBeenCalled();
+    expect(recordStepResultsSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -601,6 +601,27 @@ export type AgentSummarizationOptions = {
   model?: AgentModelValue;
 };
 
+export type AgentConversationPersistenceMode = "finish" | "step";
+
+export type AgentConversationPersistenceOptions = {
+  /**
+   * `finish` persists only at operation completion.
+   * `step` checkpoints after each step (debounced) and flushes on tool completion by default.
+   * @default "step"
+   */
+  mode?: AgentConversationPersistenceMode;
+  /**
+   * Debounce duration (ms) for step-level persistence scheduling.
+   * @default 200
+   */
+  debounceMs?: number;
+  /**
+   * When true in `step` mode, tool-result/tool-error steps trigger an immediate flush.
+   * @default true
+   */
+  flushOnToolResult?: boolean;
+};
+
 /**
  * Agent configuration options
  */
@@ -632,6 +653,7 @@ export type AgentOptions = {
   workspaceSkillsPrompt?: WorkspaceSkillsPromptOptions | boolean;
   memory?: Memory | false;
   summarization?: AgentSummarizationOptions | false;
+  conversationPersistence?: AgentConversationPersistenceOptions;
 
   // Retriever/RAG
   retriever?: BaseRetriever;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,8 @@ export type { EmbeddingRouterModelId } from "./registries/embedding-model-router
 export * from "./events/types";
 export type {
   AgentOptions,
+  AgentConversationPersistenceMode,
+  AgentConversationPersistenceOptions,
   AgentSummarizationOptions,
   AgentModelReference,
   AgentModelConfig,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,6 +8,7 @@ import type { MCPServerFactory, MCPServerLike } from "@voltagent/internal/mcp";
 import type { DangerouslyAllowAny } from "@voltagent/internal/types";
 import type { A2AServerRegistry } from "./a2a";
 import type { Agent } from "./agent/agent";
+import type { AgentConversationPersistenceOptions } from "./agent/types";
 import type { AgentStatus } from "./agent/types";
 import type { MCPServerRegistry } from "./mcp";
 import type { Memory } from "./memory";
@@ -234,6 +235,10 @@ export type VoltAgentOptions = {
    * When enabled, agents expose searchTools/callTool and hide pool tools from the model.
    */
   toolRouting?: ToolRoutingConfig;
+  /**
+   * Default conversation persistence behavior for agents that don't define one.
+   */
+  agentConversationPersistence?: AgentConversationPersistenceOptions;
   /**
    * Optional global workspace instance or configuration.
    * Agents inherit this workspace unless they explicitly provide their own workspace or set it to false.

--- a/packages/core/src/voltagent.spec.ts
+++ b/packages/core/src/voltagent.spec.ts
@@ -108,4 +108,57 @@ describe("VoltAgent defaults", () => {
     expect(agent.getMemory()).toBe(sharedMemory);
     expect(workflow.memory).toBe(sharedMemory);
   });
+
+  it("applies default agent conversation persistence when agent does not configure it", () => {
+    const agent = new Agent({
+      name: "assistant",
+      instructions: "Be helpful.",
+      model: "openai/gpt-4o-mini",
+    });
+
+    new VoltAgent({
+      agents: { assistant: agent },
+      agentConversationPersistence: {
+        mode: "finish",
+        debounceMs: 10,
+        flushOnToolResult: false,
+      },
+      checkDependencies: false,
+    });
+
+    expect((agent as any).conversationPersistence).toMatchObject({
+      mode: "finish",
+      debounceMs: 10,
+      flushOnToolResult: false,
+    });
+  });
+
+  it("preserves explicit agent conversation persistence config", () => {
+    const agent = new Agent({
+      name: "assistant",
+      instructions: "Be helpful.",
+      model: "openai/gpt-4o-mini",
+      conversationPersistence: {
+        mode: "step",
+        debounceMs: 25,
+        flushOnToolResult: true,
+      },
+    });
+
+    new VoltAgent({
+      agents: { assistant: agent },
+      agentConversationPersistence: {
+        mode: "finish",
+        debounceMs: 0,
+        flushOnToolResult: false,
+      },
+      checkDependencies: false,
+    });
+
+    expect((agent as any).conversationPersistence).toMatchObject({
+      mode: "step",
+      debounceMs: 25,
+      flushOnToolResult: true,
+    });
+  });
 });

--- a/website/docs/agents/memory/overview.md
+++ b/website/docs/agents/memory/overview.md
@@ -68,6 +68,9 @@ Notes:
 - VoltOps Observability consumes these records to render the Memory Explorer “Steps” tab and to correlate traces/logs with memory.
 - Adapters that implement the step APIs persist sub-agent activity alongside primary agent steps, so hierarchies stay visible.
 - If an adapter does not support steps, the console warns with “Conversation steps are not supported by this memory adapter.”
+- By default, agents checkpoint conversation progress during multi-step runs (`conversationPersistence.mode: "step"`).
+- Tool completion events (`tool-result`, `tool-error`) trigger immediate flushes by default (`flushOnToolResult: true`), reducing history loss risk on crashes or process interruption.
+- Use `conversationPersistence.mode: "finish"` if you want end-of-turn persistence only.
 
 ### Semantic Search (Optional)
 

--- a/website/docs/agents/overview.md
+++ b/website/docs/agents/overview.md
@@ -212,6 +212,35 @@ console.log(haiku.output);
 
 Summarization inserts a system summary and keeps the last N non-system messages before each model call. Configure it with the `summarization` option on the agent. See [Summarization](./summarization.md) for configuration and storage details.
 
+### Conversation Persistence
+
+VoltAgent persists conversation messages and step records while a run is executing. By default, it uses step-level checkpoints, which is safer for long multi-step tool chains.
+
+```ts
+const agent = new Agent({
+  name: "Assistant",
+  instructions: "Help users reliably.",
+  model: "openai/gpt-4o-mini",
+  conversationPersistence: {
+    mode: "step", // "step" (default) or "finish"
+    debounceMs: 200, // default
+    flushOnToolResult: true, // default
+  },
+});
+```
+
+You can also override this per call:
+
+```ts
+await agent.generateText("Run the workflow", {
+  conversationPersistence: {
+    mode: "finish",
+  },
+});
+```
+
+`mode: "step"` schedules persistence during execution and flushes immediately on tool completion by default. `mode: "finish"` keeps the legacy behavior of persisting only at operation completion.
+
 ### Input Types
 
 All methods accept either a string or an array of messages:

--- a/website/docs/agents/voltagent-instance.md
+++ b/website/docs/agents/voltagent-instance.md
@@ -28,7 +28,7 @@ new VoltAgent({
 ## What VoltAgent Manages
 
 - Registers agents and workflows for API access and observability.
-- Applies global defaults (logger, observability, memory).
+- Applies global defaults (logger, observability, memory, conversation persistence).
 - Boots HTTP or serverless providers.
 - Registers triggers, MCP servers, and A2A servers.
 - Coordinates graceful shutdown for servers and telemetry.
@@ -84,6 +84,28 @@ new VoltAgent({
 - Workflows: workflow `memory` > `workflowMemory` > `memory` > built-in in-memory
 
 See [Memory Overview](/docs/agents/memory/overview) for adapter options.
+
+## Conversation Persistence Defaults
+
+Set a default persistence strategy for agents that do not explicitly define `conversationPersistence`.
+
+```ts
+new VoltAgent({
+  agents: { assistant },
+  agentConversationPersistence: {
+    mode: "step", // default
+    debounceMs: 200, // default
+    flushOnToolResult: true, // default
+  },
+});
+```
+
+**Precedence**
+
+- Per-call `options.conversationPersistence`
+- Agent `conversationPersistence`
+- VoltAgent `agentConversationPersistence`
+- Built-in defaults (`mode: "step"`, `debounceMs: 200`, `flushOnToolResult: true`)
 
 ## Observability and Logging
 

--- a/website/docs/api/endpoints/agents.md
+++ b/website/docs/api/endpoints/agents.md
@@ -103,6 +103,11 @@ Generate a text response from an agent synchronously.
     "context": {
       "role": "admin",
       "tier": "premium"
+    },
+    "conversationPersistence": {
+      "mode": "step",
+      "debounceMs": 200,
+      "flushOnToolResult": true
     }
   }
 }
@@ -183,6 +188,9 @@ Generate a text response from an agent synchronously.
 | `stopSequences` | string[] | - | Stop generation sequences |
 | `providerOptions` | object | - | Provider-specific options |
 | `context` | object | - | Dynamic agent context |
+| `conversationPersistence.mode` | string | `"step"` | Persistence strategy: `"step"` or `"finish"` |
+| `conversationPersistence.debounceMs` | number | `200` | Debounce interval for step checkpoint persistence |
+| `conversationPersistence.flushOnToolResult` | boolean | `true` | Flush immediately on `tool-result`/`tool-error` in step mode |
 
 **Response:**
 

--- a/website/docs/ui/ai-sdk-integration.md
+++ b/website/docs/ui/ai-sdk-integration.md
@@ -341,12 +341,29 @@ export function ChatInterface() {
 
 ### VoltAgent Specific
 
-| Option           | Type   | Description                                        |
-| ---------------- | ------ | -------------------------------------------------- |
-| `userId`         | string | User identifier for memory persistence             |
-| `conversationId` | string | Conversation thread ID                             |
-| `context`        | object | Dynamic context (converted to Map internally)      |
-| `contextLimit`   | number | Number of previous messages to include from memory |
+| Option                                      | Type    | Description                                                                    |
+| ------------------------------------------- | ------- | ------------------------------------------------------------------------------ |
+| `userId`                                    | string  | User identifier for memory persistence                                         |
+| `conversationId`                            | string  | Conversation thread ID                                                         |
+| `context`                                   | object  | Dynamic context (converted to Map internally)                                  |
+| `contextLimit`                              | number  | Number of previous messages to include from memory                             |
+| `conversationPersistence.mode`              | string  | `"step"` (default) or `"finish"`                                               |
+| `conversationPersistence.debounceMs`        | number  | Debounce window in milliseconds (default: `200`)                               |
+| `conversationPersistence.flushOnToolResult` | boolean | Flush immediately on `tool-result`/`tool-error` in step mode (default: `true`) |
+
+Example:
+
+```ts
+options: {
+  userId,
+  conversationId,
+  conversationPersistence: {
+    mode: "step",
+    debounceMs: 200,
+    flushOnToolResult: true,
+  },
+}
+```
 
 ### AI SDK Core Options
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

During multi-step runs, conversation and tool-call history are effectively persisted at the end of the turn. If the process is interrupted mid-run, completed intermediate steps/tool results can be lost.

## What is the new behavior?

- Added configurable conversation persistence strategy:
  - `conversationPersistence.mode` (`"step" | "finish"`)
  - `conversationPersistence.debounceMs`
  - `conversationPersistence.flushOnToolResult`
- Default behavior is now step-level checkpointing (`mode: "step"`), with immediate flush on `tool-result` / `tool-error` by default.
- Step records are persisted incrementally during execution to improve crash resilience.
- Added VoltAgent-level default: `agentConversationPersistence`.
- Added tests for step persistence behavior and VoltAgent default application.
- Updated docs for Agent, VoltAgent, API endpoint options, and AI SDK UI integration.

fixes (issue)

N/A

## Notes for reviewers

- Core runtime changes are in `packages/core/src/agent/agent.ts` and related option types.
- New tests: `packages/core/src/agent/step-persistence.spec.ts` and updates in `packages/core/src/voltagent.spec.ts`.
- Changeset: `.changeset/four-drinks-rush.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist conversation and tool-call history incrementally during multi-step runs to reduce data loss if a run stops mid-execution. Adds a configurable persistence strategy with step-level checkpoints by default and immediate flush on tool results.

- **New Features**
  - Step-level persistence with debounced checkpoints; flushes immediately on tool-result/tool-error.
  - New options: conversationPersistence.mode ("step" | "finish"), conversationPersistence.debounceMs, conversationPersistence.flushOnToolResult.
  - VoltAgent default agentConversationPersistence to apply when an agent doesn’t set one.
  - Incremental step records are saved during execution; improved handling for subagent bails.
  - Tests and docs updated (Agent, VoltAgent, API options, UI integration).

- **Migration**
  - To keep previous behavior, set conversationPersistence.mode to "finish" on the agent or per call.
  - Tune write frequency with conversationPersistence.debounceMs, and disable immediate writes by setting flushOnToolResult to false.

<sup>Written for commit 8e48355d71f9e7c99c459f41c812f11fb4aa858f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added step-level conversation persistence checkpoints that save completed steps before operation end, with configurable mode ("step" or "finish"), debounce timing, and automatic flushing on tool completion.
  * Introduced per-call persistence behavior overrides and global VoltAgent defaults for agent persistence configuration.

* **Documentation**
  * Updated guides with conversation persistence configuration details, precedence rules, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->