### PR TITLE
fix(examples): fix NestJS value imports and add graceful shutdown

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -84,6 +84,16 @@
           }
         }
       }
+    },
+    {
+      "include": ["**/examples/with-nestjs/**/*.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useImportType": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/examples/with-nestjs/src/app.controller.ts
+++ b/examples/with-nestjs/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Post } from "@nestjs/common";
-import type { VoltAgentService } from "./voltagent/voltagent.service";
+import { VoltAgentService } from "./voltagent/voltagent.service";
 
 @Controller()
 export class AppController {

--- a/examples/with-nestjs/src/voltagent/voltagent-websocket.setup.ts
+++ b/examples/with-nestjs/src/voltagent/voltagent-websocket.setup.ts
@@ -4,7 +4,7 @@ import type { Socket } from "node:net";
 import type { INestApplication } from "@nestjs/common";
 import { createWebSocketServer } from "@voltagent/server-core";
 import type { WebSocketServer } from "ws";
-import type { VoltAgentService } from "./voltagent.service";
+import { VoltAgentService } from "./voltagent.service";
 
 /**
  * Setup WebSocket support for VoltAgent console in NestJS

--- a/examples/with-nestjs/src/voltagent/voltagent.middleware.ts
+++ b/examples/with-nestjs/src/voltagent/voltagent.middleware.ts
@@ -1,7 +1,7 @@
 import { Injectable, type NestMiddleware } from "@nestjs/common";
 import type { NextFunction, Request, Response } from "express";
 import type { Hono } from "hono";
-import type { VoltAgentService } from "./voltagent.service";
+import { VoltAgentService } from "./voltagent.service";
 
 /**
  * NestJS middleware that integrates VoltAgent console


### PR DESCRIPTION
## Summary

Fix the `with-nestjs` example so it boots and shuts down cleanly.

NestJS dependency injection requires runtime class references, so `import type` prevents tokens from being resolved at runtime. Switch `VoltAgentService` imports from type-only to value imports across the middleware, WebSocket setup, and app controller.

Also enable NestJS shutdown hooks and close the WebSocket server when the HTTP server shuts down so the port is released immediately on `SIGINT`/`SIGTERM`.

Add a Biome override to disable the `useImportType` rule for the `with-nestjs` example, as type-only imports are intentionally avoided there for the reasons above.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added (N/A — example code only)
- [ ] Docs have been added / updated (N/A — no public API changes)
- [ ] Changesets have been added (N/A — no published packages affected)

## What is the current behavior?

- `VoltAgentService` is imported with `import type`, which erases the class reference at compile time. NestJS cannot resolve the DI token at runtime, causing the application to fail on startup.
- The process does not respond cleanly to `SIGINT`/`SIGTERM`: the HTTP server lingers and the WebSocket server is never closed, leaving the port occupied after shutdown.

## What is the new behavior?

- `VoltAgentService` is imported as a value import everywhere it is used for NestJS injection.
- `app.enableShutdownHooks()` is called so NestJS handles termination signals. The WebSocket server is closed in the HTTP server's `close` event, ensuring the port is freed immediately.
- A Biome config override disables the `useImportType` lint rule for `examples/with-nestjs/**`, preventing the linter from reverting the intentional value imports.

## Notes for reviewers

All changes are confined to `examples/with-nestjs` and the root `biome.json`. No published packages are modified, so no changeset is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the with-nestjs example so it starts and shuts down cleanly. Uses value imports for VoltAgentService and adds graceful shutdown to release the port on exit.

- **Bug Fixes**
  - Switch VoltAgentService to value imports in middleware, WebSocket setup, and app controller to keep runtime class references for NestJS injection.
  - Enable app.enableShutdownHooks() and close the WebSocket server when the HTTP server shuts down.
  - Add a Biome override to disable useImportType for examples/with-nestjs/** to prevent reverting these value imports.

<sup>Written for commit 3c7d6cc1c027b1ed2893fa9f6dc9bb94aaf8dcab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown handling in the NestJS example application. HTTP and WebSocket servers are now properly closed during application termination, ensuring clean resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->