### PR TITLE
fix(ag-ui): preserve feedback metadata in AG-UI streams

### DIFF
--- a/.changeset/wise-pans-arrive.md
+++ b/.changeset/wise-pans-arrive.md
@@ -4,6 +4,6 @@
 
 fix: preserve assistant feedback metadata across AG-UI streams
 
-- Map VoltAgent `message-metadata` stream chunks into AG-UI-compatible events so feedback metadata reaches chat clients.
-- Carry metadata through a dedicated internal tool-result marker that can be correlated to the assistant message id.
-- Prevent those internal metadata marker messages from being sent back to the model on subsequent turns.
+- Map VoltAgent `message-metadata` stream chunks to AG-UI `CUSTOM` events, which are the protocol-native channel for application-specific metadata.
+- Keep emitting a legacy internal tool-result marker for backward compatibility with existing clients.
+- Prevent internal metadata marker tool messages from being sent back to the model on subsequent turns.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`Agent.streamText(...).toUIMessageStream()` can emit `message-metadata` chunks (for example feedback metadata), but the AG-UI adapter drops unknown chunk types.

As a result, chat clients do not reliably receive assistant feedback metadata.

## What is the new behavior?

- `@voltagent/ag-ui` now maps `message-metadata` chunks to AG-UI `CUSTOM` events (`voltagent.message_metadata`), which is the protocol-native channel for app-specific metadata.
- For backward compatibility, it also emits the existing internal tool-result marker so current clients keep working.
- Internal metadata marker tool messages remain filtered out from subsequent model input.

fixes (issue)

N/A

## Notes for reviewers

- Scope intentionally limited to `packages/ag-ui/src/voltagent-agent.ts`.
- Validation: `pnpm -C packages/ag-ui exec tsc --noEmit`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve assistant feedback metadata across streaming so feedback reliably reaches chat clients.
* **New Features**
  * Streamed message metadata is now surfaced to clients as protocol-native events for app-level handling.
* **Chores**
  * Maintain a legacy compatibility marker so existing clients continue to work; internal metadata markers are not replayed to the model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->