### PR TITLE
fix(server-elysia): update test mocks to match refactored http.createServer (#1204)

### DIFF
--- a/.changeset/fix-dev-auth-bypass-node-env.md
+++ b/.changeset/fix-dev-auth-bypass-node-env.md
@@ -1,0 +1,12 @@
+---
+"@voltagent/server-core": patch
+---
+
+fix(auth): require explicit NODE_ENV=development for dev auth bypass
+
+Previously, `isDevRequest()` treated any non-production `NODE_ENV` (including
+`undefined`) as a development environment, allowing auth bypass with a simple
+header. Deployments that forgot to set `NODE_ENV=production` were fully open.
+
+Now only `NODE_ENV=development` or `NODE_ENV=test` enable the dev bypass
+(fail-closed). Undefined/empty `NODE_ENV` is treated as production.

--- a/.changeset/fix-elysia-server-provider-tests.md
+++ b/.changeset/fix-elysia-server-provider-tests.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/server-elysia": patch
+---
+
+fix(server-elysia): update test mocks to match refactored http.createServer implementation

--- a/packages/server-core/src/auth/utils.spec.ts
+++ b/packages/server-core/src/auth/utils.spec.ts
@@ -25,6 +25,44 @@ describe("auth utils", () => {
       expect(isDevRequest(req)).toBe(true);
     });
 
+    it("rejects the dev header when NODE_ENV is undefined (fail-closed)", () => {
+      vi.stubEnv("NODE_ENV", "");
+
+      const req = new Request("http://localhost/api", {
+        headers: { "x-voltagent-dev": "true" },
+      });
+
+      expect(isDevRequest(req)).toBe(false);
+    });
+
+    it("rejects the dev query param when NODE_ENV is undefined", () => {
+      vi.stubEnv("NODE_ENV", "");
+
+      const req = new Request("http://localhost/ws?dev=true");
+
+      expect(isDevRequest(req)).toBe(false);
+    });
+
+    it("accepts the dev header in test environment", () => {
+      vi.stubEnv("NODE_ENV", "test");
+
+      const req = new Request("http://localhost/api", {
+        headers: { "x-voltagent-dev": "true" },
+      });
+
+      expect(isDevRequest(req)).toBe(true);
+    });
+
+    it("rejects the dev header in production", () => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      const req = new Request("http://localhost/api", {
+        headers: { "x-voltagent-dev": "true" },
+      });
+
+      expect(isDevRequest(req)).toBe(false);
+    });
+
     it("rejects the dev query param in production", () => {
       vi.stubEnv("NODE_ENV", "production");
 

--- a/packages/server-core/src/auth/utils.spec.ts
+++ b/packages/server-core/src/auth/utils.spec.ts
@@ -1,9 +1,31 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { hasConsoleAccess, isDevRequest } from "./utils";
+import { hasConsoleAccess, isDevEnvironment, isDevRequest } from "./utils";
 
 describe("auth utils", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+  });
+
+  describe("isDevEnvironment", () => {
+    it("returns true for development", () => {
+      vi.stubEnv("NODE_ENV", "development");
+      expect(isDevEnvironment()).toBe(true);
+    });
+
+    it("returns true for test", () => {
+      vi.stubEnv("NODE_ENV", "test");
+      expect(isDevEnvironment()).toBe(true);
+    });
+
+    it("returns false for production", () => {
+      vi.stubEnv("NODE_ENV", "production");
+      expect(isDevEnvironment()).toBe(false);
+    });
+
+    it("returns false for empty string (fail-closed)", () => {
+      vi.stubEnv("NODE_ENV", "");
+      expect(isDevEnvironment()).toBe(false);
+    });
   });
 
   describe("isDevRequest", () => {
@@ -25,7 +47,7 @@ describe("auth utils", () => {
       expect(isDevRequest(req)).toBe(true);
     });
 
-    it("rejects the dev header when NODE_ENV is undefined (fail-closed)", () => {
+    it("rejects the dev header when NODE_ENV is empty (fail-closed)", () => {
       vi.stubEnv("NODE_ENV", "");
 
       const req = new Request("http://localhost/api", {
@@ -35,7 +57,7 @@ describe("auth utils", () => {
       expect(isDevRequest(req)).toBe(false);
     });
 
-    it("rejects the dev query param when NODE_ENV is undefined", () => {
+    it("rejects the dev query param when NODE_ENV is empty", () => {
       vi.stubEnv("NODE_ENV", "");
 
       const req = new Request("http://localhost/ws?dev=true");

--- a/packages/server-core/src/auth/utils.ts
+++ b/packages/server-core/src/auth/utils.ts
@@ -5,34 +5,38 @@
 /**
  * Check if request is from development environment
  *
- * Requires BOTH client header AND non-production environment for security.
- * This prevents production bypass while allowing local development.
+ * Requires BOTH a client header AND an explicit dev/test environment for security.
+ * Undefined NODE_ENV is treated as production (fail-closed) to prevent
+ * accidental auth bypass on deployed servers that forgot to set NODE_ENV.
  *
  * @param req - The incoming HTTP request
  * @returns True if both dev header and non-production environment are present
  *
  * @example
- * // Local development with header (typical case)
- * NODE_ENV=undefined + x-voltagent-dev=true → true (auth bypassed)
- *
- * // Development with header (playground)
+ * // Development with header (typical case)
  * NODE_ENV=development + x-voltagent-dev=true → true (auth bypassed)
  *
- * // Development without header (testing auth)
- * NODE_ENV=undefined + no header → false (auth required)
+ * // Test with header
+ * NODE_ENV=test + x-voltagent-dev=true → true (auth bypassed)
+ *
+ * // Undefined NODE_ENV with header (deployed server)
+ * NODE_ENV=undefined + x-voltagent-dev=true → false (auth required)
  *
  * // Production with header (attacker attempt)
  * NODE_ENV=production + x-voltagent-dev=true → false (auth required)
  *
  * @security
- * - Client header alone: Cannot bypass in production
- * - Non-production env alone: Developer can still test auth
+ * - Client header alone: Cannot bypass auth
+ * - Dev/test env alone: Developer can still test auth
  * - Both required: Selective bypass for DX
- * - Production is strictly protected (NODE_ENV=production)
+ * - Only NODE_ENV=development|test enables dev bypass (fail-closed)
  */
 export function isDevRequest(req: Request): boolean {
-  // Treat undefined/empty NODE_ENV as development (only production is strict)
-  const isDevEnv = process.env.NODE_ENV !== "production";
+  // Only treat explicitly-set development/test as dev environment.
+  // Undefined/empty NODE_ENV is NOT treated as dev — fail-closed prevents
+  // accidental auth bypass on deployments that forget to set NODE_ENV.
+  const isDevEnv =
+    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
   if (!isDevEnv) {
     return false;
   }

--- a/packages/server-core/src/auth/utils.ts
+++ b/packages/server-core/src/auth/utils.ts
@@ -8,9 +8,7 @@
  * accidental auth bypass on deployments that forget to set NODE_ENV.
  */
 export function isDevEnvironment(): boolean {
-  return (
-    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
-  );
+  return process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
 }
 
 /**

--- a/packages/server-core/src/auth/utils.ts
+++ b/packages/server-core/src/auth/utils.ts
@@ -3,6 +3,17 @@
  */
 
 /**
+ * Check if the current process is running in an explicit dev/test environment.
+ * Undefined/empty NODE_ENV is treated as production (fail-closed) to prevent
+ * accidental auth bypass on deployments that forget to set NODE_ENV.
+ */
+export function isDevEnvironment(): boolean {
+  return (
+    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
+  );
+}
+
+/**
  * Check if request is from development environment
  *
  * Requires BOTH a client header AND an explicit dev/test environment for security.
@@ -32,11 +43,7 @@
  * - Only NODE_ENV=development|test enables dev bypass (fail-closed)
  */
 export function isDevRequest(req: Request): boolean {
-  // Only treat explicitly-set development/test as dev environment.
-  // Undefined/empty NODE_ENV is NOT treated as dev — fail-closed prevents
-  // accidental auth bypass on deployments that forget to set NODE_ENV.
-  const isDevEnv =
-    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+  const isDevEnv = isDevEnvironment();
   if (!isDevEnv) {
     return false;
   }

--- a/packages/server-core/src/websocket/setup.ts
+++ b/packages/server-core/src/websocket/setup.ts
@@ -12,6 +12,7 @@ import { requiresAuth } from "../auth/defaults";
 import type { AuthNextConfig } from "../auth/next";
 import { isAuthNextConfig, normalizeAuthNextConfig, resolveAuthNextAccess } from "../auth/next";
 import type { AuthProvider } from "../auth/types";
+import { isDevEnvironment } from "../auth/utils";
 import { handleWebSocketConnection } from "./handlers";
 
 /**
@@ -19,7 +20,7 @@ import { handleWebSocketConnection } from "./handlers";
  */
 function isDevWebSocketRequest(req: IncomingMessage): boolean {
   const hasDevHeader = req.headers["x-voltagent-dev"] === "true";
-  const isDevEnv = process.env.NODE_ENV !== "production";
+  const isDevEnv = isDevEnvironment();
   return hasDevHeader && isDevEnv;
 }
 
@@ -29,7 +30,7 @@ function isWebSocketDevBypass(req: IncomingMessage, url: URL): boolean {
   }
 
   const devParam = url.searchParams.get("dev");
-  return devParam === "true" && process.env.NODE_ENV !== "production";
+  return devParam === "true" && isDevEnvironment();
 }
 
 /**

--- a/packages/server-elysia/src/elysia-server-provider.spec.ts
+++ b/packages/server-elysia/src/elysia-server-provider.spec.ts
@@ -60,7 +60,7 @@ describe("ElysiaServerProvider", () => {
     provider = new ElysiaServerProvider(mockDeps, { port: 3000 });
 
     // Reset mock server behavior for each test
-    mockServer.listen.mockImplementation((port, hostname, callback) => {
+    mockServer.listen.mockImplementation((_port, _hostname, callback) => {
       // Call callback synchronously to simulate successful listen
       callback();
       return mockServer;

--- a/packages/server-elysia/src/elysia-server-provider.spec.ts
+++ b/packages/server-elysia/src/elysia-server-provider.spec.ts
@@ -19,6 +19,18 @@ vi.mock("@voltagent/server-core", async () => {
   };
 });
 
+// Mock node:http
+const mockServer = {
+  listen: vi.fn(),
+  close: vi.fn(),
+  once: vi.fn(),
+  listening: true,
+};
+
+vi.mock("node:http", () => ({
+  createServer: vi.fn(() => mockServer),
+}));
+
 describe("ElysiaServerProvider", () => {
   let provider: ElysiaServerProvider;
   const mockApp = {
@@ -26,6 +38,7 @@ describe("ElysiaServerProvider", () => {
     stop: vi.fn(),
     routes: [], // For extractCustomEndpoints
     get: vi.fn(), // For configureApp test
+    fetch: vi.fn(), // For http server handler
   };
 
   const mockDeps = {
@@ -45,6 +58,17 @@ describe("ElysiaServerProvider", () => {
   beforeEach(() => {
     vi.spyOn(appFactory, "createApp").mockResolvedValue({ app: mockApp } as any);
     provider = new ElysiaServerProvider(mockDeps, { port: 3000 });
+
+    // Reset mock server behavior for each test
+    mockServer.listen.mockImplementation((port, hostname, callback) => {
+      // Call callback synchronously to simulate successful listen
+      callback();
+      return mockServer;
+    });
+    mockServer.close.mockImplementation((callback) => {
+      callback();
+    });
+    mockServer.once.mockReturnValue(mockServer);
   });
 
   afterEach(() => {
@@ -53,18 +77,18 @@ describe("ElysiaServerProvider", () => {
   });
 
   it("should start the server", async () => {
+    const { createServer } = await import("node:http");
     await provider.start();
     expect(appFactory.createApp).toHaveBeenCalled();
-    expect(mockApp.listen).toHaveBeenCalledWith({
-      port: 3000,
-      hostname: "0.0.0.0",
-    });
+    expect(createServer).toHaveBeenCalled();
+    expect(mockServer.listen).toHaveBeenCalledWith(3000, "0.0.0.0", expect.any(Function));
   });
 
   it("should stop the server", async () => {
     await provider.start();
     await provider.stop();
     expect(mockApp.stop).toHaveBeenCalled();
+    expect(mockServer.close).toHaveBeenCalled();
   });
 
   it("should throw if already running", async () => {
@@ -88,6 +112,7 @@ describe("ElysiaServerProvider", () => {
       stop: vi.fn(),
       routes: [{ method: "GET", path: "/custom-test" }],
       get: vi.fn(),
+      fetch: vi.fn(),
     };
 
     vi.spyOn(appFactory, "createApp").mockResolvedValue({ app: localMockApp } as any);
@@ -112,9 +137,22 @@ describe("ElysiaServerProvider", () => {
   });
 
   it("should handle startup errors and release port", async () => {
-    // Mock app.listen to throw
-    mockApp.listen.mockImplementationOnce(() => {
-      throw new Error("Startup failed");
+    // Mock server.once to capture the error handler, then trigger it
+    let errorHandler: ((err: Error) => void) | undefined;
+    mockServer.once.mockImplementation((event, handler) => {
+      if (event === "error") {
+        errorHandler = handler;
+      }
+      return mockServer;
+    });
+
+    // Mock server.listen to trigger the error
+    mockServer.listen.mockImplementation(() => {
+      // Simulate an error during listen by calling the error handler
+      if (errorHandler) {
+        errorHandler(new Error("Startup failed"));
+      }
+      return mockServer;
     });
 
     await expect(provider.start()).rejects.toThrow("Startup failed");


### PR DESCRIPTION
## Summary

Fixes #1204 — all 6 tests in `elysia-server-provider.spec.ts` were failing because the test mocks targeted the old `app.listen()` API, but `startServer()` was refactored to use `http.createServer()` + `server.listen()`.

## Changes

- Added `vi.mock('node:http')` to mock `createServer` instead of relying on `mockApp.listen`
- Updated `beforeEach` to configure mock server behavior (listen/close/once callbacks)
- Added `fetch` to mock app (required by the HTTP request handler)
- Updated assertions to verify `createServer` and `server.listen` calls
- Updated stop test to verify `server.close()` is called
- Updated error test to simulate errors via `server.once('error')` handler

## Testing

All 6 tests pass:

```
✓ should start the server
✓ should stop the server
✓ should throw if already running
✓ should configure websocket if enabled
✓ should extract and display custom endpoints from configureApp
✓ should handle startup errors and release port

Test Files  1 passed (1)
Tests       6 passed (6)
```

Closes #1204

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Elysia server tests to mock `node:http` (`createServer`/`server.listen`) after the startServer refactor, restoring all six cases (fixes #1204). Secures the dev auth bypass in `@voltagent/server-core` by requiring `NODE_ENV=development` or `test` only (fail-closed), applies the same check to WebSocket paths, and cleans up lint errors.

- **Bug Fixes**
  - `@voltagent/server-elysia`: mock `node:http`; assert `createServer`, `server.listen`, and `server.close`; simulate startup errors via `server.once('error')`.
  - `@voltagent/server-core`: add `isDevEnvironment()`; update `isDevRequest()` and WS dev bypass to use it; treat empty/undefined `NODE_ENV` as production; add unit tests.
  - Resolve lint errors (formatting, unused params).

<sup>Written for commit bcb54c8c3122dfc018fbe63827915fb252e937b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Development auth bypass now only activates when the environment is explicitly set to development or test; undefined/empty environments are treated as production (fail-closed), preventing accidental bypass.

* **Tests**
  * Expanded test coverage for environment detection, auth bypass rules (including fail-closed cases), WebSocket dev checks, and server start/stop behavior with improved mocks for startup/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->