### PR TITLE
feat: add read-only runtime memory mode

### DIFF
--- a/.changeset/read-only-memory-mode.md
+++ b/.changeset/read-only-memory-mode.md
@@ -1,0 +1,45 @@
+---
+"@voltagent/core": patch
+"@voltagent/server-core": patch
+---
+
+feat: add per-call memory read-only mode via `memory.options.readOnly`.
+
+When `readOnly` is enabled, the agent still reads conversation context and working memory, but skips memory writes for the current call.
+
+What changes in read-only mode:
+
+- Conversation message persistence is disabled.
+- Step persistence/checkpoint writes are disabled.
+- Background input persistence for context hydration is disabled.
+- Working memory write tools are disabled (`update_working_memory`, `clear_working_memory`).
+- Read-only tool remains available (`get_working_memory`).
+
+`@voltagent/server-core` now accepts `memory.options.readOnly` in request schema/options parsing.
+
+### Before
+
+```ts
+await agent.generateText("Summarize this", {
+  memory: {
+    userId: "user-123",
+    conversationId: "conv-456",
+  },
+});
+// reads + writes memory
+```
+
+### After
+
+```ts
+await agent.generateText("Summarize this", {
+  memory: {
+    userId: "user-123",
+    conversationId: "conv-456",
+    options: {
+      readOnly: true,
+    },
+  },
+});
+// reads memory only, no writes
+```

--- a/packages/core/src/agent/agent.spec-d.ts
+++ b/packages/core/src/agent/agent.spec-d.ts
@@ -417,6 +417,7 @@ describe("Agent Type System", () => {
           userId: "user-123",
           options: {
             contextLimit: 1000,
+            readOnly: true,
             semanticMemory: {
               enabled: true,
               semanticLimit: 3,

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -1811,6 +1811,60 @@ Use pandas and summarize findings.`.split("\n"),
       // as they're handled by the MemoryManager class
     });
 
+    it("should read memory but skip persistence when memory.options.readOnly is true", async () => {
+      const memory = new Memory({
+        storage: new InMemoryStorageAdapter(),
+      });
+      const getMessagesSpy = vi.spyOn(memory, "getMessages");
+      const saveMessageWithContextSpy = vi.spyOn(memory, "saveMessageWithContext");
+
+      const agent = new Agent({
+        name: "TestAgent",
+        instructions: "Test",
+        model: mockModel as any,
+        memory,
+      });
+
+      vi.mocked(ai.generateText).mockResolvedValue({
+        text: "Response",
+        content: [],
+        reasoning: [],
+        files: [],
+        sources: [],
+        toolCalls: [],
+        toolResults: [],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        warnings: [],
+        request: {},
+        response: {
+          id: "test",
+          modelId: "test-model",
+          timestamp: new Date(),
+          messages: [],
+        },
+        steps: [],
+      } as any);
+
+      await agent.generateText("Hello", {
+        memory: {
+          userId: "user-readonly",
+          conversationId: "conv-readonly",
+          options: {
+            readOnly: true,
+          },
+        },
+      });
+
+      const memoryReadCall = getMessagesSpy.mock.calls.find(
+        ([userId, conversationId]) =>
+          userId === "user-readonly" && conversationId === "conv-readonly",
+      );
+
+      expect(memoryReadCall).toBeDefined();
+      expect(saveMessageWithContextSpy).not.toHaveBeenCalled();
+    });
+
     it("should retrieve messages from memory", async () => {
       const memory = new Memory({
         storage: new InMemoryStorageAdapter(),
@@ -2053,6 +2107,7 @@ Use pandas and summarize findings.`.split("\n"),
           conversationId: "memory-conv",
           options: {
             contextLimit: 5,
+            readOnly: true,
             semanticMemory: {
               enabled: false,
               semanticThreshold: 0.8,
@@ -2071,6 +2126,7 @@ Use pandas and summarize findings.`.split("\n"),
         userId: "memory-user",
         conversationId: "memory-conv",
         contextLimit: 5,
+        readOnly: true,
         semanticMemory: {
           enabled: false,
           semanticThreshold: 0.8,
@@ -2095,6 +2151,7 @@ Use pandas and summarize findings.`.split("\n"),
           conversationId: "memory-conv",
           options: {
             contextLimit: 4,
+            readOnly: true,
             semanticMemory: {
               enabled: true,
               semanticLimit: 2,
@@ -2114,6 +2171,7 @@ Use pandas and summarize findings.`.split("\n"),
         userId: "memory-user",
         conversationId: "memory-conv",
         contextLimit: 4,
+        readOnly: true,
         semanticMemory: {
           enabled: true,
           semanticLimit: 2,
@@ -3426,6 +3484,39 @@ Use pandas and summarize findings.`.split("\n"),
       expect(typeof prepared.get_working_memory.execute).toBe("function");
 
       workingMemorySpy.mockRestore();
+    });
+
+    it("should disable working memory write tools when memory options are read-only", async () => {
+      const memory = new Memory({
+        storage: new InMemoryStorageAdapter(),
+        workingMemory: {
+          enabled: true,
+        },
+      });
+
+      const agent = new Agent({
+        name: "TestAgent",
+        instructions: "Test",
+        model: mockModel as any,
+        memory,
+      });
+
+      const options = {
+        memory: {
+          userId: "user-1",
+          conversationId: "conv-1",
+          options: {
+            readOnly: true,
+          },
+        },
+      } as any;
+      const operationContext = (agent as any).createOperationContext("input message", options);
+      const runtimeTools = (agent as any).createWorkingMemoryTools(options, operationContext);
+      const toolNames = runtimeTools.map((tool: Tool<any, any>) => tool.name);
+
+      expect(toolNames).toContain("get_working_memory");
+      expect(toolNames).not.toContain("update_working_memory");
+      expect(toolNames).not.toContain("clear_working_memory");
     });
   });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -250,6 +250,15 @@ const firstNonBlank = (...values: Array<unknown>): string | undefined => {
   return undefined;
 };
 
+const firstDefined = <T>(...values: Array<T | null | undefined>): T | undefined => {
+  for (const value of values) {
+    if (value !== null && value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
 const isAssistantContentPart = (value: unknown): boolean => {
   if (!isRecord(value)) {
     return false;
@@ -995,6 +1004,7 @@ export class Agent {
     const feedbackOptions = this.resolveFeedbackOptions(options);
     const feedbackClient = feedbackOptions ? this.getFeedbackClient() : undefined;
     const shouldDeferPersist = Boolean(feedbackOptions && feedbackClient);
+    const shouldPersistMemory = this.shouldPersistMemoryForContext(oc);
     let feedbackMetadata: AgentFeedbackMetadata | null = null;
 
     // Wrap entire execution in root span for trace context
@@ -1231,7 +1241,7 @@ export class Agent {
 
             void this.recordStepResults(result.steps, oc);
 
-            if (!shouldDeferPersist) {
+            if (!shouldDeferPersist && shouldPersistMemory) {
               await persistQueue.flush(buffer, oc);
             }
 
@@ -1331,7 +1341,7 @@ export class Agent {
               }
             }
 
-            if (shouldDeferPersist) {
+            if (shouldDeferPersist && shouldPersistMemory) {
               await persistQueue.flush(buffer, oc);
             }
 
@@ -1486,6 +1496,7 @@ export class Agent {
     const feedbackOptions = this.resolveFeedbackOptions(options);
     const feedbackClient = feedbackOptions ? this.getFeedbackClient() : undefined;
     const shouldDeferPersist = Boolean(feedbackOptions && feedbackClient);
+    const shouldPersistMemory = this.shouldPersistMemoryForContext(oc);
     const feedbackDeferred = feedbackOptions
       ? createDeferred<AgentFeedbackMetadata | null>()
       : null;
@@ -1529,7 +1540,7 @@ export class Agent {
             { requirePending: true },
           );
         }
-        if (shouldDeferPersist) {
+        if (shouldDeferPersist && shouldPersistMemory) {
           void persistQueue.flush(buffer, oc).catch((error) => {
             oc.logger?.debug?.("Failed to persist feedback metadata", { error });
           });
@@ -1883,7 +1894,7 @@ export class Agent {
                   finishReason: finalResult.finishReason,
                 });
 
-                if (!shouldDeferPersist) {
+                if (!shouldDeferPersist && shouldPersistMemory) {
                   await persistQueue.flush(buffer, oc);
                 }
 
@@ -2034,7 +2045,7 @@ export class Agent {
 
                 if (feedbackResolved && feedbackMetadataValue) {
                   scheduleFeedbackPersist(feedbackMetadataValue);
-                } else if (shouldDeferPersist) {
+                } else if (shouldDeferPersist && shouldPersistMemory) {
                   void persistQueue.flush(buffer, oc).catch((error) => {
                     oc.logger?.debug?.("Failed to persist deferred messages", { error });
                   });
@@ -2650,7 +2661,7 @@ export class Agent {
             });
 
             // Save the object response to memory
-            if (oc.userId && oc.conversationId) {
+            if (this.shouldPersistMemoryForContext(oc) && oc.userId && oc.conversationId) {
               // Create UIMessage from the object response
               const message: UIMessage = {
                 id: randomUUID(),
@@ -3092,7 +3103,7 @@ export class Agent {
                     resolveGuardrailObject?.(finalObject);
                   }
 
-                  if (oc.userId && oc.conversationId) {
+                  if (this.shouldPersistMemoryForContext(oc) && oc.userId && oc.conversationId) {
                     const message: UIMessage = {
                       id: randomUUID(),
                       role: "assistant",
@@ -3515,6 +3526,11 @@ export class Agent {
         memoryOptions?.conversationPersistence ??
         options?.conversationPersistence ??
         parentResolvedMemory?.conversationPersistence,
+      readOnly: firstDefined(
+        contextResolvedMemory?.readOnly,
+        memoryOptions?.readOnly,
+        parentResolvedMemory?.readOnly,
+      ),
     };
   }
 
@@ -3707,6 +3723,14 @@ export class Agent {
     return queue;
   }
 
+  private isReadOnlyMemoryForContext(oc: OperationContext): boolean {
+    return oc.resolvedMemory?.readOnly === true;
+  }
+
+  private shouldPersistMemoryForContext(oc: OperationContext): boolean {
+    return !this.isReadOnlyMemoryForContext(oc);
+  }
+
   private async ensureStreamingResponseMessageId(
     oc: OperationContext,
     buffer: ConversationBuffer,
@@ -3785,6 +3809,10 @@ export class Agent {
   }
 
   private async flushPendingMessagesOnError(oc: OperationContext): Promise<void> {
+    if (!this.shouldPersistMemoryForContext(oc)) {
+      return;
+    }
+
     const buffer = this.getConversationBuffer(oc);
     const queue = this.getMemoryPersistQueue(oc);
 
@@ -4307,6 +4335,7 @@ export class Agent {
     const messages: UIMessage[] = [];
     const resolvedMemory = this.resolveMemoryRuntimeOptions(options, oc);
     const canIUseMemory = Boolean(resolvedMemory.userId);
+    const shouldPersistMemory = resolvedMemory.readOnly !== true;
     const memoryContextMessages: UIMessage[] = [];
 
     // Load memory context if available (already returns UIMessages)
@@ -4386,6 +4415,7 @@ export class Agent {
               oc.userId,
               oc.conversationId,
               resolvedMemory.contextLimit,
+              { persistInput: shouldPersistMemory },
             );
 
             // Update conversation ID
@@ -4420,7 +4450,7 @@ export class Agent {
 
           // When using semantic search, also persist the current input in background
           // so user messages are stored and embedded consistently.
-          if (isSemanticSearch && oc.userId && oc.conversationId) {
+          if (isSemanticSearch && shouldPersistMemory && oc.userId && oc.conversationId) {
             try {
               const inputForMemory =
                 typeof resolvedInput === "string"
@@ -6646,7 +6676,8 @@ export class Agent {
    */
   private createStepHandler(oc: OperationContext, options?: BaseGenerationOptions) {
     const buffer = this.getConversationBuffer(oc);
-    const persistQueue = this.getMemoryPersistQueue(oc);
+    const shouldPersistMemory = this.shouldPersistMemoryForContext(oc);
+    const persistQueue = shouldPersistMemory ? this.getMemoryPersistQueue(oc) : null;
     const conversationPersistence = this.getConversationPersistenceOptionsForContext(oc);
 
     return async (event: StepResult<ToolSet>) => {
@@ -6673,6 +6704,8 @@ export class Agent {
       }
 
       if (
+        shouldPersistMemory &&
+        persistQueue &&
         conversationPersistence.mode === "step" &&
         (hasResponseMessages || shouldFlushStepPersistence)
       ) {
@@ -6968,7 +7001,12 @@ export class Agent {
       recordTimestamp = new Date().toISOString();
     });
 
-    if (stepRecords.length > 0 && oc.userId && oc.conversationId) {
+    if (
+      this.shouldPersistMemoryForContext(oc) &&
+      stepRecords.length > 0 &&
+      oc.userId &&
+      oc.conversationId
+    ) {
       const persistStepsPromise = this.memoryManager
         .saveConversationSteps(oc, stepRecords, oc.userId, oc.conversationId)
         .catch((error) => {
@@ -7888,6 +7926,9 @@ export class Agent {
               ...(resolvedMemory.conversationPersistence !== undefined
                 ? { conversationPersistence: resolvedMemory.conversationPersistence }
                 : {}),
+              ...(resolvedMemory.readOnly !== undefined
+                ? { readOnly: resolvedMemory.readOnly }
+                : {}),
             }
           : undefined;
         const memory =
@@ -7955,6 +7996,7 @@ export class Agent {
       return [];
     }
     const resolvedMemory = this.resolveMemoryRuntimeOptions(options, operationContext);
+    const isReadOnly = resolvedMemory.readOnly === true;
 
     const memoryManager = this.memoryManager as unknown as MemoryManager;
     const memory = memoryManager.getMemory();
@@ -7981,80 +8023,82 @@ export class Agent {
       }),
     );
 
-    // Update Working Memory tool
-    const schema = memory.getWorkingMemorySchema();
-    const template = memory.getWorkingMemoryTemplate();
+    if (!isReadOnly) {
+      // Update Working Memory tool
+      const schema = memory.getWorkingMemorySchema();
+      const template = memory.getWorkingMemoryTemplate();
 
-    // Build parameters based on schema
-    const baseParams = schema
-      ? { content: schema }
-      : { content: z.string().describe("The content to store in working memory") };
+      // Build parameters based on schema
+      const baseParams = schema
+        ? { content: schema }
+        : { content: z.string().describe("The content to store in working memory") };
 
-    const modeParam = {
-      mode: z
-        .enum(["replace", "append"])
-        .default("append")
-        .describe(
-          "How to update: 'append' (default - safely merge with existing) or 'replace' (complete overwrite - DELETES other fields!)",
-        ),
-    };
+      const modeParam = {
+        mode: z
+          .enum(["replace", "append"])
+          .default("append")
+          .describe(
+            "How to update: 'append' (default - safely merge with existing) or 'replace' (complete overwrite - DELETES other fields!)",
+          ),
+      };
 
-    tools.push(
-      createTool({
-        name: "update_working_memory",
-        description: template
-          ? `Update working memory. Default mode is 'append' which safely merges new data. Only use 'replace' if you want to COMPLETELY OVERWRITE all data. Current data is in <current_context>. Template: ${template}`
-          : `Update working memory with important context. Default mode is 'append' which safely merges new data. Only use 'replace' if you want to COMPLETELY OVERWRITE all data. Current data is in <current_context>.`,
-        parameters: z.object({ ...baseParams, ...modeParam }),
-        execute: async ({ content, mode }, oc) => {
-          await memory.updateWorkingMemory({
-            conversationId: resolvedMemory.conversationId,
-            userId: resolvedMemory.userId,
-            content,
-            options: {
-              mode: mode as MemoryUpdateMode | undefined,
-            },
-          });
+      tools.push(
+        createTool({
+          name: "update_working_memory",
+          description: template
+            ? `Update working memory. Default mode is 'append' which safely merges new data. Only use 'replace' if you want to COMPLETELY OVERWRITE all data. Current data is in <current_context>. Template: ${template}`
+            : `Update working memory with important context. Default mode is 'append' which safely merges new data. Only use 'replace' if you want to COMPLETELY OVERWRITE all data. Current data is in <current_context>.`,
+          parameters: z.object({ ...baseParams, ...modeParam }),
+          execute: async ({ content, mode }, oc) => {
+            await memory.updateWorkingMemory({
+              conversationId: resolvedMemory.conversationId,
+              userId: resolvedMemory.userId,
+              content,
+              options: {
+                mode: mode as MemoryUpdateMode | undefined,
+              },
+            });
 
-          // Update root span with final content
-          if (oc?.traceContext) {
-            const finalContent = await memory.getWorkingMemory({
+            // Update root span with final content
+            if (oc?.traceContext) {
+              const finalContent = await memory.getWorkingMemory({
+                conversationId: resolvedMemory.conversationId,
+                userId: resolvedMemory.userId,
+              });
+              const rootSpan = oc.traceContext.getRootSpan();
+              rootSpan.setAttribute("agent.workingMemory.finalContent", finalContent || "");
+              rootSpan.setAttribute("agent.workingMemory.lastUpdateTime", new Date().toISOString());
+            }
+
+            return `Working memory ${mode === "replace" ? "replaced" : "updated (appended)"} successfully.`;
+          },
+        }),
+      );
+
+      // Clear Working Memory tool (optional, might not always be needed)
+      tools.push(
+        createTool({
+          name: "clear_working_memory",
+          description: "Clear the working memory content",
+          parameters: z.object({}),
+          execute: async (_, oc) => {
+            await memory.clearWorkingMemory({
               conversationId: resolvedMemory.conversationId,
               userId: resolvedMemory.userId,
             });
-            const rootSpan = oc.traceContext.getRootSpan();
-            rootSpan.setAttribute("agent.workingMemory.finalContent", finalContent || "");
-            rootSpan.setAttribute("agent.workingMemory.lastUpdateTime", new Date().toISOString());
-          }
 
-          return `Working memory ${mode === "replace" ? "replaced" : "updated (appended)"} successfully.`;
-        },
-      }),
-    );
+            // Update root span to indicate cleared state
+            if (oc?.traceContext) {
+              const rootSpan = oc.traceContext.getRootSpan();
+              rootSpan.setAttribute("agent.workingMemory.finalContent", "");
+              rootSpan.setAttribute("agent.workingMemory.lastUpdateTime", new Date().toISOString());
+            }
 
-    // Clear Working Memory tool (optional, might not always be needed)
-    tools.push(
-      createTool({
-        name: "clear_working_memory",
-        description: "Clear the working memory content",
-        parameters: z.object({}),
-        execute: async (_, oc) => {
-          await memory.clearWorkingMemory({
-            conversationId: resolvedMemory.conversationId,
-            userId: resolvedMemory.userId,
-          });
-
-          // Update root span to indicate cleared state
-          if (oc?.traceContext) {
-            const rootSpan = oc.traceContext.getRootSpan();
-            rootSpan.setAttribute("agent.workingMemory.finalContent", "");
-            rootSpan.setAttribute("agent.workingMemory.lastUpdateTime", new Date().toISOString());
-          }
-
-          return "Working memory cleared.";
-        },
-      }),
-    );
+            return "Working memory cleared.";
+          },
+        }),
+      );
+    }
 
     return tools;
   }

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -954,6 +954,11 @@ export interface CommonRuntimeMemoryBehaviorOptions {
   contextLimit?: number;
   semanticMemory?: CommonSemanticMemoryOptions;
   conversationPersistence?: AgentConversationPersistenceOptions;
+  /**
+   * When true, memory is read-only for the current call.
+   * Existing memory context can be loaded, but no writes are persisted.
+   */
+  readOnly?: boolean;
 }
 
 export interface CommonRuntimeMemoryEnvelope {
@@ -972,6 +977,7 @@ export interface CommonResolvedRuntimeMemoryOptions {
   contextLimit?: number;
   semanticMemory?: CommonSemanticMemoryOptions;
   conversationPersistence?: AgentConversationPersistenceOptions;
+  readOnly?: boolean;
 }
 
 export interface CommonGenerateOptions {

--- a/packages/core/src/memory/manager/memory-manager.ts
+++ b/packages/core/src/memory/manager/memory-manager.ts
@@ -468,6 +468,9 @@ export class MemoryManager {
     userId?: string,
     conversationIdParam?: string,
     contextLimit = 10,
+    options?: {
+      persistInput?: boolean;
+    },
   ): Promise<{ messages: UIMessage<{ createdAt: Date }>[]; conversationId: string }> {
     // Use the provided conversationId or generate a new one
     const conversationId = conversationIdParam || randomUUID();
@@ -509,7 +512,9 @@ export class MemoryManager {
       // Continue with empty messages, but don't fail the operation
     }
 
-    this.handleSequentialBackgroundOperations(context, input, userId, conversationId);
+    if (options?.persistInput !== false) {
+      this.handleSequentialBackgroundOperations(context, input, userId, conversationId);
+    }
 
     return { messages, conversationId };
   }

--- a/packages/server-core/src/schemas/agent.schemas.spec.ts
+++ b/packages/server-core/src/schemas/agent.schemas.spec.ts
@@ -55,6 +55,7 @@ describe("GenerateOptionsSchema", () => {
         conversationId: "conv-1",
         options: {
           contextLimit: 12,
+          readOnly: true,
           semanticMemory: {
             enabled: true,
             semanticLimit: 4,
@@ -75,6 +76,7 @@ describe("GenerateOptionsSchema", () => {
     expect(result.memory?.userId).toBe("user-1");
     expect(result.memory?.conversationId).toBe("conv-1");
     expect(result.memory?.options?.contextLimit).toBe(12);
+    expect(result.memory?.options?.readOnly).toBe(true);
     expect(result.memory?.options?.semanticMemory?.enabled).toBe(true);
     expect(result.memory?.options?.semanticMemory?.semanticLimit).toBe(4);
     expect(result.memory?.options?.semanticMemory?.semanticThreshold).toBe(0.8);

--- a/packages/server-core/src/schemas/agent.schemas.ts
+++ b/packages/server-core/src/schemas/agent.schemas.ts
@@ -218,6 +218,10 @@ const RuntimeMemoryBehaviorOptionsSchema = z
       .positive()
       .optional()
       .describe("Number of previous messages to include from memory"),
+    readOnly: z
+      .boolean()
+      .optional()
+      .describe("When true, memory reads are allowed but no memory writes are persisted"),
     semanticMemory: SemanticMemoryOptionsSchema.optional().describe(
       "Semantic retrieval configuration for this call",
     ),

--- a/packages/server-core/src/utils/options.ts
+++ b/packages/server-core/src/utils/options.ts
@@ -12,6 +12,7 @@ export interface ProcessedAgentOptions {
     userId?: string;
     options?: {
       contextLimit?: number;
+      readOnly?: boolean;
       semanticMemory?: {
         enabled?: boolean;
         semanticLimit?: number;

--- a/website/docs/agents/memory/overview.md
+++ b/website/docs/agents/memory/overview.md
@@ -85,6 +85,7 @@ Notes:
 - Three formats: Markdown template, JSON schema (Zod), or free-form
 - Two scopes: `conversation` (default) or `user`
 - Agent exposes tools: `get_working_memory`, `update_working_memory`, `clear_working_memory`
+- If `memory.options.readOnly: true` is set per call, only `get_working_memory` is exposed and memory writes are skipped
 
 ### Workflow State
 

--- a/website/docs/agents/memory/working-memory.md
+++ b/website/docs/agents/memory/working-memory.md
@@ -99,6 +99,9 @@ When working memory is enabled, the agent:
    - `update_working_memory(content)` - Update content (validated against schema if configured)
    - `clear_working_memory()` - Clear content
 
+If you run an operation with `options.memory.options.readOnly: true`, the agent only exposes
+`get_working_memory()` and skips write operations.
+
 The agent manages working memory proactively based on conversation flow.
 
 ## Update Modes

--- a/website/docs/api/api-reference.md
+++ b/website/docs/api/api-reference.md
@@ -53,6 +53,7 @@ Default port is 3141, but may vary based on configuration.
       "conversationId": "string",
       "options": {
         "contextLimit": 10,
+        "readOnly": false,
         "semanticMemory": {
           "enabled": true,
           "semanticLimit": 5,

--- a/website/docs/api/endpoints/agents.md
+++ b/website/docs/api/endpoints/agents.md
@@ -91,6 +91,7 @@ Generate a text response from an agent synchronously.
       "conversationId": "conv-456",
       "options": {
         "contextLimit": 10,
+        "readOnly": false,
         "conversationPersistence": {
           "mode": "step",
           "debounceMs": 200,
@@ -185,6 +186,7 @@ Generate a text response from an agent synchronously.
 | `memory.userId` | string | - | User ID for memory scoping |
 | `memory.conversationId` | string | - | Conversation ID for memory scoping |
 | `memory.options.contextLimit` | number | 10 | Message history limit |
+| `memory.options.readOnly` | boolean | `false` | Read memory context but disable memory writes for this call |
 | `memory.options.semanticMemory` | object | - | Semantic retrieval config |
 | `memory.options.semanticMemory.enabled` | boolean | - | Enable semantic retrieval for this call. Default: `undefined` (auto-enables if vectors are available). |
 | `memory.options.semanticMemory.semanticLimit` | number | 5 | Number of similar messages to retrieve |
@@ -218,6 +220,8 @@ Generate a text response from an agent synchronously.
 | `conversationPersistence.flushOnToolResult` | boolean | `true` | Deprecated: use `memory.options.conversationPersistence.flushOnToolResult` |
 
 When both top-level legacy memory fields and `memory` envelope fields are provided, runtime resolution follows `resolveMemoryRuntimeOptions()` and values under `memory` take precedence.
+
+Use `memory.options.readOnly: true` when you need memory context reads without persisting new conversation state.
 
 **Response:**
 

--- a/website/docs/ui/ai-sdk-integration.md
+++ b/website/docs/ui/ai-sdk-integration.md
@@ -357,6 +357,7 @@ export function ChatInterface() {
 | `memory.conversationId`                                    | string  | Conversation thread ID                                                         |
 | `context`                                                  | object  | Dynamic context (converted to Map internally)                                  |
 | `memory.options.contextLimit`                              | number  | Number of previous messages to include from memory                             |
+| `memory.options.readOnly`                                  | boolean | Read memory context but skip all memory writes for this call                   |
 | `memory.options.conversationPersistence.mode`              | string  | `"step"` (default) or `"finish"`                                               |
 | `memory.options.conversationPersistence.debounceMs`        | number  | Debounce window in milliseconds (default: `200`)                               |
 | `memory.options.conversationPersistence.flushOnToolResult` | boolean | Flush immediately on `tool-result`/`tool-error` in step mode (default: `true`) |
@@ -376,6 +377,7 @@ options: {
     userId,
     conversationId,
     options: {
+      readOnly: false,
       conversationPersistence: {
         mode: "step",
         debounceMs: 200,
@@ -387,6 +389,8 @@ options: {
 ```
 
 When both top-level legacy memory fields and `memory` envelope fields are provided, `memory` values are used.
+
+Set `memory.options.readOnly: true` to load memory context without persisting new messages for that request.
 
 ### AI SDK Core Options
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Runtime memory always persists new messages/steps when memory is enabled, and working memory tools always include write operations.

## What is the new behavior?

When `memory.options.readOnly: true` is provided for a call:

- Memory context is still read.
- Conversation persistence writes are skipped.
- Step persistence writes are skipped.
- Background input persistence during context hydration is skipped.
- Object response memory writes are skipped.
- Working memory write tools are disabled (`update_working_memory`, `clear_working_memory`), while `get_working_memory` remains available.
- Server schema/options now accept `memory.options.readOnly`.

fixes (issue)

N/A

## Notes for reviewers

- Added/updated tests in `@voltagent/core` and `@voltagent/server-core`.
- Verified with:
  - `pnpm --filter @voltagent/core exec vitest run src/agent/agent.spec.ts`
  - `pnpm --filter @voltagent/server-core exec vitest run src/schemas/agent.schemas.spec.ts`
  - `pnpm --filter @voltagent/core typecheck`
  - `pnpm --filter @voltagent/server-core typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-call read-only memory mode so agents can read context without persisting any new state. Enable via memory.options.readOnly and disable working memory write tools for that request.

- **New Features**
  - Accept memory.options.readOnly in runtime and server schemas.
  - Skip memory writes: conversation messages, step checkpoints, background input during hydration, and object response persistence.
  - Working memory tools: expose get_working_memory only; disable update_working_memory and clear_working_memory.
  - Guard agent persistence paths and queues to honor read-only mode.
  - Added tests in core and server-core; updated docs and API references.

<sup>Written for commit 3b31084e947845628dbc6a6709b7e927281fba73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added memory read-only mode via `memory.options.readOnly` flag for per-call control
  * When enabled, agents access existing conversation context and working memory without persisting any new state or writes
  * Read-only mode disables memory write operations while keeping read functionality available

* **Documentation**
  * Updated API reference, integration guides, and memory documentation with read-only mode examples and usage instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->