### PR TITLE
feat(workflow): add observer/watch APIs for workflow streams

### DIFF
--- a/.changeset/blue-bags-remember.md
+++ b/.changeset/blue-bags-remember.md
@@ -1,0 +1,73 @@
+---
+"@voltagent/core": minor
+---
+
+feat: add workflow observer/watch APIs for stream results
+
+### What's New
+
+- Added run-level observer APIs on `WorkflowStreamResult`:
+  - `watch(cb)`
+  - `watchAsync(cb)`
+  - `observeStream()`
+  - `streamLegacy()`
+- These APIs are now available on:
+  - `workflow.stream(...)`
+  - `workflow.timeTravelStream(...)`
+  - resumed stream results returned from `.resume(...)`
+- Added test coverage for event ordering, unsubscribe behavior, multiple watchers, callback isolation, and `observeStream()` close semantics.
+
+### SDK Example
+
+```ts
+const stream = workflow.stream({ value: 3 });
+
+const unwatch = stream.watch((event) => {
+  console.log("[watch]", event.type, event.from);
+});
+
+const unwatchAsync = await stream.watchAsync(async (event) => {
+  if (event.type === "workflow-error") {
+    await notifyOps(event);
+  }
+});
+
+const reader = stream.observeStream().getReader();
+const observerTask = (async () => {
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    console.log("[observeStream]", value.type);
+  }
+})();
+
+for await (const event of stream) {
+  console.log("[main iterator]", event.type);
+}
+
+unwatch();
+unwatchAsync();
+await observerTask;
+
+const state = await stream.streamLegacy().getWorkflowState();
+console.log("final status:", state?.status);
+```
+
+### Time Travel Stream Example
+
+```ts
+const replayStream = workflow.timeTravelStream({
+  executionId: sourceExecutionId,
+  stepId: "step-approval",
+});
+
+const stopReplayWatch = replayStream.watch((event) => {
+  console.log("[replay]", event.type, event.from);
+});
+
+for await (const event of replayStream) {
+  console.log("[replay iterator]", event.type);
+}
+
+stopReplayWatch();
+```

--- a/packages/core/src/workflow/core.ts
+++ b/packages/core/src/workflow/core.ts
@@ -3116,6 +3116,14 @@ export function createWorkflow<
             resumedSuspendController.cancel(reason);
           },
           abort: () => streamController.abort(),
+          watch: (cb) => streamController.watch(cb),
+          watchAsync: (cb) => streamController.watchAsync(cb),
+          observeStream: () => streamController.observeStream(),
+          streamLegacy: () => ({
+            stream: streamController.observeStream(),
+            getWorkflowState: () =>
+              replayExecutionMemory.getWorkflowState(suspendedResult.executionId),
+          }),
           toUIMessageStreamResponse: eventToUIMessageStreamResponse(streamController),
           [Symbol.asyncIterator]: () => streamController.getStream(),
         };
@@ -3148,6 +3156,13 @@ export function createWorkflow<
         abort: () => {
           streamController.abort();
         },
+        watch: (cb) => streamController.watch(cb),
+        watchAsync: (cb) => streamController.watchAsync(cb),
+        observeStream: () => streamController.observeStream(),
+        streamLegacy: () => ({
+          stream: streamController.observeStream(),
+          getWorkflowState: () => replayExecutionMemory.getWorkflowState(executionId),
+        }),
         [Symbol.asyncIterator]: () => streamController.getStream(),
       };
 
@@ -3294,6 +3309,14 @@ export function createWorkflow<
             resumedSuspendController.cancel(reason);
           },
           abort: () => streamController.abort(),
+          watch: (cb) => streamController.watch(cb),
+          watchAsync: (cb) => streamController.watchAsync(cb),
+          observeStream: () => streamController.observeStream(),
+          streamLegacy: () => ({
+            stream: streamController.observeStream(),
+            getWorkflowState: () =>
+              streamExecutionMemory.getWorkflowState(suspendedResult.executionId),
+          }),
           toUIMessageStreamResponse: eventToUIMessageStreamResponse(streamController),
           [Symbol.asyncIterator]: () => streamController.getStream(),
         };
@@ -3327,6 +3350,13 @@ export function createWorkflow<
         abort: () => {
           streamController.abort();
         },
+        watch: (cb) => streamController.watch(cb),
+        watchAsync: (cb) => streamController.watchAsync(cb),
+        observeStream: () => streamController.observeStream(),
+        streamLegacy: () => ({
+          stream: streamController.observeStream(),
+          getWorkflowState: () => streamExecutionMemory.getWorkflowState(executionId),
+        }),
         // AsyncIterable implementation
         [Symbol.asyncIterator]: () => streamController.getStream(),
       };

--- a/packages/core/src/workflow/types.ts
+++ b/packages/core/src/workflow/types.ts
@@ -204,6 +204,26 @@ export interface WorkflowStreamResult<
    * Abort the workflow execution
    */
   abort: () => void;
+  /**
+   * Subscribe to run-level stream events without consuming the main async iterator.
+   * Returns an unsubscribe function.
+   */
+  watch: (cb: (event: WorkflowStreamEvent) => void | Promise<void>) => () => void;
+  /**
+   * Async variant of watch() for compatibility with observer-based integrations.
+   */
+  watchAsync: (cb: (event: WorkflowStreamEvent) => void | Promise<void>) => Promise<() => void>;
+  /**
+   * Create a ReadableStream view over workflow events.
+   */
+  observeStream: () => ReadableStream<WorkflowStreamEvent>;
+  /**
+   * Compatibility surface for legacy stream consumers.
+   */
+  streamLegacy: () => {
+    stream: ReadableStream<WorkflowStreamEvent>;
+    getWorkflowState: () => ReturnType<Memory["getWorkflowState"]>;
+  };
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Workflow stream consumers can only observe events via the main async iterator (`for await ... of stream`).
There is no callback-based watch API, no `ReadableStream` observer surface, and no legacy bridge method on `WorkflowStreamResult`.

## What is the new behavior?

Adds observer/watch APIs to workflow stream results:

- `watch(cb)`
- `watchAsync(cb)`
- `observeStream()`
- `streamLegacy()`

Available on:

- `workflow.stream(...)`
- `workflow.timeTravelStream(...)`
- resumed stream results returned from `.resume(...)`

Also includes:

- `WorkflowStreamController` subscription registry + callback isolation
- tests for ordering, unsubscribe, multi-watcher behavior, throw isolation, and observeStream close semantics
- docs updates in `website/docs/workflows/streaming.md` including SDK-only note for watch APIs and REST SSE equivalents
- changeset with usage examples

fixes (issue)

N/A

## Notes for reviewers

Validation run:

- `pnpm --filter @voltagent/core test -- src/workflow/stream.spec.ts src/workflow/core.spec.ts`

Scope note:

- `docs/workflow-parity-plans/*` intentionally not included in this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds callback-based observers and a ReadableStream view to workflow streams so clients can watch events without consuming the async iterator. Improves integration options and keeps existing iterator behavior unchanged.

- **New Features**
  - Added watch(cb), watchAsync(cb), observeStream(), and streamLegacy() to WorkflowStreamResult on workflow.stream(...), workflow.timeTravelStream(...), and resumed streams.
  - Implemented subscription registry with unsubscribe support and callback isolation (one watcher error won’t break others).
  - observeStream() provides a closing ReadableStream; streamLegacy() exposes { stream, getWorkflowState } for compatibility.
  - Added tests for event ordering, unsubscribe, multi-watchers, error isolation, and observeStream close behavior.
  - Updated docs (workflows/streaming.md) with SDK-only watch APIs and REST SSE equivalents.

<sup>Written for commit 66c152f58638cb7195d0b1f36eb9558165e2a196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observer APIs for workflow streams: `watch()`, `watchAsync()`, `observeStream()`, and `streamLegacy()` enable non-destructive subscription to stream events and workflow state retrieval.

* **Tests**
  * Added comprehensive test coverage for event ordering, subscription lifecycle, callback error handling, and stream closure behavior.

* **Documentation**
  * Updated documentation with usage examples for the new observer and streaming capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->