### PR TITLE
fix(workflow): persist execution metadata and fix SQL metadata filters

### DIFF
--- a/.changeset/workflow-execution-metadata-filters.md
+++ b/.changeset/workflow-execution-metadata-filters.md
@@ -1,0 +1,13 @@
+---
+"@voltagent/core": patch
+"@voltagent/server-core": patch
+"@voltagent/libsql": patch
+"@voltagent/cloudflare-d1": patch
+---
+
+Fix workflow execution filtering by persisted metadata across adapters.
+
+- Persist `options.metadata` on workflow execution state so `/workflows/executions` filters can match tenant/user metadata.
+- Preserve existing execution metadata when updating cancelled/error workflow states.
+- Accept `options.metadata` in server workflow execution request schema.
+- Fix LibSQL and Cloudflare D1 JSON metadata query comparisons for `metadata` and `metadata.<key>` filters.

--- a/packages/cloudflare-d1/src/memory-adapter.spec.ts
+++ b/packages/cloudflare-d1/src/memory-adapter.spec.ts
@@ -1,0 +1,83 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { describe, expect, it, vi } from "vitest";
+import { D1MemoryAdapter } from "./memory-adapter";
+
+function createMockBinding(): D1Database {
+  return {
+    prepare: vi.fn(() => ({
+      bind: vi.fn().mockReturnThis(),
+      run: vi.fn().mockResolvedValue({}),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+    })),
+    batch: vi.fn().mockResolvedValue([]),
+  } as unknown as D1Database;
+}
+
+describe("D1MemoryAdapter queryWorkflowRuns", () => {
+  it("builds metadata filters with JSON-aware comparisons", async () => {
+    vi.spyOn(D1MemoryAdapter.prototype as any, "ensureInitialized").mockResolvedValue(undefined);
+
+    const adapter = new D1MemoryAdapter({
+      binding: createMockBinding(),
+      tablePrefix: "test",
+    });
+
+    const allSpy = vi.spyOn(adapter as any, "all").mockResolvedValue([
+      {
+        id: "exec-1",
+        workflow_id: "workflow-1",
+        workflow_name: "Workflow 1",
+        status: "completed",
+        input: '{"requestId":"req-1"}',
+        context: '[["tenantId","acme"]]',
+        workflow_state: '{"phase":"done"}',
+        suspension: null,
+        events: null,
+        output: null,
+        cancellation: null,
+        user_id: "user-1",
+        conversation_id: null,
+        metadata: '{"tenantId":"acme"}',
+        created_at: "2024-01-02T00:00:00Z",
+        updated_at: "2024-01-02T00:00:00Z",
+      },
+    ]);
+
+    const result = await adapter.queryWorkflowRuns({
+      workflowId: "workflow-1",
+      status: "completed",
+      from: new Date("2024-01-01T00:00:00Z"),
+      to: new Date("2024-01-03T00:00:00Z"),
+      userId: "user-1",
+      metadata: { tenantId: "acme" },
+      limit: 5,
+      offset: 2,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.input).toEqual({ requestId: "req-1" });
+    expect(result[0]?.context).toEqual([["tenantId", "acme"]]);
+    expect(result[0]?.workflowState).toEqual({ phase: "done" });
+
+    expect(allSpy).toHaveBeenCalledTimes(1);
+    const [sql, args] = allSpy.mock.calls[0];
+
+    expect(sql).toContain("workflow_id = ?");
+    expect(sql).toContain("status = ?");
+    expect(sql).toContain("created_at >=");
+    expect(sql).toContain("user_id = ?");
+    expect(sql).toContain("json_extract(metadata, ?) = json_extract(json(?), '$')");
+    expect(sql).toContain("ORDER BY created_at DESC");
+    expect(args).toEqual([
+      "workflow-1",
+      "completed",
+      "2024-01-01T00:00:00.000Z",
+      "2024-01-03T00:00:00.000Z",
+      "user-1",
+      '$."tenantId"',
+      '"acme"',
+      5,
+      2,
+    ]);
+  });
+});

--- a/packages/cloudflare-d1/src/memory-adapter.ts
+++ b/packages/cloudflare-d1/src/memory-adapter.ts
@@ -1375,7 +1375,7 @@ export class D1MemoryAdapter implements StorageAdapter {
           continue;
         }
 
-        conditions.push("json_extract(metadata, ?) = json(?)");
+        conditions.push("json_extract(metadata, ?) = json_extract(json(?), '$')");
         args.push(metadataPath, safeStringify(value));
       }
     }

--- a/packages/core/src/workflow/types.ts
+++ b/packages/core/src/workflow/types.ts
@@ -241,6 +241,10 @@ export interface WorkflowRunOptions {
    */
   userId?: string;
   /**
+   * Additional execution metadata persisted with workflow state
+   */
+  metadata?: Record<string, unknown>;
+  /**
    * The user context, this can be used to track the current user context in a workflow
    */
   context?: UserContext;

--- a/packages/libsql/src/memory-core.ts
+++ b/packages/libsql/src/memory-core.ts
@@ -1214,7 +1214,7 @@ export class LibSQLMemoryCore implements StorageAdapter {
           continue;
         }
 
-        conditions.push("json_extract(metadata, ?) = json(?)");
+        conditions.push("json_extract(metadata, ?) = json_extract(json(?), '$')");
         args.push(metadataPath, safeStringify(value));
       }
     }

--- a/packages/libsql/src/memory-v2-adapter.spec.ts
+++ b/packages/libsql/src/memory-v2-adapter.spec.ts
@@ -85,7 +85,7 @@ describe.sequential("LibSQLMemoryAdapter - Advanced Behavior", () => {
     expect(sql).toContain("status = ?");
     expect(sql).toContain("created_at >=");
     expect(sql).toContain("user_id = ?");
-    expect(sql).toContain("json_extract(metadata, ?) = json(?)");
+    expect(sql).toContain("json_extract(metadata, ?) = json_extract(json(?), '$')");
     expect(sql).toContain("ORDER BY created_at DESC");
     expect(args).toEqual([
       "workflow-1",

--- a/packages/server-core/src/schemas/agent.schemas.spec.ts
+++ b/packages/server-core/src/schemas/agent.schemas.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { WorkflowExecutionRequestSchema } from "./agent.schemas";
+
+describe("WorkflowExecutionRequestSchema", () => {
+  it("accepts options.metadata payload", () => {
+    const parsed = WorkflowExecutionRequestSchema.parse({
+      input: { value: 1 },
+      options: {
+        userId: "user-1",
+        metadata: {
+          tenantId: "acme",
+          region: "us-east-1",
+        },
+      },
+    });
+
+    expect(parsed.options?.metadata).toEqual({
+      tenantId: "acme",
+      region: "us-east-1",
+    });
+  });
+});

--- a/packages/server-core/src/schemas/agent.schemas.ts
+++ b/packages/server-core/src/schemas/agent.schemas.ts
@@ -359,6 +359,7 @@ export const WorkflowExecutionRequestSchema = z.object({
       executionId: z.string().optional(),
       context: z.any().optional(),
       workflowState: z.record(z.any()).optional(),
+      metadata: z.record(z.any()).optional(),
     })
     .optional()
     .describe("Optional execution options"),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`/workflows/executions` metadata filters (`metadata` JSON and `metadata.<key>`) can fail even when execution metadata is provided.

- Workflow execution options metadata was not persisted into workflow state.
- SQLite-based adapters compared JSON using `json_extract(metadata, ?) = json(?)`, which does not match text values like `"acme"`.

## What is the new behavior?

- Workflow `options.metadata` is persisted on workflow state creation.
- Existing execution metadata is preserved during cancelled/error updates.
- Server workflow execution schema accepts `options.metadata`.
- LibSQL and Cloudflare D1 metadata filters now use JSON-aware comparisons that correctly match scalar values.
- Added regression tests for:
  - core workflow metadata persistence
  - server-core schema acceptance for `options.metadata`
  - libsql metadata filter SQL generation
  - cloudflare-d1 metadata filter SQL generation

fixes (issue)

N/A

## Notes for reviewers

- Added changeset: `.changeset/workflow-execution-metadata-filters.md`
- Smoke-tested workflow execution listing filters with Postgres and LibSQL after these fixes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted workflow execution metadata and fixed metadata filters so /workflows/executions reliably matches JSON values across adapters. Server now accepts options.metadata, and metadata is preserved on cancel/error updates.

- **New Features**
  - Persist options.metadata when creating workflow state.
  - Preserve existing metadata during cancelled/error state updates.
  - Accept options.metadata in server-core execution request schema.

- **Bug Fixes**
  - Use JSON-aware comparisons in LibSQL and Cloudflare D1 filters to correctly match scalar values for metadata and metadata.<key>.
  - Added regression tests for metadata persistence, schema acceptance, and SQL generation across adapters.

<sup>Written for commit ea3e904e3dbd575c6755e53e4b04e4ee1abfaf13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow executions now support custom metadata that persists across execution states.
  * Added metadata-aware filtering for workflow execution queries, enabling tenant and user-based filtering.
  * Server API now accepts metadata in workflow execution requests.

* **Bug Fixes**
  * Fixed JSON metadata query comparisons for accurate filtering in LibSQL and Cloudflare D1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->