### PR TITLE
fix(ag-ui): use `input` instead of `args` for tool-call parts

### DIFF
--- a/.changeset/fix-ag-ui-tool-call-input.md
+++ b/.changeset/fix-ag-ui-tool-call-input.md
@@ -1,0 +1,12 @@
+---
+"@voltagent/ag-ui": patch
+---
+
+fix: use `input` instead of `args` for tool-call parts in message conversion
+
+When converting CopilotKit assistant messages with tool calls to VoltAgent format,
+the adapter was setting `args` on tool-call parts. The AI SDK's `ToolCallPart`
+interface expects `input`, causing the Anthropic provider to send `undefined` as
+the tool_use input — rejected by the API with:
+
+  "messages.N.content.N.tool_use.input: Input should be a valid dictionary"

--- a/packages/ag-ui/src/voltagent-agent.ts
+++ b/packages/ag-ui/src/voltagent-agent.ts
@@ -276,7 +276,7 @@ const isToolMessage = (message: Message): message is ToolMessage => message.role
 
 type VoltUIPart =
   | { type: "text"; text: string }
-  | { type: "tool-call"; toolCallId: string; toolName: string; args?: unknown }
+  | { type: "tool-call"; toolCallId: string; toolName: string; input?: unknown }
   | { type: "tool-result"; toolCallId?: string; toolName?: string; output?: unknown };
 
 type VoltUIMessage = {
@@ -311,13 +311,13 @@ function convertAGUIMessagesToVoltMessages(messages: Message[]): VoltUIMessage[]
       }
 
       for (const call of msg.toolCalls ?? []) {
-        const args = safelyParseJson(call.function.arguments);
+        const input = safelyParseJson(call.function.arguments);
         toolNameById.set(call.id, call.function.name);
         parts.push({
           type: "tool-call",
           toolCallId: call.id,
           toolName: call.function.name,
-          args,
+          input,
         });
       }
 


### PR DESCRIPTION
## Summary

- Fixes tool-call message conversion in `convertAGUIMessagesToVoltMessages()` — renames `args` to `input` on tool-call parts to match the AI SDK's `ToolCallPart` interface

## Problem

When CopilotKit replays assistant messages containing tool calls, the ag-ui adapter creates tool-call parts with an `args` field. The AI SDK's `ToolCallPart` interface (from `@ai-sdk/provider-utils`) expects `input`. When the Anthropic provider builds the API request, it reads `part.input` which is `undefined`, causing:

```
AI_APICallError: messages.N.content.N.tool_use.input: Input should be a valid dictionary
```

This breaks any multi-turn conversation where the assistant previously called a tool (the replayed message has the wrong field name).

## Root Cause

In `packages/ag-ui/src/voltagent-agent.ts`, `convertAGUIMessagesToVoltMessages()` line 314-321:

```typescript
// Before (broken)
const args = safelyParseJson(call.function.arguments);
parts.push({ type: "tool-call", toolCallId: call.id, toolName: call.function.name, args });

// After (fixed)
const input = safelyParseJson(call.function.arguments);
parts.push({ type: "tool-call", toolCallId: call.id, toolName: call.function.name, input });
```

The AI SDK `ToolCallPart` type:
```typescript
interface ToolCallPart {
  type: 'tool-call';
  toolCallId: string;
  toolName: string;
  input: unknown;  // <-- expects "input", not "args"
}
```

## Test plan

- [ ] Verified `ToolCallPart` interface in `@ai-sdk/provider-utils` expects `input` field
- [ ] Verified Anthropic provider reads `part.input` to construct `tool_use` blocks
- [ ] Multi-turn conversation with tool calls no longer throws `AI_APICallError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `input` instead of `args` for tool-call parts in `@voltagent/ag-ui` message conversion. This matches `@ai-sdk/provider-utils` `ToolCallPart` and prevents Anthropic requests from failing when replaying tool calls.

<sup>Written for commit 27387c63dca76c6bd2996dc9eb528333ad5d8898. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where tool call arguments were incorrectly formatted in message conversions, causing API rejections. Tool calls now use the expected input field format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->