### PR TITLE
docs: add reasoning stream lifecycle events to streaming docs

### DIFF
--- a/website/docs/agents/message-types.md
+++ b/website/docs/agents/message-types.md
@@ -204,12 +204,11 @@ type VoltAgentTextStreamPart<TOOLS extends Record<string, any> = Record<string, 
   };
 
 // TextStreamPart types include:
-// - text-delta
-// - tool-call
-// - tool-result
-// - finish
-// - error
-// etc.
+// - text-start, text-delta, text-end
+// - reasoning-start, reasoning-delta, reasoning-end
+// - tool-input-start, tool-input-delta, tool-input-end
+// - tool-call, tool-result, tool-error
+// - start, start-step, finish-step, finish, abort, error, source, file, raw
 ```
 
 #### Format

--- a/website/docs/agents/subagents.md
+++ b/website/docs/agents/subagents.md
@@ -126,7 +126,17 @@ const supervisorAgent = new Agent({
     // Configure which sub-agent events to forward
     fullStreamEventForwarding: {
       // Default: ['tool-call', 'tool-result']
-      types: ["tool-call", "tool-result", "text-delta", "reasoning", "source", "error", "finish"],
+      types: [
+        "tool-call",
+        "tool-result",
+        "text-delta",
+        "reasoning-start",
+        "reasoning-delta",
+        "reasoning-end",
+        "source",
+        "error",
+        "finish",
+      ],
     },
   },
 });
@@ -147,7 +157,17 @@ fullStreamEventForwarding: {
 
 // Full visibility - All events including reasoning
 fullStreamEventForwarding: {
-  types: ['tool-call', 'tool-result', 'text-delta', 'reasoning', 'source', 'error', 'finish'],
+  types: [
+    'tool-call',
+    'tool-result',
+    'text-delta',
+    'reasoning-start',
+    'reasoning-delta',
+    'reasoning-end',
+    'source',
+    'error',
+    'finish'
+  ],
 }
 
 // Clean tool names - No agent prefix (add prefix manually when consuming events if desired)
@@ -810,15 +830,15 @@ for await (const message of result.toUIMessageStream()) {
 
 **Event Types Reference:**
 
-| Event Type    | Description                      | Default         |
-| ------------- | -------------------------------- | --------------- |
-| `tool-call`   | Tool invocations                 | ✅ Included     |
-| `tool-result` | Tool results                     | ✅ Included     |
-| `text-delta`  | Text chunk generation            | ❌ NOT included |
-| `reasoning`   | Model reasoning (if available)   | ❌ NOT included |
-| `source`      | Retrieved sources (if available) | ❌ NOT included |
-| `error`       | Error events                     | ❌ NOT included |
-| `finish`      | Stream completion                | ❌ NOT included |
+| Event Type                                              | Description                              | Default         |
+| ------------------------------------------------------- | ---------------------------------------- | --------------- |
+| `tool-call`                                             | Tool invocations                         | ✅ Included     |
+| `tool-result`                                           | Tool results                             | ✅ Included     |
+| `text-delta`                                            | Text chunk generation                    | ❌ NOT included |
+| `reasoning-start` / `reasoning-delta` / `reasoning-end` | Model reasoning lifecycle (if available) | ❌ NOT included |
+| `source`                                                | Retrieved sources (if available)         | ❌ NOT included |
+| `error`                                                 | Error events                             | ❌ NOT included |
+| `finish`                                                | Stream completion                        | ❌ NOT included |
 
 ### Observability
 

--- a/website/docs/api/endpoints/agents.md
+++ b/website/docs/api/endpoints/agents.md
@@ -357,13 +357,13 @@ Generate a text response and stream raw fullStream data via Server-Sent Events (
 
 The stream returns raw AI SDK fullStream events. Each event is a JSON object containing the complete event data.
 
-**Event Types:**
+**Common Event Types:**
 
-- `text-delta` - Incremental text chunks with delta content
-- `tool-call` - Tool invocation events
-- `tool-result` - Tool execution results
-- `finish` - Stream completion with usage statistics
-- `error` - Error events if something goes wrong
+- Lifecycle: `start`, `start-step`, `finish-step`, `finish`, `abort`, `error`
+- Text: `text-start`, `text-delta`, `text-end`
+- Reasoning: `reasoning-start`, `reasoning-delta`, `reasoning-end` (if available from the selected model/provider)
+- Tools: `tool-input-start`, `tool-input-delta`, `tool-input-end`, `tool-call`, `tool-result`, `tool-error`
+- Other: `source`, `file`, `raw`
 
 **Use Cases:**
 
@@ -412,6 +412,15 @@ while (true) {
       const eventData = JSON.parse(line.slice(6));
       // Handle different event types
       switch (eventData.type) {
+        case "reasoning-start":
+          console.log("Reasoning started:", eventData.id);
+          break;
+        case "reasoning-delta":
+          console.log("Reasoning:", eventData.delta);
+          break;
+        case "reasoning-end":
+          console.log("Reasoning completed:", eventData.id);
+          break;
         case "text-delta":
           console.log("Text:", eventData.delta);
           break;

--- a/website/docs/api/streaming.md
+++ b/website/docs/api/streaming.md
@@ -77,11 +77,24 @@ while (true) {
   for (const line of lines) {
     if (line.startsWith("data: ")) {
       const event = JSON.parse(line.slice(6));
-      // Handle event.type: 'start' (includes messageId), 'text-delta', 'tool-call', 'tool-result', 'finish'
+      // Handle event types like:
+      // - lifecycle: 'start', 'start-step', 'finish-step', 'finish', 'abort', 'error'
+      // - text: 'text-start', 'text-delta', 'text-end'
+      // - reasoning: 'reasoning-start', 'reasoning-delta', 'reasoning-end'
+      // - tools: 'tool-input-start', 'tool-input-delta', 'tool-input-end', 'tool-call', 'tool-result', 'tool-error'
+      // - other: 'source', 'file', 'raw'
     }
   }
 }
 ```
+
+Common `fullStream` event types:
+
+- Lifecycle: `start`, `start-step`, `finish-step`, `finish`, `abort`, `error`
+- Text: `text-start`, `text-delta`, `text-end`
+- Reasoning: `reasoning-start`, `reasoning-delta`, `reasoning-end` (emitted only when model/provider returns reasoning traces)
+- Tools: `tool-input-start`, `tool-input-delta`, `tool-input-end`, `tool-call`, `tool-result`, `tool-error`
+- Other: `source`, `file`, `raw`
 
 ### Agents: Stream Object
 

--- a/website/docs/ui/ai-sdk-integration.md
+++ b/website/docs/ui/ai-sdk-integration.md
@@ -23,6 +23,7 @@ VoltAgent provides two streaming endpoints:
 - `/agents/:id/stream` - Raw fullStream events
 
 Use `/chat` for UI integration with useChat.
+Use `/stream` when you need low-level events such as `reasoning-start`, `reasoning-delta`, and `reasoning-end`.
 
 ## Basic Implementation
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [ ] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Streaming docs do not clearly list the reasoning lifecycle events. In some places, `reasoning` is shown as a single event type, which is inaccurate for `fullStream` usage.

## What is the new behavior?

Documentation now explicitly covers reasoning lifecycle events:

- `reasoning-start`
- `reasoning-delta`
- `reasoning-end`

It also updates raw stream event references/examples and sub-agent forwarding examples to use the exact event names.

Fixes #1001

## Notes for reviewers

Doc-only change. No runtime code changes.
Tests/changeset are not added because this PR only updates documentation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified streaming docs by documenting reasoning lifecycle events and updating examples to handle reasoning-start, reasoning-delta, and reasoning-end correctly. Resolves #1001 by replacing the single “reasoning” event with explicit lifecycle parts across agents, API, and sub-agent forwarding.

- **Bug Fixes**
  - Added reasoning lifecycle events to event references and code samples.
  - Updated sub-agent forwarding configs to include reasoning-start/delta/end.
  - Clarified /stream endpoint to list lifecycle, text, reasoning, and tool event families.

<sup>Written for commit 761beb9878c462a95938f613b7294add52b1afca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded streaming event types documentation with new lifecycle categories: reasoning-start/delta/end, text-start/delta/end, and tool input/result/error variants.
  * Updated API documentation to reflect broader streaming event taxonomy across agents, sub-agents, and streaming endpoints.
  * Added guidance on using `/stream` endpoint for low-level reasoning events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->