### PR TITLE
fix(core): forward providerMetadata on tool-result stream chunks

### DIFF
--- a/.changeset/fix-tool-output-provider-metadata.md
+++ b/.changeset/fix-tool-output-provider-metadata.md
@@ -1,0 +1,14 @@
+---
+"@voltagent/core": patch
+---
+
+fix(core): forward providerMetadata on tool-result and tool-error stream chunks
+
+Google Vertex thinking models attach `providerMetadata` (containing `thoughtSignature`) to
+tool-output stream events. The `tool-result` → `tool-output-available` and `tool-error` →
+`tool-output-error` conversions in `convertFullStreamChunkToUIMessageStream` were not forwarding
+this field, causing the AI SDK's UI message stream schema validation to reject the chunk as
+having unrecognized keys. This broke all tool calls when using `@ai-sdk/google-vertex` with
+thinking models (e.g. `gemini-3-flash-preview`).
+
+Fixes #1195

--- a/packages/core/src/agent/streaming/guardrail-stream.spec.ts
+++ b/packages/core/src/agent/streaming/guardrail-stream.spec.ts
@@ -402,4 +402,110 @@ describe("Output guardrail streaming integration", () => {
     }
     expect(collected.join("")).toBe("hello");
   });
+
+  it("preserves providerMetadata on tool-result events (Google Vertex thinking models)", async () => {
+    const googleThoughtSignature = "CiQBjz1rXwFvT1I/B/3qqqGc2FdAgzW+FJY4Tg/zPaWUtF6imFw=";
+    const parts: VoltAgentTextStreamPart[] = [
+      { type: "start" } as VoltAgentTextStreamPart,
+      {
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "getWeather",
+        input: { location: "Perth" },
+        providerMetadata: { google: { thoughtSignature: googleThoughtSignature } },
+      } as VoltAgentTextStreamPart,
+      {
+        type: "tool-result",
+        toolCallId: "tool-1",
+        output: { weather: { location: "Perth", condition: "Sunny", temperature: 25 } },
+        providerMetadata: { google: { thoughtSignature: googleThoughtSignature } },
+      } as VoltAgentTextStreamPart,
+      { type: "text-start", id: "text-1" } as VoltAgentTextStreamPart,
+      { type: "text-delta", id: "text-1", delta: "The weather is sunny." } as any,
+      { type: "text-end", id: "text-1" } as VoltAgentTextStreamPart,
+      { type: "finish", finishReason: "stop" } as any,
+    ];
+
+    const pipeline = buildPipeline(parts, {
+      id: "passthrough",
+      name: "Passthrough",
+      handler: async (_ctx) => ({ pass: true }) as const,
+      streamHandler: ({ part }) => part,
+    });
+
+    const emitted: VoltAgentTextStreamPart[] = [];
+    for await (const chunk of pipeline.fullStream) {
+      emitted.push(chunk as VoltAgentTextStreamPart);
+    }
+
+    await pipeline.finalizePromise;
+
+    // tool-call should preserve providerMetadata
+    const toolCall = emitted.find((c) => c.type === "tool-call") as any;
+    expect(toolCall).toBeDefined();
+    expect(toolCall.providerMetadata).toEqual({
+      google: { thoughtSignature: googleThoughtSignature },
+    });
+
+    // tool-result should preserve providerMetadata (the fix for #1195)
+    const toolResult = emitted.find((c) => c.type === "tool-result") as any;
+    expect(toolResult).toBeDefined();
+    expect(toolResult.providerMetadata).toEqual({
+      google: { thoughtSignature: googleThoughtSignature },
+    });
+  });
+
+  it("forwards providerMetadata to tool-output-available in UI stream (fixes #1195)", async () => {
+    const googleThoughtSignature = "CiQBjz1rXwFvT1I/B/3qqqGc2FdAgzW+FJY4Tg/zPaWUtF6imFw=";
+    const parts: VoltAgentTextStreamPart[] = [
+      { type: "start" } as VoltAgentTextStreamPart,
+      {
+        type: "tool-call",
+        toolCallId: "tool-1",
+        toolName: "getWeather",
+        input: { location: "Perth" },
+        providerMetadata: { google: { thoughtSignature: googleThoughtSignature } },
+      } as VoltAgentTextStreamPart,
+      {
+        type: "tool-result",
+        toolCallId: "tool-1",
+        output: { weather: { location: "Perth", condition: "Sunny", temperature: 25 } },
+        providerMetadata: { google: { thoughtSignature: googleThoughtSignature } },
+      } as VoltAgentTextStreamPart,
+      { type: "text-start", id: "text-1" } as VoltAgentTextStreamPart,
+      { type: "text-delta", id: "text-1", delta: "The weather is sunny." } as any,
+      { type: "text-end", id: "text-1" } as VoltAgentTextStreamPart,
+      { type: "finish", finishReason: "stop" } as any,
+    ];
+
+    const pipeline = buildPipeline(parts, {
+      id: "passthrough",
+      name: "Passthrough",
+      handler: async (_ctx) => ({ pass: true }) as const,
+      streamHandler: ({ part }) => part,
+    });
+
+    const uiStream = pipeline.createUIStream();
+    const uiChunks: Array<Record<string, unknown>> = [];
+    for await (const chunk of uiStream) {
+      uiChunks.push(chunk as Record<string, unknown>);
+    }
+
+    await pipeline.finalizePromise;
+
+    // tool-input-available (from tool-call) should have providerMetadata
+    const toolInput = uiChunks.find((c) => c.type === "tool-input-available") as any;
+    expect(toolInput).toBeDefined();
+    expect(toolInput.providerMetadata).toEqual({
+      google: { thoughtSignature: googleThoughtSignature },
+    });
+
+    // tool-output-available (from tool-result) should have providerMetadata
+    // Before the fix, this was missing and caused zod schema validation to fail
+    const toolOutput = uiChunks.find((c) => c.type === "tool-output-available") as any;
+    expect(toolOutput).toBeDefined();
+    expect(toolOutput.providerMetadata).toEqual({
+      google: { thoughtSignature: googleThoughtSignature },
+    });
+  });
 });

--- a/packages/core/src/agent/streaming/guardrail-stream.ts
+++ b/packages/core/src/agent/streaming/guardrail-stream.ts
@@ -573,6 +573,7 @@ function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMessage>({
         toolCallId?: string;
         output?: unknown;
         providerExecuted?: boolean;
+        providerMetadata?: unknown;
         dynamic?: unknown;
       };
       return {
@@ -580,6 +581,7 @@ function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMessage>({
         toolCallId: typed.toolCallId,
         output: typed.output,
         ...(typed.providerExecuted != null ? { providerExecuted: typed.providerExecuted } : {}),
+        ...(typed.providerMetadata != null ? { providerMetadata: typed.providerMetadata } : {}),
         ...(typed.dynamic != null ? { dynamic: typed.dynamic } : {}),
       } as InferUIMessageChunk<UI_MESSAGE>;
     }
@@ -589,6 +591,7 @@ function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMessage>({
         toolCallId?: string;
         error?: unknown;
         providerExecuted?: boolean;
+        providerMetadata?: unknown;
         dynamic?: unknown;
       };
       return {
@@ -596,16 +599,18 @@ function convertFullStreamChunkToUIMessageStream<UI_MESSAGE extends UIMessage>({
         toolCallId: typed.toolCallId,
         errorText: onError(typed.error),
         ...(typed.providerExecuted != null ? { providerExecuted: typed.providerExecuted } : {}),
+        ...(typed.providerMetadata != null ? { providerMetadata: typed.providerMetadata } : {}),
         ...(typed.dynamic != null ? { dynamic: typed.dynamic } : {}),
       } as InferUIMessageChunk<UI_MESSAGE>;
     }
 
     case "tool-output": {
-      const typed = part as { toolCallId?: string; output: unknown };
+      const typed = part as { toolCallId?: string; output: unknown; providerMetadata?: unknown };
       return {
         type: "tool-output-available",
         toolCallId: typed.toolCallId,
         output: typed.output,
+        ...(typed.providerMetadata != null ? { providerMetadata: typed.providerMetadata } : {}),
       } as InferUIMessageChunk<UI_MESSAGE>;
     }
 


### PR DESCRIPTION
## Summary

Fixes #1195 — Tool calls do not work with Google Vertex thinking models due to a zod schema mismatch.

Google Vertex thinking models (e.g. `gemini-3-flash-preview`) attach `providerMetadata` containing `thoughtSignature` to tool-output stream events. The `tool-result` → `tool-output-available` and `tool-error` → `tool-output-error` conversions in `convertFullStreamChunkToUIMessageStream` were not forwarding this field, causing the AI SDK's UI message stream schema validation to reject the chunk with `unrecognized_keys` errors.

The fix adds `providerMetadata` forwarding to three cases (`tool-result`, `tool-error`, `tool-output`), matching the pattern already used by `tool-call`, `text-*`, `reasoning-*`, and `source-*` chunk types.

## Changes

| File | What |
|---|---|
| `packages/core/src/agent/streaming/guardrail-stream.ts` | Forward `providerMetadata` in `tool-result`, `tool-error`, and `tool-output` cases |
| `packages/core/src/agent/streaming/guardrail-stream.spec.ts` | 2 regression tests: fullStream passthrough + UI stream conversion |
| `.changeset/fix-tool-output-provider-metadata.md` | Patch changeset for `@voltagent/core` |

## Root cause

In `convertFullStreamChunkToUIMessageStream`, the `tool-call` case correctly forwards `providerMetadata`:

```typescript
case "tool-call": {
  const typed = part as {
    // ...
    providerMetadata?: unknown;  // ✅ included
  };
  return {
    // ...
    ...(typed.providerMetadata != null ? { providerMetadata: typed.providerMetadata } : {}),  // ✅ forwarded
  };
}
```

But `tool-result` did not:

```typescript
case "tool-result": {
  const typed = part as {
    // ...
    // ❌ providerMetadata was missing from the type assertion
  };
  return {
    // ...
    // ❌ providerMetadata was not forwarded
  };
}
```

When the AI SDK's `createUIMessageStream` received a `tool-output-available` chunk containing the unexpected `providerMetadata` key from Google's thinking model, zod's strict schema validation rejected it entirely, crashing the stream.

## Test plan

- [x] 2 new regression tests added
  - `preserves providerMetadata on tool-result events (Google Vertex thinking models)` — validates fullStream passthrough
  - `forwards providerMetadata to tool-output-available in UI stream (fixes #1195)` — validates the UI stream conversion that was failing
- [x] All 7 guardrail-stream tests pass
- [x] Biome lint clean
- [x] Changeset included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards `providerMetadata` on `tool-result`, `tool-error`, and `tool-output` stream chunks to fix schema errors with Google Vertex thinking models. Restores tool calls and UI stream validation when using `@ai-sdk/google-vertex` (fixes #1195).

- **Bug Fixes**
  - Carry `providerMetadata` through `convertFullStreamChunkToUIMessageStream` for `tool-result` → `tool-output-available`, `tool-error` → `tool-output-error`, and `tool-output`.
  - Add two regression tests (full stream passthrough and UI stream conversion).
  - Include a patch changeset for `@voltagent/core`.

<sup>Written for commit 6c202167d53b6d6ef8ad1e998315fa840c748f0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider metadata preservation during tool event stream conversions, resolving schema validation failures for Vertex thinking models. The metadata, including thoughtSignature, is now correctly maintained throughout the streaming pipeline.

* **Tests**
  * Added integration tests verifying provider metadata is properly propagated for tool events in the streaming pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->