### PR TITLE
feat(core): add GuardrailProvider interface for pluggable guardrail implementations

### DIFF
--- a/packages/core/src/agent/guardrail-provider.spec.ts
+++ b/packages/core/src/agent/guardrail-provider.spec.ts
@@ -265,6 +265,72 @@ describe("createGuardrailsFromProvider", () => {
     });
   });
 
+  describe("malformed modify decisions (fail-closed)", () => {
+    it("blocks input when action is modify but modifiedContent is missing", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({
+        pass: true,
+        action: "modify",
+        // no modifiedContent
+        message: "tried to modify",
+      });
+      const provider: GuardrailProvider = { name: "BadModify", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(false);
+      expect(result.action).toBe("block");
+      expect(result.message).toBe("tried to modify");
+    });
+
+    it("blocks output when action is modify but modifiedContent is missing", async () => {
+      const evaluateOutput = vi.fn().mockResolvedValue({
+        pass: true,
+        action: "modify",
+        // no modifiedContent
+      });
+      const provider: GuardrailProvider = { name: "BadModifyOut", evaluateOutput };
+      const { outputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await outputGuardrails[0].handler(makeOutputArgs("response"));
+      expect(result.pass).toBe(false);
+      expect(result.action).toBe("block");
+    });
+
+    it("provides a default message when modify lacks both modifiedContent and message", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({
+        pass: true,
+        action: "modify",
+      });
+      const provider: GuardrailProvider = { name: "NoMsg", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(false);
+      expect(result.message).toContain("NoMsg");
+      expect(result.message).toContain("modify");
+    });
+  });
+
+  describe("collision-safe IDs", () => {
+    it("generates a fallback ID when provider name produces an empty slug", () => {
+      const provider: GuardrailProvider = {
+        name: "---",
+        evaluateInput: () => ({ pass: true }),
+      };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const guardrail = inputGuardrails[0] as any;
+      expect(guardrail.id).toBeTruthy();
+      expect(guardrail.id).not.toBe("-input");
+    });
+
+    it("uses explicit id option over generated slug", () => {
+      const provider: GuardrailProvider = {
+        name: "Some Provider",
+        evaluateInput: () => ({ pass: true }),
+      };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider, { id: "explicit" });
+      const guardrail = inputGuardrails[0] as any;
+      expect(guardrail.id).toBe("explicit-input");
+    });
+  });
+
   describe("multiple providers", () => {
     it("can combine guardrails from multiple providers", () => {
       const providerA: GuardrailProvider = {

--- a/packages/core/src/agent/guardrail-provider.spec.ts
+++ b/packages/core/src/agent/guardrail-provider.spec.ts
@@ -278,7 +278,8 @@ describe("createGuardrailsFromProvider", () => {
       const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
       expect(result.pass).toBe(false);
       expect(result.action).toBe("block");
-      expect(result.message).toBe("tried to modify");
+      expect(result.message).toContain("BadModify");
+      expect(result.message).toContain("modifiedContent");
     });
 
     it("blocks output when action is modify but modifiedContent is missing", async () => {
@@ -292,6 +293,60 @@ describe("createGuardrailsFromProvider", () => {
       const result = await outputGuardrails[0].handler(makeOutputArgs("response"));
       expect(result.pass).toBe(false);
       expect(result.action).toBe("block");
+      expect(result.message).toContain("BadModifyOut");
+    });
+
+    it("blocks when provider returns explicit action: block even with pass: true (input)", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({
+        pass: true,
+        action: "block",
+        message: "Explicit block overrides pass",
+      });
+      const provider: GuardrailProvider = { name: "AuthBlock", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(false);
+      expect(result.action).toBe("block");
+      expect(result.message).toBe("Explicit block overrides pass");
+    });
+
+    it("blocks when provider returns action: block without pass field (input)", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({
+        action: "block",
+        message: "No pass field",
+      });
+      const provider: GuardrailProvider = { name: "NoPassBlock", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(false);
+      expect(result.action).toBe("block");
+    });
+
+    it("allows when provider returns explicit action: allow with pass: false (action authoritative)", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({
+        pass: false,
+        action: "allow",
+        message: "Explicit allow overrides pass",
+      });
+      const provider: GuardrailProvider = { name: "AuthAllow", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(true);
+      expect(result.action).toBe("allow");
+    });
+
+    it("blocks when provider returns explicit action: block even with pass: true (output)", async () => {
+      const evaluateOutput = vi.fn().mockResolvedValue({
+        pass: true,
+        action: "block",
+        message: "Explicit block on output",
+      });
+      const provider: GuardrailProvider = { name: "AuthBlockOut", evaluateOutput };
+      const { outputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await outputGuardrails[0].handler(makeOutputArgs("response"));
+      expect(result.pass).toBe(false);
+      expect(result.action).toBe("block");
+      expect(result.message).toBe("Explicit block on output");
     });
 
     it("provides a default message when modify lacks both modifiedContent and message", async () => {

--- a/packages/core/src/agent/guardrail-provider.spec.ts
+++ b/packages/core/src/agent/guardrail-provider.spec.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type GuardrailProvider,
+  type GuardrailProviderContext,
+  type GuardrailProviderDecision,
+  createGuardrailsFromProvider,
+} from "./guardrail-provider";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal stub for the `agent` property in guardrail args. */
+const stubAgent = { name: "test-agent" } as any;
+
+/** Minimal operation context stub. */
+const stubOc = {
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+} as any;
+
+function makeInputArgs(text: string) {
+  return {
+    input: text,
+    inputText: text,
+    originalInput: text,
+    originalInputText: text,
+    agent: stubAgent,
+    context: stubOc,
+    operation: "generateText",
+  } as any;
+}
+
+function makeOutputArgs(text: string) {
+  return {
+    output: text,
+    outputText: text,
+    originalOutput: text,
+    originalOutputText: text,
+    agent: stubAgent,
+    context: stubOc,
+    operation: "generateText",
+    usage: undefined,
+    finishReason: null,
+    warnings: null,
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createGuardrailsFromProvider", () => {
+  it("returns empty arrays when provider implements neither direction", () => {
+    const provider: GuardrailProvider = { name: "Empty Provider" };
+    const { inputGuardrails, outputGuardrails } = createGuardrailsFromProvider(provider);
+    expect(inputGuardrails).toHaveLength(0);
+    expect(outputGuardrails).toHaveLength(0);
+  });
+
+  it("creates an input guardrail when evaluateInput is implemented", () => {
+    const provider: GuardrailProvider = {
+      name: "Input Only",
+      evaluateInput: () => ({ pass: true }),
+    };
+    const { inputGuardrails, outputGuardrails } = createGuardrailsFromProvider(provider);
+    expect(inputGuardrails).toHaveLength(1);
+    expect(outputGuardrails).toHaveLength(0);
+  });
+
+  it("creates an output guardrail when evaluateOutput is implemented", () => {
+    const provider: GuardrailProvider = {
+      name: "Output Only",
+      evaluateOutput: () => ({ pass: true }),
+    };
+    const { inputGuardrails, outputGuardrails } = createGuardrailsFromProvider(provider);
+    expect(inputGuardrails).toHaveLength(0);
+    expect(outputGuardrails).toHaveLength(1);
+  });
+
+  it("creates both guardrails when provider implements both directions", () => {
+    const provider: GuardrailProvider = {
+      name: "Full Provider",
+      evaluateInput: () => ({ pass: true }),
+      evaluateOutput: () => ({ pass: true }),
+    };
+    const { inputGuardrails, outputGuardrails } = createGuardrailsFromProvider(provider);
+    expect(inputGuardrails).toHaveLength(1);
+    expect(outputGuardrails).toHaveLength(1);
+  });
+
+  it("sets guardrail metadata from provider properties", () => {
+    const provider: GuardrailProvider = {
+      name: "AIP Identity",
+      description: "Cryptographic agent identity verification",
+      severity: "critical",
+      tags: ["identity", "security"],
+      evaluateInput: () => ({ pass: true }),
+    };
+    const { inputGuardrails } = createGuardrailsFromProvider(provider);
+    const guardrail = inputGuardrails[0] as any;
+    expect(guardrail.name).toBe("AIP Identity (input)");
+    expect(guardrail.id).toBe("aip-identity-input");
+    expect(guardrail.description).toBe("Cryptographic agent identity verification");
+    expect(guardrail.severity).toBe("critical");
+    expect(guardrail.tags).toEqual(["identity", "security"]);
+  });
+
+  it("allows overriding metadata via options", () => {
+    const provider: GuardrailProvider = {
+      name: "My Provider",
+      severity: "info",
+      tags: ["base"],
+      evaluateInput: () => ({ pass: true }),
+    };
+    const { inputGuardrails } = createGuardrailsFromProvider(provider, {
+      id: "custom-id",
+      severity: "warning",
+      tags: ["extra"],
+    });
+    const guardrail = inputGuardrails[0] as any;
+    expect(guardrail.id).toBe("custom-id-input");
+    expect(guardrail.severity).toBe("warning");
+    expect(guardrail.tags).toEqual(["base", "extra"]);
+  });
+
+  describe("input guardrail handler", () => {
+    it("passes content through when provider returns pass: true", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({ pass: true });
+      const provider: GuardrailProvider = { name: "Allow", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(true);
+      expect(result.action).toBe("allow");
+    });
+
+    it("passes content through when provider returns undefined", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue(undefined);
+      const provider: GuardrailProvider = { name: "NoOp", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(true);
+    });
+
+    it("blocks content when provider returns pass: false", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({
+        pass: false,
+        message: "Identity verification failed",
+      });
+      const provider: GuardrailProvider = { name: "Block", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(false);
+      expect(result.action).toBe("block");
+      expect(result.message).toBe("Identity verification failed");
+    });
+
+    it("modifies content when provider returns action: modify", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({
+        pass: true,
+        action: "modify",
+        modifiedContent: "sanitized input",
+        message: "Content redacted",
+      });
+      const provider: GuardrailProvider = { name: "Modify", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("sensitive data"));
+      expect(result.pass).toBe(true);
+      expect(result.action).toBe("modify");
+      expect(result.modifiedInput).toBe("sanitized input");
+      expect(result.message).toBe("Content redacted");
+    });
+
+    it("passes the correct context to the provider", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({ pass: true });
+      const provider: GuardrailProvider = { name: "CtxCheck", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      await inputGuardrails[0].handler(makeInputArgs("test input"));
+      expect(evaluateInput).toHaveBeenCalledWith("test input", {
+        agentName: "test-agent",
+        operation: "generateText",
+        direction: "input",
+      });
+    });
+
+    it("preserves metadata from provider decision", async () => {
+      const evaluateInput = vi.fn().mockResolvedValue({
+        pass: true,
+        metadata: { trustScore: 0.95, did: "did:aip:abc123" },
+      });
+      const provider: GuardrailProvider = { name: "Meta", evaluateInput };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.metadata).toEqual({ trustScore: 0.95, did: "did:aip:abc123" });
+    });
+
+    it("works with synchronous evaluateInput", async () => {
+      const provider: GuardrailProvider = {
+        name: "Sync",
+        evaluateInput: () => ({ pass: true, message: "sync ok" }),
+      };
+      const { inputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await inputGuardrails[0].handler(makeInputArgs("hello"));
+      expect(result.pass).toBe(true);
+      expect(result.message).toBe("sync ok");
+    });
+  });
+
+  describe("output guardrail handler", () => {
+    it("passes output through when provider returns pass: true", async () => {
+      const evaluateOutput = vi.fn().mockResolvedValue({ pass: true });
+      const provider: GuardrailProvider = { name: "AllowOut", evaluateOutput };
+      const { outputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await outputGuardrails[0].handler(makeOutputArgs("model response"));
+      expect(result.pass).toBe(true);
+      expect(result.action).toBe("allow");
+    });
+
+    it("blocks output when provider returns pass: false", async () => {
+      const evaluateOutput = vi.fn().mockResolvedValue({
+        pass: false,
+        message: "Output contains PII",
+      });
+      const provider: GuardrailProvider = { name: "BlockOut", evaluateOutput };
+      const { outputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await outputGuardrails[0].handler(makeOutputArgs("name: John Doe"));
+      expect(result.pass).toBe(false);
+      expect(result.action).toBe("block");
+      expect(result.message).toBe("Output contains PII");
+    });
+
+    it("modifies output when provider returns action: modify", async () => {
+      const evaluateOutput = vi.fn().mockResolvedValue({
+        pass: true,
+        action: "modify",
+        modifiedContent: "[redacted]",
+      });
+      const provider: GuardrailProvider = { name: "RedactOut", evaluateOutput };
+      const { outputGuardrails } = createGuardrailsFromProvider(provider);
+      const result = await outputGuardrails[0].handler(makeOutputArgs("secret data"));
+      expect(result.pass).toBe(true);
+      expect(result.action).toBe("modify");
+      expect(result.modifiedOutput).toBe("[redacted]");
+    });
+
+    it("passes the correct context to the provider", async () => {
+      const evaluateOutput = vi.fn().mockResolvedValue({ pass: true });
+      const provider: GuardrailProvider = { name: "OutCtx", evaluateOutput };
+      const { outputGuardrails } = createGuardrailsFromProvider(provider);
+      await outputGuardrails[0].handler(makeOutputArgs("response text"));
+      expect(evaluateOutput).toHaveBeenCalledWith("response text", {
+        agentName: "test-agent",
+        operation: "generateText",
+        direction: "output",
+      });
+    });
+
+    it("handles empty outputText gracefully", async () => {
+      const evaluateOutput = vi.fn().mockResolvedValue({ pass: true });
+      const provider: GuardrailProvider = { name: "EmptyOut", evaluateOutput };
+      const { outputGuardrails } = createGuardrailsFromProvider(provider);
+      const args = makeOutputArgs("");
+      args.outputText = undefined;
+      await outputGuardrails[0].handler(args);
+      expect(evaluateOutput).toHaveBeenCalledWith("", expect.any(Object));
+    });
+  });
+
+  describe("multiple providers", () => {
+    it("can combine guardrails from multiple providers", () => {
+      const providerA: GuardrailProvider = {
+        name: "Provider A",
+        evaluateInput: () => ({ pass: true }),
+      };
+      const providerB: GuardrailProvider = {
+        name: "Provider B",
+        evaluateInput: () => ({ pass: true }),
+        evaluateOutput: () => ({ pass: true }),
+      };
+
+      const a = createGuardrailsFromProvider(providerA);
+      const b = createGuardrailsFromProvider(providerB);
+
+      const combined = {
+        inputGuardrails: [...a.inputGuardrails, ...b.inputGuardrails],
+        outputGuardrails: [...a.outputGuardrails, ...b.outputGuardrails],
+      };
+
+      expect(combined.inputGuardrails).toHaveLength(2);
+      expect(combined.outputGuardrails).toHaveLength(1);
+    });
+  });
+});

--- a/packages/core/src/agent/guardrail-provider.ts
+++ b/packages/core/src/agent/guardrail-provider.ts
@@ -107,7 +107,7 @@ export interface GuardrailProvider {
   evaluateInput?(
     content: string,
     context: GuardrailProviderContext,
-  ): Promise<GuardrailProviderDecision> | GuardrailProviderDecision;
+  ): Promise<GuardrailProviderDecision | undefined> | GuardrailProviderDecision | undefined;
 
   /**
    * Evaluate output content before it is returned to the caller.
@@ -116,7 +116,7 @@ export interface GuardrailProvider {
   evaluateOutput?(
     content: string,
     context: GuardrailProviderContext,
-  ): Promise<GuardrailProviderDecision> | GuardrailProviderDecision;
+  ): Promise<GuardrailProviderDecision | undefined> | GuardrailProviderDecision | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -168,7 +168,8 @@ export function createGuardrailsFromProvider(
   inputGuardrails: InputGuardrail[];
   outputGuardrails: OutputGuardrail[];
 } {
-  const id = options?.id ?? slugify(provider.name);
+  const baseSlug = slugify(provider.name);
+  const id = options?.id ?? (baseSlug || `provider-${nextProviderId()}`);
   const severity = options?.severity ?? provider.severity;
   const tags = mergeTags(provider.tags, options?.tags);
 
@@ -195,13 +196,23 @@ export function createGuardrailsFromProvider(
 
         if (!decision || decision.pass !== false) {
           const resolvedAction = decision?.action ?? "allow";
-          if (resolvedAction === "modify" && decision?.modifiedContent !== undefined) {
+          if (resolvedAction === "modify") {
+            if (decision?.modifiedContent !== undefined) {
+              return {
+                pass: true,
+                action: "modify",
+                message: decision?.message,
+                metadata: decision?.metadata,
+                modifiedInput: decision.modifiedContent as InputGuardrailResult["modifiedInput"],
+              };
+            }
+            // Malformed: action is "modify" but no modifiedContent provided.
+            // Fail closed to prevent bypassing guardrail transformations.
             return {
-              pass: true,
-              action: "modify",
-              message: decision?.message,
+              pass: false,
+              action: "block",
+              message: decision?.message ?? `Provider "${provider.name}" returned action "modify" without modifiedContent`,
               metadata: decision?.metadata,
-              modifiedInput: decision.modifiedContent as InputGuardrailResult["modifiedInput"],
             };
           }
           return {
@@ -245,13 +256,23 @@ export function createGuardrailsFromProvider(
 
         if (!decision || decision.pass !== false) {
           const resolvedAction = decision?.action ?? "allow";
-          if (resolvedAction === "modify" && decision?.modifiedContent !== undefined) {
+          if (resolvedAction === "modify") {
+            if (decision?.modifiedContent !== undefined) {
+              return {
+                pass: true,
+                action: "modify",
+                message: decision?.message,
+                metadata: decision?.metadata,
+                modifiedOutput: decision.modifiedContent,
+              };
+            }
+            // Malformed: action is "modify" but no modifiedContent provided.
+            // Fail closed to prevent bypassing guardrail transformations.
             return {
-              pass: true,
-              action: "modify",
-              message: decision?.message,
+              pass: false,
+              action: "block",
+              message: decision?.message ?? `Provider "${provider.name}" returned action "modify" without modifiedContent`,
               metadata: decision?.metadata,
-              modifiedOutput: decision.modifiedContent,
             };
           }
           return {
@@ -280,6 +301,11 @@ export function createGuardrailsFromProvider(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+let _providerIdCounter = 0;
+function nextProviderId(): string {
+  return String(++_providerIdCounter);
+}
 
 function slugify(name: string): string {
   return name

--- a/packages/core/src/agent/guardrail-provider.ts
+++ b/packages/core/src/agent/guardrail-provider.ts
@@ -194,38 +194,61 @@ export function createGuardrailsFromProvider(
 
         const decision = await evaluate(args.inputText, context);
 
-        if (!decision || decision.pass !== false) {
-          const resolvedAction = decision?.action ?? "allow";
-          if (resolvedAction === "modify") {
-            if (decision?.modifiedContent !== undefined) {
-              return {
-                pass: true,
-                action: "modify",
-                message: decision?.message,
-                metadata: decision?.metadata,
-                modifiedInput: decision.modifiedContent as InputGuardrailResult["modifiedInput"],
-              };
-            }
-            // Malformed: action is "modify" but no modifiedContent provided.
-            // Fail closed to prevent bypassing guardrail transformations.
+        // No decision — allow by default.
+        if (!decision) {
+          return { pass: true, action: "allow" };
+        }
+
+        // Explicit action is authoritative when present.
+        if (decision.action !== undefined) {
+          if (decision.action === "block") {
             return {
               pass: false,
               action: "block",
-              message: decision?.message ?? `Provider "${provider.name}" returned action "modify" without modifiedContent`,
-              metadata: decision?.metadata,
+              message: decision.message,
+              metadata: decision.metadata,
             };
           }
+          if (decision.action === "modify") {
+            if (decision.modifiedContent === undefined) {
+              // Modify without content — fail closed.
+              return {
+                pass: false,
+                action: "block",
+                message: `Provider "${provider.name}" returned action "modify" without modifiedContent — blocking as a safety precaution.`,
+                metadata: decision.metadata,
+              };
+            }
+            return {
+              pass: true,
+              action: "modify",
+              message: decision.message,
+              metadata: decision.metadata,
+              modifiedInput: decision.modifiedContent as InputGuardrailResult["modifiedInput"],
+            };
+          }
+          // action === "allow" — trust the provider.
           return {
             pass: true,
             action: "allow",
-            message: decision?.message,
-            metadata: decision?.metadata,
+            message: decision.message,
+            metadata: decision.metadata,
+          };
+        }
+
+        // No explicit action — fall back to pass boolean.
+        if (decision.pass === false) {
+          return {
+            pass: false,
+            action: "block",
+            message: decision.message,
+            metadata: decision.metadata,
           };
         }
 
         return {
-          pass: false,
-          action: decision.action ?? "block",
+          pass: true,
+          action: "allow",
           message: decision.message,
           metadata: decision.metadata,
         };
@@ -254,38 +277,61 @@ export function createGuardrailsFromProvider(
 
         const decision = await evaluate(outputText, context);
 
-        if (!decision || decision.pass !== false) {
-          const resolvedAction = decision?.action ?? "allow";
-          if (resolvedAction === "modify") {
-            if (decision?.modifiedContent !== undefined) {
-              return {
-                pass: true,
-                action: "modify",
-                message: decision?.message,
-                metadata: decision?.metadata,
-                modifiedOutput: decision.modifiedContent,
-              };
-            }
-            // Malformed: action is "modify" but no modifiedContent provided.
-            // Fail closed to prevent bypassing guardrail transformations.
+        // No decision — allow by default.
+        if (!decision) {
+          return { pass: true, action: "allow" };
+        }
+
+        // Explicit action is authoritative when present.
+        if (decision.action !== undefined) {
+          if (decision.action === "block") {
             return {
               pass: false,
               action: "block",
-              message: decision?.message ?? `Provider "${provider.name}" returned action "modify" without modifiedContent`,
-              metadata: decision?.metadata,
+              message: decision.message,
+              metadata: decision.metadata,
             };
           }
+          if (decision.action === "modify") {
+            if (decision.modifiedContent === undefined) {
+              // Modify without content — fail closed.
+              return {
+                pass: false,
+                action: "block",
+                message: `Provider "${provider.name}" returned action "modify" without modifiedContent — blocking as a safety precaution.`,
+                metadata: decision.metadata,
+              };
+            }
+            return {
+              pass: true,
+              action: "modify",
+              message: decision.message,
+              metadata: decision.metadata,
+              modifiedOutput: decision.modifiedContent,
+            };
+          }
+          // action === "allow" — trust the provider.
           return {
             pass: true,
             action: "allow",
-            message: decision?.message,
-            metadata: decision?.metadata,
+            message: decision.message,
+            metadata: decision.metadata,
+          };
+        }
+
+        // No explicit action — fall back to pass boolean.
+        if (decision.pass === false) {
+          return {
+            pass: false,
+            action: "block",
+            message: decision.message,
+            metadata: decision.metadata,
           };
         }
 
         return {
-          pass: false,
-          action: decision.action ?? "block",
+          pass: true,
+          action: "allow",
           message: decision.message,
           metadata: decision.metadata,
         };

--- a/packages/core/src/agent/guardrail-provider.ts
+++ b/packages/core/src/agent/guardrail-provider.ts
@@ -1,0 +1,299 @@
+/**
+ * GuardrailProvider — A pluggable interface for external guardrail implementations.
+ *
+ * External packages (e.g., AIP, APort) implement this interface to provide
+ * identity verification, trust scoring, content filtering, or any other
+ * guardrail logic. VoltAgent agents can then use any provider without
+ * coupling to a specific implementation.
+ *
+ * @example
+ * ```typescript
+ * import { Agent, createGuardrailsFromProvider } from "@voltagent/core";
+ * import { AIPGuardrailProvider } from "@aip/voltagent-provider";
+ *
+ * const provider = new AIPGuardrailProvider({ trustThreshold: 0.7 });
+ * const { inputGuardrails, outputGuardrails } = createGuardrailsFromProvider(provider);
+ *
+ * const agent = new Agent({
+ *   name: "my-agent",
+ *   inputGuardrails,
+ *   outputGuardrails,
+ * });
+ * ```
+ */
+
+import type {
+  GuardrailAction,
+  GuardrailSeverity,
+  InputGuardrail,
+  InputGuardrailArgs,
+  InputGuardrailResult,
+  OutputGuardrail,
+  OutputGuardrailArgs,
+  OutputGuardrailResult,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Provider types
+// ---------------------------------------------------------------------------
+
+/**
+ * Context passed to a guardrail provider for each evaluation.
+ * Keeps the provider decoupled from VoltAgent internals while giving it
+ * the information it needs.
+ */
+export interface GuardrailProviderContext {
+  /** The name of the agent being guarded. */
+  agentName: string;
+  /** The operation being performed (e.g., "generateText", "streamText"). */
+  operation: string;
+  /** Direction of the guardrail check. */
+  direction: "input" | "output";
+}
+
+/**
+ * The decision returned by a guardrail provider after evaluation.
+ */
+export interface GuardrailProviderDecision {
+  /** Whether the content passes the guardrail check. */
+  pass: boolean;
+  /**
+   * The action to take.
+   * - `"allow"` — let the content through (default when pass is true)
+   * - `"modify"` — replace the content with `modifiedContent`
+   * - `"block"` — reject the content (default when pass is false)
+   */
+  action?: GuardrailAction;
+  /** Human-readable reason for the decision. */
+  message?: string;
+  /**
+   * Replacement content when action is `"modify"`.
+   * For input guardrails this replaces the user input.
+   * For output guardrails this replaces the model output.
+   */
+  modifiedContent?: unknown;
+  /** Arbitrary metadata attached to the guardrail span for observability. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Abstract interface that external guardrail packages implement.
+ *
+ * At minimum a provider must implement {@link evaluateInput} or
+ * {@link evaluateOutput} (or both). Methods that are not implemented
+ * are skipped — no guardrail is created for that direction.
+ *
+ * The optional {@link name}, {@link description}, {@link severity}, and
+ * {@link tags} properties control how the guardrail appears in
+ * observability traces.
+ */
+export interface GuardrailProvider {
+  /** Display name for this provider (used in traces and logs). */
+  readonly name: string;
+
+  /** Optional human-readable description. */
+  readonly description?: string;
+
+  /** Severity level used when the guardrail blocks content. */
+  readonly severity?: GuardrailSeverity;
+
+  /** Tags for filtering and categorization in traces. */
+  readonly tags?: string[];
+
+  /**
+   * Evaluate input content before it reaches the model.
+   * Return `undefined` or `{ pass: true }` to allow the input through.
+   */
+  evaluateInput?(
+    content: string,
+    context: GuardrailProviderContext,
+  ): Promise<GuardrailProviderDecision> | GuardrailProviderDecision;
+
+  /**
+   * Evaluate output content before it is returned to the caller.
+   * Return `undefined` or `{ pass: true }` to allow the output through.
+   */
+  evaluateOutput?(
+    content: string,
+    context: GuardrailProviderContext,
+  ): Promise<GuardrailProviderDecision> | GuardrailProviderDecision;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link createGuardrailsFromProvider}.
+ */
+export interface CreateGuardrailsFromProviderOptions {
+  /**
+   * Override the provider's default severity for the generated guardrails.
+   */
+  severity?: GuardrailSeverity;
+  /**
+   * Additional tags merged with the provider's own tags.
+   */
+  tags?: string[];
+  /**
+   * Optional unique id for the generated guardrail definitions.
+   * Defaults to a slug derived from the provider name.
+   */
+  id?: string;
+}
+
+/**
+ * Convert a {@link GuardrailProvider} into VoltAgent-native guardrail arrays
+ * that can be passed directly to an Agent constructor or per-call options.
+ *
+ * Only directions that the provider implements are included. If the provider
+ * implements neither `evaluateInput` nor `evaluateOutput`, both arrays will
+ * be empty.
+ *
+ * @example
+ * ```typescript
+ * const { inputGuardrails, outputGuardrails } = createGuardrailsFromProvider(myProvider);
+ *
+ * const agent = new Agent({
+ *   name: "guarded-agent",
+ *   inputGuardrails,
+ *   outputGuardrails,
+ * });
+ * ```
+ */
+export function createGuardrailsFromProvider(
+  provider: GuardrailProvider,
+  options?: CreateGuardrailsFromProviderOptions,
+): {
+  inputGuardrails: InputGuardrail[];
+  outputGuardrails: OutputGuardrail[];
+} {
+  const id = options?.id ?? slugify(provider.name);
+  const severity = options?.severity ?? provider.severity;
+  const tags = mergeTags(provider.tags, options?.tags);
+
+  const inputGuardrails: InputGuardrail[] = [];
+  const outputGuardrails: OutputGuardrail[] = [];
+
+  if (provider.evaluateInput) {
+    const evaluate = provider.evaluateInput.bind(provider);
+
+    const inputGuardrail: InputGuardrail = {
+      id: `${id}-input`,
+      name: `${provider.name} (input)`,
+      description: provider.description,
+      severity,
+      tags,
+      handler: async (args: InputGuardrailArgs): Promise<InputGuardrailResult> => {
+        const context: GuardrailProviderContext = {
+          agentName: args.agent.name,
+          operation: args.operation,
+          direction: "input",
+        };
+
+        const decision = await evaluate(args.inputText, context);
+
+        if (!decision || decision.pass !== false) {
+          const resolvedAction = decision?.action ?? "allow";
+          if (resolvedAction === "modify" && decision?.modifiedContent !== undefined) {
+            return {
+              pass: true,
+              action: "modify",
+              message: decision?.message,
+              metadata: decision?.metadata,
+              modifiedInput: decision.modifiedContent as InputGuardrailResult["modifiedInput"],
+            };
+          }
+          return {
+            pass: true,
+            action: "allow",
+            message: decision?.message,
+            metadata: decision?.metadata,
+          };
+        }
+
+        return {
+          pass: false,
+          action: decision.action ?? "block",
+          message: decision.message,
+          metadata: decision.metadata,
+        };
+      },
+    };
+
+    inputGuardrails.push(inputGuardrail);
+  }
+
+  if (provider.evaluateOutput) {
+    const evaluate = provider.evaluateOutput.bind(provider);
+
+    const outputGuardrail: OutputGuardrail = {
+      id: `${id}-output`,
+      name: `${provider.name} (output)`,
+      description: provider.description,
+      severity,
+      tags,
+      handler: async (args: OutputGuardrailArgs): Promise<OutputGuardrailResult> => {
+        const outputText = args.outputText ?? "";
+        const context: GuardrailProviderContext = {
+          agentName: args.agent.name,
+          operation: args.operation,
+          direction: "output",
+        };
+
+        const decision = await evaluate(outputText, context);
+
+        if (!decision || decision.pass !== false) {
+          const resolvedAction = decision?.action ?? "allow";
+          if (resolvedAction === "modify" && decision?.modifiedContent !== undefined) {
+            return {
+              pass: true,
+              action: "modify",
+              message: decision?.message,
+              metadata: decision?.metadata,
+              modifiedOutput: decision.modifiedContent,
+            };
+          }
+          return {
+            pass: true,
+            action: "allow",
+            message: decision?.message,
+            metadata: decision?.metadata,
+          };
+        }
+
+        return {
+          pass: false,
+          action: decision.action ?? "block",
+          message: decision.message,
+          metadata: decision.metadata,
+        };
+      },
+    };
+
+    outputGuardrails.push(outputGuardrail);
+  }
+
+  return { inputGuardrails, outputGuardrails };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function mergeTags(
+  providerTags?: string[],
+  optionTags?: string[],
+): string[] | undefined {
+  if (!providerTags?.length && !optionTags?.length) {
+    return undefined;
+  }
+  return [...(providerTags ?? []), ...(optionTags ?? [])];
+}

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -46,4 +46,11 @@ export {
   createDefaultSafetyGuardrails,
 } from "./guardrails/defaults";
 export { createInputGuardrail, createOutputGuardrail } from "./guardrail";
+export { createGuardrailsFromProvider } from "./guardrail-provider";
+export type {
+  GuardrailProvider,
+  GuardrailProviderContext,
+  GuardrailProviderDecision,
+  CreateGuardrailsFromProviderOptions,
+} from "./guardrail-provider";
 export { createInputMiddleware, createOutputMiddleware } from "./middleware";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,13 @@ export {
   createDefaultSafetyGuardrails,
 } from "./agent/guardrails/defaults";
 export { createInputGuardrail, createOutputGuardrail } from "./agent/guardrail";
+export { createGuardrailsFromProvider } from "./agent/guardrail-provider";
+export type {
+  GuardrailProvider,
+  GuardrailProviderContext,
+  GuardrailProviderDecision,
+  CreateGuardrailsFromProviderOptions,
+} from "./agent/guardrail-provider";
 export { createInputMiddleware, createOutputMiddleware } from "./agent/middleware";
 export type {
   CreateInputGuardrailOptions,


### PR DESCRIPTION
## Summary

Adds a **provider-agnostic `GuardrailProvider` interface** that external packages can implement to provide guardrail logic — identity verification, content filtering, trust scoring, or any custom check — without coupling to VoltAgent internals.

This addresses [#1166](https://github.com/VoltAgent/voltagent/issues/1166) by enabling a clean plugin model where:
- Users can implement their own guardrail provider
- External implementations (AIP, APort, etc.) plug in via the same interface
- Skipping guardrails entirely works exactly as before — zero breaking changes

## What's Added

### `GuardrailProvider` interface

```typescript
interface GuardrailProvider {
  readonly name: string;
  readonly description?: string;
  readonly severity?: GuardrailSeverity;
  readonly tags?: string[];

  evaluateInput?(content: string, context: GuardrailProviderContext): Promise<GuardrailProviderDecision> | GuardrailProviderDecision;
  evaluateOutput?(content: string, context: GuardrailProviderContext): Promise<GuardrailProviderDecision> | GuardrailProviderDecision;
}
```

Providers implement `evaluateInput`, `evaluateOutput`, or both. Each returns a decision: `allow`, `modify` (with replacement content), or `block`.

### `createGuardrailsFromProvider()` factory

Converts any `GuardrailProvider` into standard VoltAgent `InputGuardrail[]` / `OutputGuardrail[]` arrays:

```typescript
import { Agent, createGuardrailsFromProvider } from "@voltagent/core";

const provider = new MyGuardrailProvider();
const { inputGuardrails, outputGuardrails } = createGuardrailsFromProvider(provider);

const agent = new Agent({
  name: "guarded-agent",
  inputGuardrails,
  outputGuardrails,
});
```

Multiple providers can be combined by spreading their guardrail arrays together.

### Custom provider example

```typescript
import { GuardrailProvider } from "@voltagent/core";

class ContentFilterProvider implements GuardrailProvider {
  readonly name = "Content Filter";
  readonly severity = "critical" as const;

  async evaluateInput(content: string) {
    if (containsPII(content)) {
      return { pass: false, message: "Input contains PII" };
    }
    return { pass: true };
  }

  async evaluateOutput(content: string) {
    return {
      pass: true,
      action: "modify" as const,
      modifiedContent: redactSensitiveData(content),
    };
  }
}
```

## Design Decisions

1. **Adapter pattern, not new pipeline.** Providers produce standard `InputGuardrail`/`OutputGuardrail` arrays via the factory. No changes to the existing guardrail execution pipeline — `resolveGuardrailSets`, `runInputGuardrails`, and `runOutputGuardrails` work unchanged.

2. **Text-based evaluation surface.** Providers receive plain text (extracted from whatever message format is in use). This keeps the provider interface simple and framework-agnostic while covering the common case.

3. **Sync or async.** Provider methods can return decisions synchronously or as promises — the factory handles both.

4. **Observable by default.** Provider name, description, severity, and tags flow through to OpenTelemetry spans. Decision metadata is attached to guardrail result metadata.

## Tests

19 tests covering:
- Empty provider (no methods implemented)
- Input-only, output-only, and both-direction providers
- Allow, block, and modify decisions
- Context passing (agent name, operation, direction)
- Metadata preservation
- Synchronous providers
- Combining multiple providers
- Options overrides (custom id, severity, additional tags)

## Files Changed

| File | Change |
|------|--------|
| `packages/core/src/agent/guardrail-provider.ts` | New — interface + factory |
| `packages/core/src/agent/guardrail-provider.spec.ts` | New — 19 tests |
| `packages/core/src/agent/index.ts` | Export new types + factory |
| `packages/core/src/index.ts` | Re-export from package root |

## Breaking Changes

None. This is purely additive. Existing guardrail configuration continues to work exactly as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-agnostic `GuardrailProvider` and a `createGuardrailsFromProvider()` factory to plug external guardrail logic into the existing pipeline. Adds safety fixes (authoritative action, fail-closed modify, collision-safe IDs); fully opt-in and non-breaking. Addresses #1166.

- New Features
  - `GuardrailProvider` with optional `evaluateInput`/`evaluateOutput`; decisions support allow/modify/block with message and metadata; methods may return `undefined`.
  - `createGuardrailsFromProvider()` returns standard Input/Output guardrail arrays; supports `id`, `severity`, `tags`; providers can be combined; works sync or async.
  - Exported types and factory from `@voltagent/core`; 28 tests cover directions, actions, context/metadata, overrides, and edge cases.

- Bug Fixes
  - Explicit `action` is authoritative (block overrides pass:true; allow overrides pass:false).
  - Modify decisions without `modifiedContent` now block (fail-closed) with a clear default message.
  - Collision-safe IDs when provider name slug is empty; handles empty `outputText`; align return types to include `undefined`.

<sup>Written for commit 54cb6d1273ca59b23bc2e7a311488143bd3feeb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pluggable guardrail provider system that generates input and output guardrails, supports allow/block/modify decisions (with fail-closed on malformed modifies), preserves provider metadata, and lets options override/merge severity, tags, and IDs.

* **Tests**
  * Added comprehensive tests covering guardrail generation, handler behavior (allow/block/modify and fail-closed cases), metadata merging, ID fallbacks, and multi-provider composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->