### PR TITLE
feat: expose provider sandbox instances (E2B + Daytona)

### DIFF
--- a/.changeset/tall-lions-give.md
+++ b/.changeset/tall-lions-give.md
@@ -1,0 +1,8 @@
+---
+"@voltagent/sandbox-e2b": patch
+---
+
+feat: expose the underlying E2B SDK sandbox instance from `E2BSandbox`.
+
+- Added a public `getSandbox()` method that returns the original `e2b` `Sandbox` instance so provider-specific APIs (for example `files.read`) can be used directly.
+- Added `E2BSandboxInstance` type export for the underlying SDK sandbox type.

--- a/.changeset/wet-bees-poke.md
+++ b/.changeset/wet-bees-poke.md
@@ -1,0 +1,8 @@
+---
+"@voltagent/sandbox-daytona": patch
+---
+
+feat: expose the underlying Daytona SDK sandbox instance from `DaytonaSandbox`.
+
+- Added a public `getSandbox()` method that returns the original `@daytonaio/sdk` `Sandbox` instance so provider-specific APIs can be used directly.
+- Added `DaytonaSandboxInstance` type export for the underlying SDK sandbox type.

--- a/website/docs/workspaces/sandbox.md
+++ b/website/docs/workspaces/sandbox.md
@@ -127,6 +127,35 @@ const daytonaWorkspace = new Workspace({
 });
 ```
 
+If you need provider-specific APIs, keep a reference to the provider and access its native SDK instance:
+
+```ts
+import { E2BSandbox } from "@voltagent/sandbox-e2b";
+
+const sandbox = new E2BSandbox({
+  apiKey: process.env.E2B_API_KEY,
+});
+
+const workspace = new Workspace({ sandbox });
+
+const e2bSandbox = await sandbox.getSandbox();
+const bytes = await e2bSandbox.files.read("/workspace/file.txt", { format: "bytes" });
+```
+
+```ts
+import { DaytonaSandbox } from "@voltagent/sandbox-daytona";
+
+const sandbox = new DaytonaSandbox({
+  apiKey: process.env.DAYTONA_API_KEY,
+  apiUrl: "http://localhost:3000",
+});
+
+const workspace = new Workspace({ sandbox });
+
+const daytonaSandbox = await sandbox.getSandbox();
+const response = await daytonaSandbox.process.executeCommand("ls -la");
+```
+
 ## Custom sandbox provider
 
 You can implement `WorkspaceSandbox` and plug it into `Workspace` directly.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

- `@voltagent/sandbox-e2b` and `@voltagent/sandbox-daytona` do not expose their original provider SDK sandbox instances via public API.
- Users who need provider-specific APIs (for example E2B `files.read(..., { format: "bytes" })`) must access private internals with unsafe casts.

## What is the new behavior?

- Added public `getSandbox()` accessors to both providers:
  - `E2BSandbox#getSandbox()`
  - `DaytonaSandbox#getSandbox()`
- Added exported SDK instance types:
  - `E2BSandboxInstance`
  - `DaytonaSandboxInstance`
- Updated workspace sandbox docs with provider-specific usage examples.
- Simplified docs examples to rely on TypeScript inference instead of explicit `Sandbox` type annotations.

fixes #1062

## Notes for reviewers

- This keeps existing lazy-initialization/caching logic; only the public accessor surface is added.
- Added separate changesets for both `@voltagent/sandbox-e2b` and `@voltagent/sandbox-daytona`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the native E2B and Daytona sandbox instances via a new getSandbox() so you can use provider-specific APIs safely without unsafe casts. Fixes #1062.

- **New Features**
  - Export E2BSandboxInstance and DaytonaSandboxInstance types for direct SDK usage.
  - Update docs with provider-specific examples; simplify workspace examples using TypeScript inference.
  - Preserve existing lazy initialization and caching; internal resolver renamed to resolveSandbox.

<sup>Written for commit 2b2cb118bd5e859d5b30963122bd0d8cedd187b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added access to underlying E2B and Daytona sandbox instances for direct provider-specific API usage.
  * Exported new public types for type-safe sandbox instance access.

* **Documentation**
  * Added comprehensive examples showing how to leverage provider-specific functionality and native SDK operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->