### PR TITLE
fix(auth): require explicit NODE_ENV=development for dev auth bypass

### DIFF
--- a/.changeset/fix-dev-auth-bypass-node-env.md
+++ b/.changeset/fix-dev-auth-bypass-node-env.md
@@ -1,0 +1,12 @@
+---
+"@voltagent/server-core": patch
+---
+
+fix(auth): require explicit NODE_ENV=development for dev auth bypass
+
+Previously, `isDevRequest()` treated any non-production `NODE_ENV` (including
+`undefined`) as a development environment, allowing auth bypass with a simple
+header. Deployments that forgot to set `NODE_ENV=production` were fully open.
+
+Now only `NODE_ENV=development` or `NODE_ENV=test` enable the dev bypass
+(fail-closed). Undefined/empty `NODE_ENV` is treated as production.

--- a/packages/server-core/src/auth/utils.spec.ts
+++ b/packages/server-core/src/auth/utils.spec.ts
@@ -25,6 +25,44 @@ describe("auth utils", () => {
       expect(isDevRequest(req)).toBe(true);
     });
 
+    it("rejects the dev header when NODE_ENV is undefined (fail-closed)", () => {
+      vi.stubEnv("NODE_ENV", "");
+
+      const req = new Request("http://localhost/api", {
+        headers: { "x-voltagent-dev": "true" },
+      });
+
+      expect(isDevRequest(req)).toBe(false);
+    });
+
+    it("rejects the dev query param when NODE_ENV is undefined", () => {
+      vi.stubEnv("NODE_ENV", "");
+
+      const req = new Request("http://localhost/ws?dev=true");
+
+      expect(isDevRequest(req)).toBe(false);
+    });
+
+    it("accepts the dev header in test environment", () => {
+      vi.stubEnv("NODE_ENV", "test");
+
+      const req = new Request("http://localhost/api", {
+        headers: { "x-voltagent-dev": "true" },
+      });
+
+      expect(isDevRequest(req)).toBe(true);
+    });
+
+    it("rejects the dev header in production", () => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      const req = new Request("http://localhost/api", {
+        headers: { "x-voltagent-dev": "true" },
+      });
+
+      expect(isDevRequest(req)).toBe(false);
+    });
+
     it("rejects the dev query param in production", () => {
       vi.stubEnv("NODE_ENV", "production");
 

--- a/packages/server-core/src/auth/utils.spec.ts
+++ b/packages/server-core/src/auth/utils.spec.ts
@@ -1,9 +1,31 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { hasConsoleAccess, isDevRequest } from "./utils";
+import { hasConsoleAccess, isDevEnvironment, isDevRequest } from "./utils";
 
 describe("auth utils", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  describe("isDevEnvironment", () => {
+    it("returns true for development", () => {
+      vi.stubEnv("NODE_ENV", "development");
+      expect(isDevEnvironment()).toBe(true);
+    });
+
+    it("returns true for test", () => {
+      vi.stubEnv("NODE_ENV", "test");
+      expect(isDevEnvironment()).toBe(true);
+    });
+
+    it("returns false for production", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      expect(isDevEnvironment()).toBe(false);
+    });
+
+    it("returns false for empty string (fail-closed)", () => {
+      vi.stubEnv("NODE_ENV", "");
+      expect(isDevEnvironment()).toBe(false);
+    });
   });
 
   describe("isDevRequest", () => {
@@ -25,7 +47,7 @@ describe("auth utils", () => {
       expect(isDevRequest(req)).toBe(true);
     });
 
-    it("rejects the dev header when NODE_ENV is undefined (fail-closed)", () => {
+    it("rejects the dev header when NODE_ENV is empty (fail-closed)", () => {
       vi.stubEnv("NODE_ENV", "");
 
       const req = new Request("http://localhost/api", {
@@ -35,7 +57,7 @@ describe("auth utils", () => {
       expect(isDevRequest(req)).toBe(false);
     });
 
-    it("rejects the dev query param when NODE_ENV is undefined", () => {
+    it("rejects the dev query param when NODE_ENV is empty", () => {
       vi.stubEnv("NODE_ENV", "");
 
       const req = new Request("http://localhost/ws?dev=true");

--- a/packages/server-core/src/auth/utils.spec.ts
+++ b/packages/server-core/src/auth/utils.spec.ts
@@ -26,6 +26,11 @@ describe("auth utils", () => {
       vi.stubEnv("NODE_ENV", "");
       expect(isDevEnvironment()).toBe(false);
     });
+
+    it("returns false when NODE_ENV is undefined (fail-closed)", () => {
+      vi.stubEnv("NODE_ENV", undefined as unknown as string);
+      expect(isDevEnvironment()).toBe(false);
+    });
   });
 
   describe("isDevRequest", () => {
@@ -59,6 +64,24 @@ describe("auth utils", () => {
 
     it("rejects the dev query param when NODE_ENV is empty", () => {
       vi.stubEnv("NODE_ENV", "");
+
+      const req = new Request("http://localhost/ws?dev=true");
+
+      expect(isDevRequest(req)).toBe(false);
+    });
+
+    it("rejects the dev header when NODE_ENV is undefined (fail-closed)", () => {
+      vi.stubEnv("NODE_ENV", undefined as unknown as string);
+
+      const req = new Request("http://localhost/api", {
+        headers: { "x-voltagent-dev": "true" },
+      });
+
+      expect(isDevRequest(req)).toBe(false);
+    });
+
+    it("rejects the dev query param when NODE_ENV is undefined", () => {
+      vi.stubEnv("NODE_ENV", undefined as unknown as string);
 
       const req = new Request("http://localhost/ws?dev=true");
 

--- a/packages/server-core/src/auth/utils.ts
+++ b/packages/server-core/src/auth/utils.ts
@@ -5,34 +5,38 @@
 /**
  * Check if request is from development environment
  *
- * Requires BOTH client header AND non-production environment for security.
- * This prevents production bypass while allowing local development.
+ * Requires BOTH a client header AND an explicit dev/test environment for security.
+ * Undefined NODE_ENV is treated as production (fail-closed) to prevent
+ * accidental auth bypass on deployed servers that forgot to set NODE_ENV.
  *
  * @param req - The incoming HTTP request
  * @returns True if both dev header and non-production environment are present
  *
  * @example
- * // Local development with header (typical case)
- * NODE_ENV=undefined + x-voltagent-dev=true → true (auth bypassed)
- *
- * // Development with header (playground)
+ * // Development with header (typical case)
  * NODE_ENV=development + x-voltagent-dev=true → true (auth bypassed)
  *
- * // Development without header (testing auth)
- * NODE_ENV=undefined + no header → false (auth required)
+ * // Test with header
+ * NODE_ENV=test + x-voltagent-dev=true → true (auth bypassed)
+ *
+ * // Undefined NODE_ENV with header (deployed server)
+ * NODE_ENV=undefined + x-voltagent-dev=true → false (auth required)
  *
  * // Production with header (attacker attempt)
  * NODE_ENV=production + x-voltagent-dev=true → false (auth required)
  *
  * @security
- * - Client header alone: Cannot bypass in production
- * - Non-production env alone: Developer can still test auth
+ * - Client header alone: Cannot bypass auth
+ * - Dev/test env alone: Developer can still test auth
  * - Both required: Selective bypass for DX
- * - Production is strictly protected (NODE_ENV=production)
+ * - Only NODE_ENV=development|test enables dev bypass (fail-closed)
  */
 export function isDevRequest(req: Request): boolean {
-  // Treat undefined/empty NODE_ENV as development (only production is strict)
-  const isDevEnv = process.env.NODE_ENV !== "production";
+  // Only treat explicitly-set development/test as dev environment.
+  // Undefined/empty NODE_ENV is NOT treated as dev — fail-closed prevents
+  // accidental auth bypass on deployments that forget to set NODE_ENV.
+  const isDevEnv =
+    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
   if (!isDevEnv) {
     return false;
   }

--- a/packages/server-core/src/auth/utils.ts
+++ b/packages/server-core/src/auth/utils.ts
@@ -3,6 +3,17 @@
  */
 
 /**
+ * Check if the current process is running in an explicit dev/test environment.
+ * Undefined/empty NODE_ENV is treated as production (fail-closed) to prevent
+ * accidental auth bypass on deployments that forget to set NODE_ENV.
+ */
+export function isDevEnvironment(): boolean {
+  return (
+    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
+  );
+}
+
+/**
  * Check if request is from development environment
  *
  * Requires BOTH a client header AND an explicit dev/test environment for security.
@@ -32,11 +43,7 @@
  * - Only NODE_ENV=development|test enables dev bypass (fail-closed)
  */
 export function isDevRequest(req: Request): boolean {
-  // Only treat explicitly-set development/test as dev environment.
-  // Undefined/empty NODE_ENV is NOT treated as dev — fail-closed prevents
-  // accidental auth bypass on deployments that forget to set NODE_ENV.
-  const isDevEnv =
-    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+  const isDevEnv = isDevEnvironment();
   if (!isDevEnv) {
     return false;
   }

--- a/packages/server-core/src/websocket/setup.ts
+++ b/packages/server-core/src/websocket/setup.ts
@@ -12,6 +12,7 @@ import { requiresAuth } from "../auth/defaults";
 import type { AuthNextConfig } from "../auth/next";
 import { isAuthNextConfig, normalizeAuthNextConfig, resolveAuthNextAccess } from "../auth/next";
 import type { AuthProvider } from "../auth/types";
+import { isDevEnvironment } from "../auth/utils";
 import { handleWebSocketConnection } from "./handlers";
 
 /**
@@ -19,7 +20,7 @@ import { handleWebSocketConnection } from "./handlers";
  */
 function isDevWebSocketRequest(req: IncomingMessage): boolean {
   const hasDevHeader = req.headers["x-voltagent-dev"] === "true";
-  const isDevEnv = process.env.NODE_ENV !== "production";
+  const isDevEnv = isDevEnvironment();
   return hasDevHeader && isDevEnv;
 }
 
@@ -29,7 +30,7 @@ function isWebSocketDevBypass(req: IncomingMessage, url: URL): boolean {
   }
 
   const devParam = url.searchParams.get("dev");
-  return devParam === "true" && process.env.NODE_ENV !== "production";
+  return devParam === "true" && isDevEnvironment();
 }
 
 /**


### PR DESCRIPTION
## Bug

`isDevRequest()` treats any non-production `NODE_ENV` (including `undefined`) as a dev environment, allowing full auth bypass with a simple `x-voltagent-dev: true` header. Deployed servers that forget to set `NODE_ENV=production` are fully open to unauthenticated access.

Closes #1206

## Changes

- **`isDevRequest()`**: Only `NODE_ENV=development` or `NODE_ENV=test` enable the dev bypass (fail-closed). Undefined/empty `NODE_ENV` is now treated as production.
- Updated JSDoc comments and examples to reflect the new behavior.
- Added 4 test cases covering: undefined NODE_ENV rejection (header + query param), test environment acceptance, and production rejection.

## Before / After

| NODE_ENV | Dev header | Before | After |
|---|---|---|---|
| `undefined` | ✅ | **bypassed** 🔓 | **auth required** 🔒 |
| `""` (empty) | ✅ | **bypassed** 🔓 | **auth required** 🔒 |
| `development` | ✅ | bypassed | bypassed |
| `test` | ✅ | bypassed | bypassed |
| `production` | ✅ | auth required | auth required |

## Testing

- Added tests for undefined/empty NODE_ENV rejection
- Added test for NODE_ENV=test acceptance
- Added test for production header rejection
- All existing tests remain passing (dev header + dev query param in development)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an explicit `NODE_ENV=development` or `NODE_ENV=test` for the dev auth bypass across HTTP and WebSocket paths. Unset/empty `NODE_ENV` now behaves as production (fail-closed) to prevent accidental unauthenticated access.

- **Bug Fixes**
  - Added shared `isDevEnvironment()` and used it in `isDevRequest()` and WebSocket checks; only `development`/`test` enable the bypass.
  - Expanded tests with `isDevEnvironment` unit coverage and cases for unset/empty `NODE_ENV`, test env acceptance, and production rejection.

<sup>Written for commit df18d87701859a5b150ece3f073d679205da2a6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dev authentication bypass now requires NODE_ENV to be explicitly "development" or "test"; unset/empty or other values no longer permit bypass (applies to HTTP and WebSocket dev bypasses).
* **Tests**
  * Added tests validating dev-environment detection and acceptance/rejection of dev bypass across NODE_ENV values.
* **Chores / Documentation**
  * Added a release note/changeset and updated docs to describe the new fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->