### PR TITLE
fix(serverless-hono): withWaitUntil must not destroy global state when context has no waitUntil

### DIFF
--- a/.changeset/rude-pianos-marry.md
+++ b/.changeset/rude-pianos-marry.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/serverless-hono": patch
+---
+
+fix(serverless-hono): withWaitUntil must not destroy global state when context has no waitUntil

--- a/packages/serverless-hono/src/utils/wait-until-wrapper.ts
+++ b/packages/serverless-hono/src/utils/wait-until-wrapper.ts
@@ -34,20 +34,21 @@ export function withWaitUntil(context?: WaitUntilContext | null): () => void {
 
   if (currentWaitUntil && typeof currentWaitUntil === "function") {
     // Bind to context to avoid "Illegal invocation" errors
-    // And allow errors (like DataCloneError) to propagate so caller can handle fallback
-    globals.___voltagent_wait_until = currentWaitUntil.bind(context);
-  } else {
-    globals.___voltagent_wait_until = undefined;
-  }
-
-  // Return cleanup function
-  return () => {
-    if (currentWaitUntil) {
-      if (previousWaitUntil) {
-        globals.___voltagent_wait_until = previousWaitUntil;
-      } else {
-        globals.___voltagent_wait_until = undefined;
+    // Wrap in try/catch so errors (like DataCloneError) are swallowed and don't break the caller
+    const boundWaitUntil = currentWaitUntil.bind(context);
+    globals.___voltagent_wait_until = (promise: Promise<unknown>) => {
+      try {
+        boundWaitUntil(promise);
+      } catch {
+        // Swallow errors to avoid breaking the caller
       }
-    }
+    };
+  }
+  // No else branch — don't touch global when context has no waitUntil,
+  // to avoid destroying a previously set value from an outer scope
+
+  // Return cleanup function that always restores the previous state
+  return () => {
+    globals.___voltagent_wait_until = previousWaitUntil;
   };
 }


### PR DESCRIPTION
Fixes #1203

## Problem

`withWaitUntil` in `@voltagent/serverless-hono` had two bugs:

1. **Global state destruction**: The `else` branch unconditionally set `globals.___voltagent_wait_until = undefined` whenever `context.waitUntil` was absent. This silently destroyed any value previously set by an outer scope, breaking background tasks (observability, logging) in middleware chains where an inner handler passed `{}` as context.

2. **Error propagation**: Errors thrown by `context.waitUntil` (e.g. `DataCloneError` in Cloudflare Workers) propagated to callers. The test suite expected these to be swallowed, but the implementation let them through.

Additionally, the cleanup function only restored the previous `waitUntil` when `currentWaitUntil` was truthy, meaning cleanup was a no-op when called with a context that had no `waitUntil` — leaving the global state permanently altered.

## Solution

- **Remove the `else` branch entirely**: when `context` has no `waitUntil`, the global is left untouched.
- **Wrap the bound `waitUntil` call in `try/catch`**: errors from the underlying implementation (like `DataCloneError`) are now swallowed so callers are not affected.
- **Simplify the cleanup function**: always restores `previousWaitUntil` unconditionally, regardless of whether `currentWaitUntil` was set.

## Testing

All 11 tests in `wait-until-wrapper.spec.ts` now pass, including the two that previously failed:
- `should handle errors from context.waitUntil gracefully`
- `should not affect global state when context has no waitUntil`

```
✓ should set global waitUntil when context has waitUntil
✓ should not set global waitUntil when context is undefined
✓ should not set global waitUntil when context is null
✓ should not set global waitUntil when context has no waitUntil
✓ should call context.waitUntil when global waitUntil is invoked
✓ should handle errors from context.waitUntil gracefully
✓ should restore previous waitUntil after cleanup
✓ should clear global waitUntil after cleanup when no previous value existed
✓ should handle nested calls with proper state restoration
✓ should not affect global state when context has no waitUntil
✓ should handle context with non-function waitUntil

Test Files  1 passed (1)
      Tests  11 passed (11)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes global waitUntil handling in `@voltagent/serverless-hono`’s `withWaitUntil`. It no longer clears outer global state when a context lacks `waitUntil`, swallows underlying errors, and always restores the previous global value.

- **Bug Fixes**
  - Removed the else branch so the global isn’t reset when `context.waitUntil` is missing.
  - Wrapped the bound `waitUntil` in try/catch to swallow errors (e.g., Cloudflare Workers’ `DataCloneError`).
  - Cleanup now always restores the previous global `waitUntil`.

<sup>Written for commit b91b5d5e4138b633618c5d06d9e70a0eab0cad64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented inadvertent modification of global state when execution context lacks async hooks.
  * Improved resilience by catching and suppressing non-critical errors from async callbacks to avoid cascading failures.
  * Simplified cleanup to more reliably restore prior runtime state after operations complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->