### PR TITLE
feat(workflow): add attach endpoint for in-progress streams

### DIFF
--- a/.changeset/workflow-stream-attach-1081.md
+++ b/.changeset/workflow-stream-attach-1081.md
@@ -1,0 +1,14 @@
+---
+"@voltagent/core": patch
+"@voltagent/server-core": patch
+"@voltagent/server-hono": patch
+"@voltagent/serverless-hono": patch
+"@voltagent/server-elysia": patch
+---
+
+Add stream attach support for in-progress workflow executions.
+
+- Add `GET /workflows/:id/executions/:executionId/stream` to attach to an active workflow SSE stream.
+- Add replay support for missed SSE events via `fromSequence` and `Last-Event-ID`.
+- Keep `POST /workflows/:id/stream` behavior unchanged for starting new executions.
+- Ensure streamed workflow resume uses a fresh suspend controller so attach clients continue receiving events after resume.

--- a/packages/core/src/workflow/core.ts
+++ b/packages/core/src/workflow/core.ts
@@ -2204,6 +2204,9 @@ export function createWorkflow<
             },
           );
 
+          // Use a fresh controller for this resumed run.
+          const resumedSuspendController = createDefaultSuspendController();
+
           // Execute the resume by calling stream again with resume options
           const executeResume = async () => {
             // Get the suspension metadata
@@ -2231,7 +2234,7 @@ export function createWorkflow<
                 resumeStepIndex,
                 resumeData: input,
               },
-              suspendController,
+              suspendController: resumedSuspendController,
             };
 
             // Re-execute with streaming from the suspension point
@@ -2283,10 +2286,10 @@ export function createWorkflow<
               return streamResult.resume(input2, opts);
             },
             suspend: (reason?: string) => {
-              suspendController.suspend(reason);
+              resumedSuspendController.suspend(reason);
             },
             cancel: (reason?: string) => {
-              suspendController.cancel(reason);
+              resumedSuspendController.cancel(reason);
             },
             abort: () => streamController.abort(),
             toUIMessageStreamResponse: eventToUIMessageStreamResponse(streamController),

--- a/packages/server-core/src/auth/defaults.spec.ts
+++ b/packages/server-core/src/auth/defaults.spec.ts
@@ -108,6 +108,7 @@ describe("Auth Defaults", () => {
       it("should require auth for workflow execution endpoints", () => {
         expect(requiresAuth("POST", "/workflows/my-workflow/run")).toBe(true);
         expect(requiresAuth("POST", "/workflows/123/stream")).toBe(true);
+        expect(requiresAuth("GET", "/workflows/123/executions/exec-1/stream")).toBe(true);
       });
 
       it("should require auth for workflow control endpoints", () => {

--- a/packages/server-core/src/auth/defaults.ts
+++ b/packages/server-core/src/auth/defaults.ts
@@ -112,6 +112,7 @@ export const PROTECTED_ROUTES = [
   // ========================================
   "POST /workflows/:id/run", // Run workflow
   "POST /workflows/:id/stream", // Stream workflow execution
+  "GET /workflows/:id/executions/:executionId/stream", // Attach workflow stream execution
 
   // ========================================
   // WORKFLOW CONTROL (State Modification)

--- a/packages/server-core/src/edge.ts
+++ b/packages/server-core/src/edge.ts
@@ -23,6 +23,7 @@ export {
   handleGetWorkflow,
   handleExecuteWorkflow,
   handleStreamWorkflow,
+  handleAttachWorkflowStream,
   handleSuspendWorkflow,
   handleResumeWorkflow,
   handleListWorkflowRuns,

--- a/packages/server-core/src/handlers/workflow.stream-attach.handlers.spec.ts
+++ b/packages/server-core/src/handlers/workflow.stream-attach.handlers.spec.ts
@@ -1,0 +1,263 @@
+import type { ServerProviderDeps, WorkflowStateEntry } from "@voltagent/core";
+import type { Logger } from "@voltagent/internal";
+import { describe, expect, it, vi } from "vitest";
+import type { ErrorResponse } from "../types/responses";
+import { isErrorResponse } from "../types/responses";
+import { handleAttachWorkflowStream, handleStreamWorkflow } from "./workflow.handlers";
+
+type ParsedSSEEvent = {
+  id?: string;
+  data: Record<string, unknown>;
+};
+
+function createLogger(): Logger {
+  return {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    level: "info",
+    silent: vi.fn(),
+  } as unknown as Logger;
+}
+
+function createSuspendController() {
+  return {
+    signal: new AbortController().signal,
+    suspend: vi.fn(),
+    cancel: vi.fn(),
+    isSuspended: vi.fn().mockReturnValue(false),
+    isCancelled: vi.fn().mockReturnValue(false),
+    getReason: vi.fn(),
+    getCancelReason: vi.fn(),
+  };
+}
+
+function createDeps(options?: {
+  workflowExists?: boolean;
+  workflowState?: WorkflowStateEntry | null;
+  streamFactory?: () => any;
+}): {
+  deps: ServerProviderDeps;
+  getWorkflowState: ReturnType<typeof vi.fn>;
+} {
+  const getWorkflowState = vi.fn().mockResolvedValue(options?.workflowState ?? null);
+  const stream = options?.streamFactory ? options.streamFactory : vi.fn();
+
+  const workflow = {
+    createSuspendController: vi.fn().mockReturnValue(createSuspendController()),
+    stream,
+    memory: {
+      getWorkflowState,
+      queryWorkflowRuns: vi.fn().mockResolvedValue([]),
+    },
+  };
+
+  const deps = {
+    agentRegistry: {} as any,
+    workflowRegistry: {
+      getWorkflow: vi.fn((id: string) => {
+        if (options?.workflowExists === false || id !== "wf-1") {
+          return undefined;
+        }
+
+        return { workflow };
+      }),
+      getWorkflowsForApi: vi.fn(),
+      getWorkflowDetailForApi: vi.fn(),
+      getWorkflowCount: vi.fn(),
+      getAllWorkflowIds: vi.fn().mockReturnValue(["wf-1"]),
+      on: vi.fn(),
+      off: vi.fn(),
+      activeExecutions: new Map(),
+      resumeSuspendedWorkflow: vi.fn(),
+    },
+    triggerRegistry: {} as any,
+  } as unknown as ServerProviderDeps;
+
+  return { deps, getWorkflowState };
+}
+
+async function readSSEEvent(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<ParsedSSEEvent> {
+  const { done, value } = await reader.read();
+  expect(done).toBe(false);
+  expect(value).toBeDefined();
+
+  const chunk = new TextDecoder().decode(value);
+  const lines = chunk
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+
+  const dataLines: string[] = [];
+  let id: string | undefined;
+
+  for (const line of lines) {
+    if (line.startsWith("id:")) {
+      id = line.slice(3).trim();
+      continue;
+    }
+
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trim());
+    }
+  }
+
+  return {
+    id,
+    data: JSON.parse(dataLines.join("\n")) as Record<string, unknown>,
+  };
+}
+
+function assertErrorResponse(
+  value: ReadableStream | ErrorResponse,
+): asserts value is ErrorResponse {
+  expect(isErrorResponse(value)).toBe(true);
+}
+
+describe("workflow stream attach handler", () => {
+  it("returns 404 when workflow does not exist", async () => {
+    const logger = createLogger();
+    const { deps } = createDeps({ workflowExists: false });
+
+    const response = await handleAttachWorkflowStream("wf-1", "exec-1", {}, deps, logger);
+
+    assertErrorResponse(response);
+    expect(response.httpStatus).toBe(404);
+    expect(response.error).toContain("Workflow not found");
+  });
+
+  it("returns 409 when execution is terminal and not streamable", async () => {
+    const logger = createLogger();
+    const { deps } = createDeps({
+      workflowState: {
+        id: "exec-1",
+        workflowId: "wf-1",
+        workflowName: "Workflow 1",
+        status: "completed",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const response = await handleAttachWorkflowStream("wf-1", "exec-1", {}, deps, logger);
+
+    assertErrorResponse(response);
+    expect(response.httpStatus).toBe(409);
+    expect(response.error).toContain("not streamable");
+  });
+
+  it("returns 409 when execution exists but has no active stream session", async () => {
+    const logger = createLogger();
+    const { deps } = createDeps({
+      workflowState: {
+        id: "exec-1",
+        workflowId: "wf-1",
+        workflowName: "Workflow 1",
+        status: "running",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const response = await handleAttachWorkflowStream("wf-1", "exec-1", {}, deps, logger);
+
+    assertErrorResponse(response);
+    expect(response.httpStatus).toBe(409);
+    expect(response.error).toContain("no active stream context");
+  });
+
+  it("attaches to active stream and replays from sequence cursor", async () => {
+    const logger = createLogger();
+
+    let releaseSecondEvent: (() => void) | null = null;
+    const secondEventReady = new Promise<void>((resolve) => {
+      releaseSecondEvent = resolve;
+    });
+
+    const executionId = "exec-stream-1";
+    const { deps } = createDeps({
+      workflowState: {
+        id: executionId,
+        workflowId: "wf-1",
+        workflowName: "Workflow 1",
+        status: "running",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      streamFactory: () => ({
+        executionId,
+        [Symbol.asyncIterator]: async function* () {
+          yield {
+            type: "workflow-start",
+            executionId,
+            from: "Workflow 1",
+            status: "running",
+            timestamp: new Date().toISOString(),
+          };
+
+          await secondEventReady;
+
+          yield {
+            type: "step-complete",
+            executionId,
+            from: "Step 1",
+            status: "success",
+            timestamp: new Date().toISOString(),
+          };
+        },
+        result: Promise.resolve({ ok: true }),
+        status: Promise.resolve("completed"),
+        endAt: Promise.resolve(new Date("2026-01-01T00:00:00.000Z")),
+      }),
+    });
+
+    const initialStreamResponse = await handleStreamWorkflow("wf-1", { input: {} }, deps, logger);
+    expect(isErrorResponse(initialStreamResponse)).toBe(false);
+
+    if (isErrorResponse(initialStreamResponse)) {
+      return;
+    }
+
+    const primaryReader = initialStreamResponse.getReader();
+    const firstEvent = await readSSEEvent(primaryReader);
+    expect(firstEvent.data.type).toBe("workflow-start");
+
+    const attachResponse = await handleAttachWorkflowStream(
+      "wf-1",
+      executionId,
+      {
+        fromSequence: firstEvent.id,
+      },
+      deps,
+      logger,
+    );
+    expect(isErrorResponse(attachResponse)).toBe(false);
+
+    if (isErrorResponse(attachResponse)) {
+      return;
+    }
+
+    const attachedReader = attachResponse.getReader();
+
+    expect(releaseSecondEvent).not.toBeNull();
+    releaseSecondEvent?.();
+
+    const primarySecond = await readSSEEvent(primaryReader);
+    expect(primarySecond.data.type).toBe("step-complete");
+
+    const attachedSecond = await readSSEEvent(attachedReader);
+    expect(attachedSecond.data.type).toBe("step-complete");
+
+    const primaryFinal = await readSSEEvent(primaryReader);
+    expect(primaryFinal.data.type).toBe("workflow-result");
+
+    const attachedFinal = await readSSEEvent(attachedReader);
+    expect(attachedFinal.data.type).toBe("workflow-result");
+  });
+});

--- a/packages/server-core/src/routes/definitions.ts
+++ b/packages/server-core/src/routes/definitions.ts
@@ -509,6 +509,33 @@ export const WORKFLOW_ROUTES = {
       },
     },
   },
+  attachWorkflowStream: {
+    method: "get" as const,
+    path: "/workflows/:id/executions/:executionId/stream",
+    summary: "Attach to workflow execution stream",
+    description:
+      "Attach to an in-progress workflow execution stream and receive real-time events via Server-Sent Events (SSE). Use Last-Event-ID header or `fromSequence` query parameter to replay missed events on reconnect.",
+    tags: ["Workflow Management"],
+    operationId: "attachWorkflowStream",
+    responses: {
+      200: {
+        description: "Successfully attached to workflow SSE stream",
+        contentType: "text/event-stream",
+      },
+      404: {
+        description: "Workflow or execution not found",
+        contentType: "application/json",
+      },
+      409: {
+        description: "Workflow execution is not streamable in current state",
+        contentType: "application/json",
+      },
+      500: {
+        description: "Failed to attach workflow stream due to server error",
+        contentType: "application/json",
+      },
+    },
+  },
   suspendWorkflow: {
     method: "post" as const,
     path: "/workflows/:id/executions/:executionId/suspend",

--- a/packages/server-hono/src/routes/agent.routes.ts
+++ b/packages/server-hono/src/routes/agent.routes.ts
@@ -792,6 +792,72 @@ Event types include:
   description: WORKFLOW_ROUTES.streamWorkflow.description,
 });
 
+// Attach to workflow stream route
+export const attachWorkflowStreamRoute = createRoute({
+  method: WORKFLOW_ROUTES.attachWorkflowStream.method,
+  path: WORKFLOW_ROUTES.attachWorkflowStream.path
+    .replace(":id", "{id}")
+    .replace(":executionId", "{executionId}"),
+  request: {
+    params: z.object({
+      id: workflowIdParam(),
+      executionId: executionIdParam(),
+    }),
+    query: z.object({
+      fromSequence: z
+        .string()
+        .optional()
+        .describe("Replay events with sequence greater than this value"),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "text/event-stream": {
+          schema: WorkflowStreamEventSchema,
+        },
+      },
+      description: `Server-Sent Events stream for an existing workflow execution.
+Each event includes SSE id for replay/reconnect support:
+'id: 42\\n'
+'data: {"type":"step-start","executionId":"...", ...}\\n\\n'`,
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description:
+        WORKFLOW_ROUTES.attachWorkflowStream.responses?.[404]?.description ||
+        "Workflow or execution not found",
+    },
+    409: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description:
+        WORKFLOW_ROUTES.attachWorkflowStream.responses?.[409]?.description ||
+        "Workflow execution is not streamable",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ErrorSchema,
+        },
+      },
+      description:
+        WORKFLOW_ROUTES.attachWorkflowStream.responses?.[500]?.description ||
+        "Internal server error",
+    },
+  },
+  tags: [...WORKFLOW_ROUTES.attachWorkflowStream.tags],
+  summary: WORKFLOW_ROUTES.attachWorkflowStream.summary,
+  description: WORKFLOW_ROUTES.attachWorkflowStream.description,
+});
+
 // Execute workflow route
 export const executeWorkflowRoute = createRoute({
   method: WORKFLOW_ROUTES.executeWorkflow.method,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

- Workflow streaming can only be established while starting a new execution via `POST /workflows/:id/stream`.
- There is no API to attach to an already-running execution stream by `executionId`, so reconnect/resume observers cannot receive live events.

## What is the new behavior?

- Added `GET /workflows/:id/executions/:executionId/stream` to attach to an active workflow SSE stream.
- Added replay support for reconnects using `fromSequence` query param and `Last-Event-ID`.
- Added explicit attach error behavior:
  - `404` when workflow/execution is not found
  - `409` when execution is not streamable (completed/cancelled/error or no active stream session)
- Kept `POST /workflows/:id/stream` behavior unchanged for starting new executions.
- Resume now works with active streamed sessions (attach clients continue receiving events after resume).

fixes #1081

## Notes for reviewers

- Added new handler tests for stream attach behavior in `packages/server-core/src/handlers/workflow.stream-attach.handlers.spec.ts`.
- Verified suspend -> attach -> resume flow manually against `examples/with-workflow` smoke scenario.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an attach endpoint to join in-progress workflow SSE streams and support reconnects with replay. Addresses Linear #1081 and keeps the existing start-stream endpoint unchanged.

- **New Features**
  - Added GET /workflows/:id/executions/:executionId/stream to attach to active streams.
  - Supports replay on reconnect via fromSequence query param and Last-Event-ID.
  - Returns 404 if workflow/execution not found, 409 if not streamable or no active session.
  - Resume now uses a fresh suspend controller so attached clients continue receiving events.
  - Added route handlers in server-core, Elysia, Hono, and serverless-Hono; protected by auth.
  - Updated OpenAPI route definitions and added handler tests.

<sup>Written for commit b42509360a3ebb8062a4595471d84e1d22e8ca8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to attach to in-progress workflow execution streams via Server-Sent Events (SSE) for real-time monitoring.
  * Implemented event replay on reconnection using Last-Event-ID header or fromSequence query parameter to recover previously missed stream events.
  * Existing workflow stream creation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->