### PR TITLE
fix: skip memory persistence for delegated sub-agent calls

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3794,6 +3794,12 @@ export class Agent {
   }
 
   private shouldPersistMemoryForContext(oc: OperationContext): boolean {
+    // Skip memory persistence for delegated sub-agent calls to prevent
+    // polluting the parent conversation's memory with duplicate messages.
+    // See: https://github.com/VoltAgent/voltagent/issues/1026
+    if (oc.parentAgentId) {
+      return false;
+    }
     return !this.isReadOnlyMemoryForContext(oc);
   }
 


### PR DESCRIPTION
## Problem

When a parent (supervisor) agent delegates a task to a sub-agent via \delegate_task\, and the sub-agent has a \memory\ instance configured, the sub-agent persists its own user message and assistant response into the **same \conversationId\** as the parent agent. On subsequent turns, the parent's \prepareMessages()\ loads these extra messages, causing the LLM to see duplicate/phantom messages.

## Root Cause

In \SubAgentManager.handoffTask()\, the parent's \conversationId\ is passed directly to the sub-agent via \aseOptions\. When the sub-agent has \memory\, its persistence pipeline treats the delegated task as a new user message in the parent's conversation.

## Fix

\shouldPersistMemoryForContext()\ now checks for \parentAgentId\ on the \OperationContext\. This field is already set during delegation (line 3692/3742 in agent.ts), so no additional plumbing is needed. When a sub-agent is executing a delegated task, it skips memory persistence entirely.

This is the minimal, non-breaking fix — sub-agents acting as stateless task executors don't need to persist to the parent's conversation history. The existing \metadata.subAgentId\ / \metadata.subAgentName\ fields (from PR #786) remain available for any future read-side filtering needs.

## Workaround (before this fix)

Remove \memory\ from sub-agents entirely.

Fixes #1026

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip memory persistence for delegated sub‑agent calls to stop polluting the parent conversation and avoid duplicate/phantom messages. `Agent.shouldPersistMemoryForContext` now returns false when `OperationContext.parentAgentId` is set (fixes #1026).

<sup>Written for commit 01ba714f8d857c328854bc8c18a14499355cc2a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate message entries appearing in conversation memory when sub-agents are delegated tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->