### PR TITLE
fix(core): persist workflow context mutations across steps

### DIFF
--- a/.changeset/neat-context-persist.md
+++ b/.changeset/neat-context-persist.md
@@ -1,0 +1,10 @@
+---
+"@voltagent/core": patch
+---
+
+fix: persist workflow context mutations across steps and downstream agents/tools
+
+Workflows now consistently use the execution context map when building step state.
+This ensures context written in one step is visible in later steps and in `andAgent` calls.
+
+Also aligns workflow event/stream context payloads with the normalized runtime context.

--- a/packages/core/src/workflow/core.ts
+++ b/packages/core/src/workflow/core.ts
@@ -923,7 +923,7 @@ export function createWorkflow<
           workflowName: name,
           status: "running" as const,
           input,
-          context: options?.context ? Array.from(options.context.entries()) : undefined,
+          context: options?.context ? Array.from(contextMap.entries()) : undefined,
           workflowState: workflowStateStore,
           userId: options?.userId,
           conversationId: options?.conversationId,
@@ -951,7 +951,7 @@ export function createWorkflow<
 
       // Create stream writer - real one for streaming, no-op for regular execution
       const streamWriter = streamController
-        ? new WorkflowStreamWriterImpl(streamController, executionId, id, name, 0, options?.context)
+        ? new WorkflowStreamWriterImpl(streamController, executionId, id, name, 0, contextMap)
         : new NoOpWorkflowStreamWriter();
 
       // Initialize workflow execution context with the correct execution ID
@@ -1013,7 +1013,7 @@ export function createWorkflow<
         from: name,
         input: input as Record<string, any>,
         status: "running",
-        context: options?.context,
+        context: contextMap,
         timestamp: new Date().toISOString(),
       });
 
@@ -1035,6 +1035,7 @@ export function createWorkflow<
         // When resuming, use the existing execution ID
         stateManager.start(input, {
           ...options,
+          context: contextMap,
           executionId: executionId, // Use the resumed execution ID
           active: options.resumeFrom.resumeStepIndex,
           workflowState: workflowStateStore,
@@ -1042,6 +1043,7 @@ export function createWorkflow<
       } else {
         stateManager.start(input, {
           ...options,
+          context: contextMap,
           executionId: executionId, // Use the created execution ID
           workflowState: workflowStateStore,
         });
@@ -1191,7 +1193,7 @@ export function createWorkflow<
               input: stateManager.state.data,
               output: undefined,
               status: "cancelled",
-              context: options?.context,
+              context: contextMap,
               timestamp: new Date().toISOString(),
               stepIndex: index,
               stepType: step.type,
@@ -1234,7 +1236,7 @@ export function createWorkflow<
               executionId,
               from: name,
               status: "cancelled",
-              context: options?.context,
+              context: contextMap,
               timestamp: new Date().toISOString(),
               metadata: { reason },
             });
@@ -1421,7 +1423,7 @@ export function createWorkflow<
                 step.id,
                 step.name || step.id,
                 index,
-                options?.context,
+                contextMap,
               )
             : new NoOpWorkflowStreamWriter();
           executionContext.streamWriter = stepWriter;
@@ -1433,7 +1435,7 @@ export function createWorkflow<
             from: step.name || step.id,
             input: stateManager.state.data,
             status: "running",
-            context: options?.context,
+            context: contextMap,
             timestamp: new Date().toISOString(),
             stepIndex: index,
             stepType: step.type,
@@ -1531,7 +1533,7 @@ export function createWorkflow<
               input: stateManager.state.data,
               output: undefined,
               status: "suspended",
-              context: options?.context,
+              context: contextMap,
               timestamp: new Date().toISOString(),
               stepIndex: index,
               metadata: {
@@ -1625,7 +1627,7 @@ export function createWorkflow<
                     step.id,
                     step.name || step.id,
                     index,
-                    options?.context,
+                    contextMap,
                   )
                 : new NoOpWorkflowStreamWriter();
 
@@ -1725,7 +1727,7 @@ export function createWorkflow<
                 input: stateManager.state.data,
                 output: result,
                 status: isSkipped ? "skipped" : "success",
-                context: options?.context,
+                context: contextMap,
                 timestamp: new Date().toISOString(),
                 stepIndex: index,
                 stepType: step.type as any,
@@ -1887,7 +1889,7 @@ export function createWorkflow<
           from: name,
           output: finalState.result,
           status: "success",
-          context: options?.context,
+          context: contextMap,
           timestamp: new Date().toISOString(),
         });
 
@@ -1930,7 +1932,7 @@ export function createWorkflow<
             executionId,
             from: name,
             status: "cancelled",
-            context: options?.context,
+            context: contextMap,
             timestamp: new Date().toISOString(),
             metadata: cancellationReason ? { reason: cancellationReason } : undefined,
           });
@@ -2024,7 +2026,7 @@ export function createWorkflow<
           from: name,
           status: "error",
           error: error,
-          context: options?.context,
+          context: contextMap,
           timestamp: new Date().toISOString(),
         });
 

--- a/packages/core/src/workflow/internal/utils.ts
+++ b/packages/core/src/workflow/internal/utils.ts
@@ -27,7 +27,7 @@ export function convertWorkflowStateToParam<INPUT>(
     executionId: state.executionId,
     conversationId: state.conversationId,
     userId: state.userId,
-    context: state.context,
+    context: executionContext?.context ?? state.context,
     workflowState: state.workflowState,
     active: state.active,
     startAt: state.startAt,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Workflow step context mutations are not reliably visible to downstream steps/agents when context is not explicitly initialized via `run(..., { context })`.

In issue #1003, setting `state.context` inside an early step (e.g. `state.context?.set("new_key", "new_value")`) could appear to work in-step but later `andAgent`/tool calls still saw an empty context.

## What is the new behavior?

- Workflow execution now consistently initializes and propagates the normalized runtime context map through step state and execution context.
- Step mutations to `state.context` are preserved and visible in downstream steps and `andAgent` calls.
- Workflow stream/event context payloads are aligned with the same normalized runtime context.
- Added regression tests for:
  - context initialization + persistence across steps
  - context mutation visibility in downstream `andAgent` calls

fixes #1003

## Notes for reviewers

### Code changes
- `packages/core/src/workflow/core.ts`
  - Use `contextMap` consistently for state initialization, stream writer context, and emitted events.
- `packages/core/src/workflow/internal/utils.ts`
  - Prefer execution context map in `convertWorkflowStateToParam` (`executionContext?.context ?? state.context`).
- `packages/core/src/workflow/core.spec.ts`
  - Added coverage for context persistence and downstream `andAgent` visibility.
- `.changeset/neat-context-persist.md`
  - Patch release note for `@voltagent/core`.

### Verification
- `pnpm --filter @voltagent/core test -- workflow/core.spec.ts workflow/usage-tracking.spec.ts workflow/steps/and-agent.spec.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist workflow context mutations across steps and downstream agents/tools, fixing missing context in later steps. Addresses #1003.

- **Bug Fixes**
  - Initialize and propagate a normalized context map through execution and step state.
  - Preserve state.context mutations and pass context to andAgent/tool calls.
  - Align workflow stream/event context payloads with the runtime context.
  - Add regression tests for context init, cross-step persistence, and andAgent visibility.

<sup>Written for commit cd38640b2e00995e53832ea64f030e43d629f045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Context mutations now persist across workflow steps and are accessible in downstream agents and tool calls
  - Execution context is consistently used throughout workflow execution to ensure proper context propagation across all steps
  - Workflow event and stream context payloads are now aligned with runtime context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->