### PR TITLE
fix(langfuse-exporter): update langfuse sdk to handle non-JSON error responses

### DIFF
--- a/.changeset/fuzzy-turkeys-smell.md
+++ b/.changeset/fuzzy-turkeys-smell.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/langfuse-exporter": patch
+---
+
+chore(langfuse-exporter): update `langfuse` dependency to `^3.38.6` to include upstream fixes for non-JSON error responses during export retries (fixes #670)

--- a/packages/langfuse-exporter/package.json
+++ b/packages/langfuse-exporter/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
-    "langfuse": "^3.37.2"
+    "langfuse": "^3.38.6"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4048,8 +4048,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.1(@opentelemetry/api@1.9.0)
       langfuse:
-        specifier: ^3.37.2
-        version: 3.38.4
+        specifier: ^3.38.6
+        version: 3.38.6
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
@@ -30603,18 +30603,18 @@ packages:
       - ws
     dev: false
 
-  /langfuse-core@3.38.4:
-    resolution: {integrity: sha512-onTAqcEGhoXuBgqDFXe2t+bt9Vi+5YChRgdz3voM49JKoHwtVZQiUdqTfjSivGR75eSbYoiaIL8IRoio+jaqwg==}
+  /langfuse-core@3.38.6:
+    resolution: {integrity: sha512-EcZXa+DK9FJdi1I30+u19eKjuBJ04du6j2Nybk19KKCuraLczg/ppkTQcGvc4QOk//OAi3qUHrajUuV74RXsBQ==}
     engines: {node: '>=18'}
     dependencies:
       mustache: 4.2.0
     dev: false
 
-  /langfuse@3.38.4:
-    resolution: {integrity: sha512-2UqMeHLl3DGNX1Nh/cO4jGhk7TzDJ6gjQLlyS9rwFCKVO81xot6b58yeTsTB5YrWupWsOxQtMNoQYIQGOUlH9Q==}
+  /langfuse@3.38.6:
+    resolution: {integrity: sha512-mtwfsNGIYvObRh+NYNGlJQJDiBN+Wr3Hnr++wN25mxuOpSTdXX+JQqVCyAqGL5GD2TAXRZ7COsN42Vmp9krYmg==}
     engines: {node: '>=18'}
     dependencies:
-      langfuse-core: 3.38.4
+      langfuse-core: 3.38.6
     dev: false
 
   /langium@3.3.1:


### PR DESCRIPTION
Fixes #670

## Summary
- bump `langfuse` in `@voltagent/langfuse-exporter` from `^3.37.2` to `^3.38.6`
- include a changeset for the package release

## Why
Issue #670 reports `SyntaxError: Failed to parse JSON` from the Langfuse SDK on non-JSON error responses during export calls. This updates to the latest 3.x patch level with upstream handling improvements.

## Validation
- `pnpm --filter @voltagent/langfuse-exporter lint`
- `pnpm --filter @voltagent/langfuse-exporter test`
- `pnpm --filter @voltagent/langfuse-exporter build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update langfuse-exporter to use Langfuse ^3.38.6 so non-JSON error responses during export retries are handled correctly. Adds a changeset for a patch release; fixes #670.

<sup>Written for commit 36850c1c76233d41029b3acf12d96819af687fc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of non-JSON error responses during export retries in the Langfuse exporter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->