### PR TITLE
style: add global brand-themed scrollbar styling

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -5356,6 +5356,67 @@ nav.table-of-contents .table-of-contents__link--active,
   }
 }
 
+/* ========================================
+   Global Scrollbar Styling
+   Brand-themed scrollbars using emerald green (#10b981)
+   ======================================== */
+
+/* Firefox scrollbar styling */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(16, 185, 129, 0.3) transparent;
+}
+
+/* Webkit (Chrome, Safari, Edge) global scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(16, 185, 129, 0.3);
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(16, 185, 129, 0.5);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* Light mode scrollbar track */
+[data-theme="light"] ::-webkit-scrollbar-track {
+  background: rgba(243, 244, 246, 0.5);
+}
+
+[data-theme="light"] * {
+  scrollbar-color: rgba(16, 185, 129, 0.3) rgba(243, 244, 246, 0.5);
+}
+
+/* Dark mode scrollbar */
+[data-theme="dark"] ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb {
+  background-color: rgba(16, 185, 129, 0.3);
+}
+
+[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(16, 185, 129, 0.5);
+}
+
+[data-theme="dark"] * {
+  scrollbar-color: rgba(16, 185, 129, 0.3) transparent;
+}
+
 /* Scrollbar styling for table of contents */
 .tableOfContents::-webkit-scrollbar {
   width: 5px;
@@ -5366,21 +5427,21 @@ nav.table-of-contents .table-of-contents__link--active,
 }
 
 .tableOfContents::-webkit-scrollbar-thumb {
-  background-color: rgba(107, 114, 128, 0.3);
+  background-color: rgba(16, 185, 129, 0.3);
   border-radius: 10px;
 }
 
 .tableOfContents::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(107, 114, 128, 0.5);
+  background-color: rgba(16, 185, 129, 0.5);
 }
 
-/* Dark mode scrollbar */
+/* Dark mode TOC scrollbar */
 [data-theme="dark"] .tableOfContents::-webkit-scrollbar-thumb {
-  background-color: rgba(156, 163, 175, 0.3);
+  background-color: rgba(16, 185, 129, 0.3);
 }
 
 [data-theme="dark"] .tableOfContents::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(156, 163, 175, 0.5);
+  background-color: rgba(16, 185, 129, 0.5);
 }
 
 /* Animate the active TOC item */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -5392,27 +5392,33 @@ nav.table-of-contents .table-of-contents__link--active,
 }
 
 /* Light mode scrollbar track */
-[data-theme="light"] ::-webkit-scrollbar-track {
+[data-theme="light"]::-webkit-scrollbar-track,
+[data-theme="light"] *::-webkit-scrollbar-track {
   background: rgba(243, 244, 246, 0.5);
 }
 
+[data-theme="light"],
 [data-theme="light"] * {
   scrollbar-color: rgba(16, 185, 129, 0.3) rgba(243, 244, 246, 0.5);
 }
 
 /* Dark mode scrollbar */
-[data-theme="dark"] ::-webkit-scrollbar-track {
+[data-theme="dark"]::-webkit-scrollbar-track,
+[data-theme="dark"] *::-webkit-scrollbar-track {
   background: transparent;
 }
 
-[data-theme="dark"] ::-webkit-scrollbar-thumb {
+[data-theme="dark"]::-webkit-scrollbar-thumb,
+[data-theme="dark"] *::-webkit-scrollbar-thumb {
   background-color: rgba(16, 185, 129, 0.3);
 }
 
-[data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
+[data-theme="dark"]::-webkit-scrollbar-thumb:hover,
+[data-theme="dark"] *::-webkit-scrollbar-thumb:hover {
   background-color: rgba(16, 185, 129, 0.5);
 }
 
+[data-theme="dark"],
 [data-theme="dark"] * {
   scrollbar-color: rgba(16, 185, 129, 0.3) transparent;
 }
@@ -5428,7 +5434,7 @@ nav.table-of-contents .table-of-contents__link--active,
 
 .tableOfContents::-webkit-scrollbar-thumb {
   background-color: rgba(16, 185, 129, 0.3);
-  border-radius: 10px;
+  border-radius: 4px;
 }
 
 .tableOfContents::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
## Summary

Fixes #1157 — Adds custom scrollbar styling across the entire VoltAgent documentation website using the brand emerald green color (`#10b981`).

### Changes

- **Global scrollbar styles**: Added Webkit (`::-webkit-scrollbar`) and Firefox (`scrollbar-width`, `scrollbar-color`) global scrollbar rules using emerald green (`rgba(16, 185, 129, 0.3)`) with smooth hover transitions
- **Light/dark theme support**: Light mode uses a subtle gray track (`rgba(243, 244, 246, 0.5)`), dark mode uses a transparent track — both with emerald green thumbs
- **Updated TOC scrollbar**: Changed existing `.tableOfContents` scrollbar from generic gray (`rgba(107, 114, 128, ...)`) to brand-consistent emerald green
- **Modern design**: 8px width, 4px border-radius, transparent corners for a clean, unobtrusive look

### Design Specs (from issue)

| Property | Value |
|---|---|
| Width | 8px (global), 5px (TOC) |
| Thumb color | `rgba(16, 185, 129, 0.3)` |
| Thumb hover | `rgba(16, 185, 129, 0.5)` |
| Border radius | 4px |
| Track (dark) | transparent |
| Track (light) | `rgba(243, 244, 246, 0.5)` |

## Test plan

- [ ] Verify scrollbar appears with emerald green thumb in Chrome/Edge (Webkit)
- [ ] Verify scrollbar appears correctly in Firefox (thin, emerald green)
- [ ] Test dark mode — thumb is emerald green, track is transparent
- [ ] Test light mode — thumb is emerald green, track is subtle gray
- [ ] Verify TOC sidebar scrollbar uses updated brand colors
- [ ] Confirm hover transitions work smoothly
- [ ] Check scrollbar-corner is transparent (no white square in scroll areas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds global brand-themed scrollbars across the docs, using emerald green thumbs with light/dark track support for a cleaner, consistent look. Closes #1157.

- **New Features**
  - Global CSS for WebKit and Firefox (`::-webkit-scrollbar`, `scrollbar-width/color`) with emerald green thumbs and hover.
  - Light mode: subtle gray track; dark mode: transparent track; transparent scrollbar corner.
  - Modern proportions: 8px width, 4px radius; smooth hover transitions.
  - TOC scrollbar updated to brand green with 5px width.

- **Bug Fixes**
  - Theme selectors now target root scrollbars (not only descendants) for correct light/dark styling.
  - TOC thumb border-radius corrected to 4px to match spec.

<sup>Written for commit dbd9dcdfb37e746fa839fb7ad76b169b082b71fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Global scrollbar styling updated for more consistent look across browsers
  * Scrollbar thumb colors switched to emerald brand tones, with hover states
  * Explicit light/dark theme scrollbar overrides for better contrast
  * Table of Contents scrollbar aligned with brand color and refined (smaller corner radius)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->