### PR TITLE
fix(core): auto-register standalone Agent VoltOps client for observability export

### DIFF
--- a/.changeset/cold-humans-travel.md
+++ b/.changeset/cold-humans-travel.md
@@ -1,0 +1,10 @@
+---
+"@voltagent/core": patch
+---
+
+fix: auto-register standalone Agent VoltOps client for remote observability export
+
+- When an `Agent` is created with `voltOpsClient` and no global client is registered, the agent now seeds `AgentRegistry` with that client.
+- This enables remote OTLP trace/log exporters that resolve credentials via global registry in standalone `new Agent(...)` setups (without `new VoltAgent(...)`).
+- Existing global client precedence is preserved; agent-level client does not override an already configured global client.
+- Added coverage in `client-priority.spec.ts` for both auto-register and non-override scenarios.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -877,6 +877,12 @@ export class Agent {
       options.logger,
     );
 
+    // Allow standalone Agent usage (without VoltAgent wrapper) to initialize
+    // remote observability processors that depend on the global VoltOps client.
+    if (this.voltOpsClient && !AgentRegistry.getInstance().getGlobalVoltOpsClient()) {
+      AgentRegistry.getInstance().setGlobalVoltOpsClient(this.voltOpsClient);
+    }
+
     // Log agent creation
     this.logger.debug(`Agent created: ${this.name}`, {
       event: LogEvents.AGENT_CREATED,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

When `Agent` is used standalone with `voltOpsClient` (without creating `new VoltAgent(...)`), remote observability exporters resolve credentials from `AgentRegistry` global client and may fail to initialize because only agent-local client is set.

## What is the new behavior?

`Agent` now auto-registers its `voltOpsClient` into `AgentRegistry` when no global client exists.

This preserves existing precedence:
- if a global client already exists, it is not overridden
- if no global client exists, standalone `Agent` setup works for remote observability export

Added tests in `src/voltops/client-priority.spec.ts` for both auto-register and non-override scenarios.

Validation run:
- `pnpm --filter @voltagent/core exec vitest run src/voltops/client-priority.spec.ts`

fixes (issue)

N/A

## Notes for reviewers

- This closes the framework gap that required app-side workaround (`AgentRegistry.getInstance().setGlobalVoltOpsClient(...)`) in standalone integrations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standalone Agent now auto-registers its voltOpsClient in the AgentRegistry so remote observability exporters can resolve credentials. Preserves precedence and never overrides an existing global client.

- Bug Fixes
  - Seed AgentRegistry with the agent’s voltOpsClient when no global client is set.
  - Do not override an existing global client.
  - Added tests for auto-register and non-override scenarios.

<sup>Written for commit a63faa1103fb5f64407af50c005398b7ec1f456f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent instances now automatically register their observability client to the global registry when no global client is already configured. This enables remote observability and OTLP exporters to function properly in standalone Agent setups while preserving existing global client precedence.

* **Tests**
  * Added test coverage for auto-registration behavior and global client priority handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->