### PR TITLE
fix(workflow): improve typing for state parameter

### DIFF
--- a/.changeset/olive-ears-smoke.md
+++ b/.changeset/olive-ears-smoke.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix(workflow): improve typing for state parameter

--- a/packages/core/src/workflow/internal/state.ts
+++ b/packages/core/src/workflow/internal/state.ts
@@ -32,7 +32,7 @@ export type WorkflowState<INPUT, RESULT> = {
   /** the initial input data to the workflow */
   input: InternalExtractWorkflowInputData<INPUT>;
   /** current data being processed */
-  data: DangerouslyAllowAny;
+  data: unknown;
   /** shared workflow state across steps */
   workflowState: WorkflowStateStore;
   /** the result of workflow execution, null until execution is complete */

--- a/packages/core/src/workflow/types.ts
+++ b/packages/core/src/workflow/types.ts
@@ -1120,7 +1120,7 @@ export interface UpdateWorkflowStepOptions {
  * The state parameter passed to workflow steps
  */
 export type WorkflowStepState<INPUT> = Omit<
-  WorkflowState<INPUT, DangerouslyAllowAny>,
+  WorkflowState<INPUT, unknown>,
   "data" | "result"
 > & {
   /** Workflow execution context for event tracking */


### PR DESCRIPTION
## Summary

Replace `DangerouslyAllowAny` with `unknown` in `WorkflowState` and `WorkflowStepState` types to provide stricter type checking for workflow state parameter in execute handlers.

## Changes

- `packages/core/src/workflow/internal/state.ts`: Changed `data: DangerouslyAllowAny` to `data: unknown`
- `packages/core/src/workflow/types.ts`: Changed `WorkflowState<INPUT, DangerouslyAllowAny>` to `WorkflowState<INPUT, unknown>`

## Motivation

This addresses issue #645 where `state` was typed as `any` making it difficult to debug workflow execution code. Using `unknown` provides better type safety while maintaining compatibility with existing code.

## Testing

The change is purely TypeScript type-level and does not affect runtime behavior.

Closes #645

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens typing of workflow state by replacing DangerouslyAllowAny with unknown in WorkflowState and WorkflowStepState to improve type safety of the state parameter in execute handlers; adds a changeset. Addresses #645 with no runtime impact.

<sup>Written for commit 0efe87999d14ee1128bbc13abb37134493d94a9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for workflow state parameters to enforce stricter type checking and enhance type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->