### PR TITLE
fix(core): preserve fullStream output after startup probe

### DIFF
--- a/.changeset/green-lizards-wave.md
+++ b/.changeset/green-lizards-wave.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/core": patch
+---
+
+fix: preserve stream output after startup probe on ReadableStream providers
+
+`Agent.streamText()` and `Agent.streamObject()` now probe stream startup using a tee'd branch instead of consuming and cancelling the original `fullStream`.
+
+This prevents early stream interruption where some providers could emit reasoning events and then terminate before forwarding final `text-delta` output to consumers.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

For some `ReadableStream`-based providers, stream startup probing could consume/cancel the original `fullStream`.

In practice this could result in reasoning events being emitted but final answer `text-delta` chunks not reaching consumers before `finish`.

## What is the new behavior?

Startup probing now uses a tee'd probe branch and preserves a passthrough stream for downstream consumption.

`Agent.streamText()` and `Agent.streamObject()` both now continue forwarding full stream output correctly after probing.

A regression test was added in `packages/core/src/agent/agent.spec.ts` to verify `reasoning-delta`, `text-delta`, and `finish` are all present after probe.

fixes (issue)

N/A

## Notes for reviewers

- Changeset: `.changeset/green-lizards-wave.md`
- Validations run:
  - `pnpm --filter @voltagent/core test:single src/agent/agent.spec.ts -t "Stream Text"`
  - `pnpm --filter @voltagent/core typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stream startup probing to preserve fullStream on ReadableStream-based providers. Prevents early interruption so consumers receive reasoning, text, and finish events.

- **Bug Fixes**
  - Probe uses ReadableStream.tee to read from a probe branch while passing through the main stream.
  - Added regression test to ensure reasoning-delta, text-delta, and finish are emitted after probing.

<sup>Written for commit e5cf2319267a151552b118cdd337051922c45bfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

