### PR TITLE
feat(core): expose request headers to dynamic agents

### DIFF
--- a/.changeset/expose-request-headers-dynamic-agents.md
+++ b/.changeset/expose-request-headers-dynamic-agents.md
@@ -1,0 +1,43 @@
+---
+"@voltagent/core": patch
+"@voltagent/server-core": patch
+"@voltagent/server-hono": patch
+"@voltagent/server-elysia": patch
+"@voltagent/serverless-hono": patch
+---
+
+feat(agent): expose request headers to dynamic agent configuration
+
+Dynamic `instructions`, `model`, and `tools` functions now receive a `headers` map in
+`DynamicValueOptions` when an agent is called through the built-in HTTP endpoints. This makes it
+possible to configure tenant-aware models and request-scoped tools from headers such as
+`authorization`, `x-tenant-id`, or `x-user-id` without manually copying them into
+`options.context`.
+
+Header names are normalized to lowercase:
+
+```ts
+const agent = new Agent({
+  name: "Tenant Agent",
+  instructions: "You are a tenant-aware assistant.",
+  model: ({ headers }) => {
+    return headers?.["x-tenant-id"] === "enterprise" ? "openai/gpt-4o" : "openai/gpt-4o-mini";
+  },
+  tools: ({ headers }) => {
+    return headers?.authorization ? [createTenantTool(headers.authorization)] : [];
+  },
+});
+```
+
+For direct in-process calls, pass `requestHeaders`:
+
+```ts
+await agent.generateText("Hello", {
+  requestHeaders: {
+    authorization: "Bearer token",
+    "x-tenant-id": "tenant-1",
+  },
+});
+```
+
+Fixes #1201

--- a/packages/core/src/agent/agent.spec-d.ts
+++ b/packages/core/src/agent/agent.spec-d.ts
@@ -227,6 +227,7 @@ describe("Agent Type System", () => {
       // Dynamic model function
       const dynamicModelFn: DynamicValue<AgentModelReference> = async (options) => {
         expectTypeOf(options.context).toMatchTypeOf<Map<string | symbol, unknown>>();
+        expectTypeOf(options.headers).toMatchTypeOf<Record<string, string> | undefined>();
         return mockModel;
       };
 
@@ -257,6 +258,7 @@ describe("Agent Type System", () => {
       // Dynamic value function
       const dynamicInstructions: InstructionsDynamicValue = async (options) => {
         expectTypeOf(options).toMatchTypeOf<{ context?: UserContext }>();
+        expectTypeOf(options.headers).toMatchTypeOf<Record<string, string> | undefined>();
         return "Dynamic instructions";
       };
       expectTypeOf(dynamicInstructions).toMatchTypeOf<InstructionsDynamicValue>();
@@ -277,6 +279,7 @@ describe("Agent Type System", () => {
       // Dynamic model
       const dynamicModel: ModelDynamicValue<ModelRouterModelId> = async (options) => {
         expectTypeOf(options).toMatchTypeOf<{ context?: UserContext }>();
+        expectTypeOf(options.headers).toMatchTypeOf<Record<string, string> | undefined>();
         return "openai/gpt-4o-mini";
       };
       expectTypeOf(dynamicModel).toMatchTypeOf<ModelDynamicValue<ModelRouterModelId>>();
@@ -311,6 +314,7 @@ describe("Agent Type System", () => {
       // Dynamic tools
       const dynamicTools: ToolsDynamicValue = async (options) => {
         expectTypeOf(options).toMatchTypeOf<{ context?: UserContext }>();
+        expectTypeOf(options.headers).toMatchTypeOf<Record<string, string> | undefined>();
         return [tool];
       };
       expectTypeOf(dynamicTools).toMatchTypeOf<ToolsDynamicValue>();
@@ -430,6 +434,10 @@ describe("Agent Type System", () => {
         maxSteps: 5,
         signal: new AbortSignal(),
         context: new Map(),
+        requestHeaders: {
+          authorization: "Bearer token",
+          "x-tenant-id": "tenant-1",
+        },
       };
 
       const legacyOptions: PublicGenerateOptions = {

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -4672,6 +4672,55 @@ Use pandas and summarize findings.`.split("\n"),
       expect(systemMessage.content).toContain("Use markdown to format your answers");
     });
 
+    it("should expose request headers to dynamic model, tools, and instructions", async () => {
+      const requestHeaders = {
+        authorization: "Bearer test-token",
+        "x-tenant-id": "tenant-1",
+      };
+      const dynamicInstructions = vi.fn().mockResolvedValue("Dynamic content");
+      const dynamicModel = vi.fn().mockResolvedValue(mockModel as any);
+      const dynamicTools = vi.fn().mockResolvedValue([]);
+
+      const agent = new Agent({
+        name: "TestAgent",
+        instructions: dynamicInstructions,
+        model: dynamicModel,
+        tools: dynamicTools,
+      });
+
+      vi.mocked(ai.generateText).mockResolvedValue({
+        text: "Response",
+        content: [{ type: "text", text: "Response" }],
+        reasoning: [],
+        files: [],
+        sources: [],
+        toolCalls: [],
+        toolResults: [],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        warnings: [],
+        request: {},
+        response: {
+          id: "test",
+          modelId: "test-model",
+          timestamp: new Date(),
+          messages: [],
+        },
+        steps: [],
+      } as any);
+
+      await agent.generateText("Hello", {
+        requestHeaders,
+      });
+
+      expect(dynamicInstructions.mock.calls[0][0].headers).toEqual(requestHeaders);
+      expect(dynamicModel.mock.calls[0][0].headers).toEqual(requestHeaders);
+      expect(dynamicTools.mock.calls[0][0].headers).toEqual(requestHeaders);
+
+      const callArgs = vi.mocked(ai.generateText).mock.calls[0][0] as Record<string, unknown>;
+      expect(callArgs.requestHeaders).toBeUndefined();
+    });
+
     it("should add retriever context correctly through enrichInstructions", async () => {
       // Create mock retriever
       const mockRetriever = {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -845,6 +845,14 @@ export interface BaseGenerationOptions<TProviderOptions extends ProviderOptions 
    */
   conversationId?: string;
   context?: ContextInput;
+  /**
+   * HTTP request headers associated with this call.
+   *
+   * Server adapters populate this from the incoming request and expose it to
+   * dynamic `model`, `instructions`, and `tools` callbacks as `headers`.
+   * This is separate from AI SDK/provider `headers`.
+   */
+  requestHeaders?: Record<string, string>;
   elicitation?: (request: unknown) => Promise<unknown>;
 
   // Parent tracking
@@ -1259,6 +1267,7 @@ export class Agent {
               conversationId,
               memory: _memory,
               context, // Explicitly exclude to prevent collision with AI SDK's future 'context' field
+              requestHeaders: _requestHeaders,
               parentAgentId,
               parentOperationContext,
               hooks,
@@ -1877,6 +1886,7 @@ export class Agent {
           conversationId,
           memory: _memory,
           context, // Explicitly exclude to prevent collision with AI SDK's future 'context' field
+          requestHeaders: _requestHeaders,
           parentAgentId,
           parentOperationContext,
           hooks,
@@ -2780,6 +2790,7 @@ export class Agent {
               conversationId,
               memory: _memory,
               context, // Explicitly exclude to prevent collision with AI SDK's future 'context' field
+              requestHeaders: _requestHeaders,
               parentAgentId,
               parentOperationContext,
               hooks,
@@ -3153,6 +3164,7 @@ export class Agent {
           conversationId,
           memory: _memory,
           context, // Explicitly exclude to prevent collision with AI SDK's future 'context' field
+          requestHeaders: _requestHeaders,
           parentAgentId,
           parentOperationContext,
           hooks,
@@ -4058,6 +4070,7 @@ export class Agent {
     return {
       operationId,
       context,
+      requestHeaders: options?.requestHeaders ?? options?.parentOperationContext?.requestHeaders,
       systemContext,
       isActive: true,
       logger,
@@ -5080,6 +5093,7 @@ export class Agent {
 
     const dynamicValueOptions: DynamicValueOptions = {
       context: oc.context,
+      headers: oc.requestHeaders,
       prompts: promptHelper,
     };
 
@@ -5541,10 +5555,12 @@ export class Agent {
         (this.prompts
           ? {
               context: oc.context,
+              headers: oc.requestHeaders,
               prompts: this.prompts,
             }
           : {
               context: oc.context,
+              headers: oc.requestHeaders,
               prompts: {
                 getPrompt: async () => ({ type: "text" as const, text: "" }),
               },

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1078,6 +1078,9 @@ export interface CommonGenerateOptions {
   // Optional user-defined context to be passed from a parent operation
   context?: UserContext;
 
+  // HTTP request headers associated with this generation call, when available.
+  requestHeaders?: Record<string, string>;
+
   // Optional hooks to be included only during the operation call and not persisted in the agent
   hooks?: AgentHooks;
 }
@@ -1305,6 +1308,9 @@ export type OperationContext = {
 
   /** User-managed context map for this operation */
   readonly context: Map<string | symbol, unknown>;
+
+  /** HTTP request headers associated with this operation, when available */
+  readonly requestHeaders?: Record<string, string>;
 
   /** System-managed context map for internal operation tracking */
   readonly systemContext: Map<string | symbol, unknown>;

--- a/packages/core/src/voltops/types.ts
+++ b/packages/core/src/voltops/types.ts
@@ -56,6 +56,8 @@ export type PromptHelper = {
 export interface DynamicValueOptions {
   /** User context map */
   context: Map<string | symbol, unknown>;
+  /** HTTP request headers for server-triggered agent calls, when available */
+  headers?: Record<string, string>;
   /** Prompt helper (available when VoltOpsClient is configured) */
   prompts: PromptHelper;
 }

--- a/packages/server-core/src/handlers/agent.handlers.spec.ts
+++ b/packages/server-core/src/handlers/agent.handlers.spec.ts
@@ -1,5 +1,6 @@
 import { ToolDeniedError } from "@voltagent/core";
 import { describe, expect, it, vi } from "vitest";
+import { processAgentOptions } from "../utils/options";
 import { handleChatStream, handleGenerateText } from "./agent.handlers";
 
 describe("server-core: agent.handlers ClientHTTPError mapping", () => {
@@ -54,6 +55,71 @@ describe("server-core: agent.handlers ClientHTTPError mapping", () => {
     expect(res).toMatchObject({
       success: false,
       error: "Model timeout",
+    });
+  });
+
+  it("handleGenerateText should pass request headers into agent options", async () => {
+    const logger = { error: vi.fn() } as any;
+
+    const mockAgent = {
+      generateText: vi.fn(async () => ({
+        text: "ok",
+        usage: undefined,
+        finishReason: "stop",
+        toolCalls: [],
+        toolResults: [],
+        feedback: null,
+      })),
+    } as any;
+
+    const deps = {
+      agentRegistry: {
+        getAgent: vi.fn(() => mockAgent),
+      },
+    } as any;
+
+    const headers = new Headers({
+      Authorization: "Bearer test-token",
+      "X-Tenant-ID": "tenant-1",
+    });
+
+    const res = await handleGenerateText(
+      "agent-1",
+      { input: "hi" },
+      deps,
+      logger,
+      undefined,
+      headers,
+    );
+
+    expect(res.success).toBe(true);
+    expect(mockAgent.generateText).toHaveBeenCalledWith(
+      "hi",
+      expect.objectContaining({
+        requestHeaders: {
+          authorization: "Bearer test-token",
+          "x-tenant-id": "tenant-1",
+        },
+      }),
+    );
+  });
+});
+
+describe("server-core: processAgentOptions", () => {
+  it("processAgentOptions should lowercase Headers entries", () => {
+    const headers = new Headers();
+    vi.spyOn(headers, "entries").mockReturnValue(
+      [
+        ["Authorization", "Bearer test-token"],
+        ["X-Tenant-ID", "tenant-1"],
+      ][Symbol.iterator]() as HeadersIterator<[string, string]>,
+    );
+
+    const options = processAgentOptions({ options: {} }, undefined, headers);
+
+    expect(options.requestHeaders).toEqual({
+      authorization: "Bearer test-token",
+      "x-tenant-id": "tenant-1",
     });
   });
 });

--- a/packages/server-core/src/handlers/agent.handlers.ts
+++ b/packages/server-core/src/handlers/agent.handlers.ts
@@ -66,6 +66,7 @@ export async function handleGenerateText(
   deps: ServerProviderDeps,
   logger: Logger,
   signal?: AbortSignal,
+  requestHeaders?: Headers | Record<string, string | string[] | undefined>,
 ): Promise<ApiResponse> {
   try {
     const agent = deps.agentRegistry.getAgent(agentId);
@@ -77,7 +78,7 @@ export async function handleGenerateText(
     }
 
     const { input } = body;
-    const options = processAgentOptions(body, signal);
+    const options = processAgentOptions(body, signal, requestHeaders);
 
     const result = await agent.generateText(input, options);
 
@@ -131,6 +132,7 @@ export async function handleStreamText(
   deps: ServerProviderDeps,
   logger: Logger,
   signal?: AbortSignal,
+  requestHeaders?: Headers | Record<string, string | string[] | undefined>,
 ): Promise<Response> {
   try {
     const agent = deps.agentRegistry.getAgent(agentId);
@@ -150,7 +152,7 @@ export async function handleStreamText(
     }
 
     const { input } = body;
-    const options = processAgentOptions(body, signal);
+    const options = processAgentOptions(body, signal, requestHeaders);
 
     const result = await agent.streamText(input, options);
 
@@ -216,6 +218,7 @@ export async function handleChatStream(
   deps: ServerProviderDeps,
   logger: Logger,
   signal?: AbortSignal,
+  requestHeaders?: Headers | Record<string, string | string[] | undefined>,
 ): Promise<Response> {
   try {
     const agent = deps.agentRegistry.getAgent(agentId);
@@ -245,7 +248,7 @@ export async function handleChatStream(
       typeof body?.options?.resumableStream === "boolean"
         ? body.options.resumableStream
         : (deps.resumableStreamDefault ?? false);
-    const options = processAgentOptions(body, signal);
+    const options = processAgentOptions(body, signal, requestHeaders);
     const memory =
       options.memory && typeof options.memory === "object" ? options.memory : undefined;
     const memoryConversationId =
@@ -478,6 +481,7 @@ export async function handleGenerateObject(
   deps: ServerProviderDeps,
   logger: Logger,
   signal?: AbortSignal,
+  requestHeaders?: Headers | Record<string, string | string[] | undefined>,
 ): Promise<ApiResponse> {
   try {
     const agent = deps.agentRegistry.getAgent(agentId);
@@ -489,7 +493,7 @@ export async function handleGenerateObject(
     }
 
     const { input, schema: jsonSchema } = body;
-    const options = processAgentOptions(body, signal);
+    const options = processAgentOptions(body, signal, requestHeaders);
 
     // Convert JSON schema to Zod schema (supports zod v3 and v4)
     const zodSchema = ("toJSONSchema" in z ? convertJsonSchemaToZod : convertJsonSchemaToZodV3)(
@@ -521,6 +525,7 @@ export async function handleStreamObject(
   deps: ServerProviderDeps,
   logger: Logger,
   signal?: AbortSignal,
+  requestHeaders?: Headers | Record<string, string | string[] | undefined>,
 ): Promise<Response> {
   try {
     const agent = deps.agentRegistry.getAgent(agentId);
@@ -540,7 +545,7 @@ export async function handleStreamObject(
     }
 
     const { input, schema: jsonSchema } = body;
-    const options = processAgentOptions(body, signal);
+    const options = processAgentOptions(body, signal, requestHeaders);
 
     // Convert JSON schema to Zod schema (supports zod v3 and v4)
     const zodSchema = ("toJSONSchema" in z ? convertJsonSchemaToZod : convertJsonSchemaToZodV3)(

--- a/packages/server-core/src/utils/options.ts
+++ b/packages/server-core/src/utils/options.ts
@@ -3,6 +3,34 @@ import { z } from "zod";
 import { convertJsonSchemaToZod } from "zod-from-json-schema";
 import { convertJsonSchemaToZod as convertJsonSchemaToZodV3 } from "zod-from-json-schema-v3";
 
+type RequestHeadersInput = Headers | Record<string, string | string[] | undefined>;
+
+function normalizeRequestHeaders(
+  headers?: RequestHeadersInput,
+): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    const entries = Array.from(headers.entries()).map(
+      ([key, value]) => [key.toLowerCase(), value] as const,
+    );
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      normalized[key.toLowerCase()] = value;
+    } else if (Array.isArray(value)) {
+      normalized[key.toLowerCase()] = value.join(", ");
+    }
+  }
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
 /**
  * Process agent options from request body
  */
@@ -52,6 +80,7 @@ export interface ProcessedAgentOptions {
   stopSequences?: string[];
   maxRetries?: number;
   abortSignal?: AbortSignal;
+  requestHeaders?: Record<string, string>;
   onFinish?: (result: unknown) => Promise<void>;
   output?: any;
   resumableStream?: boolean;
@@ -61,13 +90,19 @@ export interface ProcessedAgentOptions {
 /**
  * Process and normalize agent options from request body
  */
-export function processAgentOptions(body: any, signal?: AbortSignal): ProcessedAgentOptions {
+export function processAgentOptions(
+  body: any,
+  signal?: AbortSignal,
+  requestHeaders?: RequestHeadersInput,
+): ProcessedAgentOptions {
   // Now all options should be in body.options, no need to merge from root
   const options = body.options || {};
+  const normalizedRequestHeaders = normalizeRequestHeaders(requestHeaders);
 
   const processedOptions: ProcessedAgentOptions = {
     ...options,
     ...(signal && { abortSignal: signal }),
+    ...(normalizedRequestHeaders && { requestHeaders: normalizedRequestHeaders }),
   };
 
   // Convert context to Map for internal use

--- a/packages/server-elysia/src/routes/agent.routes.ts
+++ b/packages/server-elysia/src/routes/agent.routes.ts
@@ -126,7 +126,14 @@ export function registerAgentRoutes(app: Elysia, deps: ServerProviderDeps, logge
   app.post(
     "/agents/:id/text",
     async ({ params, body, request, set }) => {
-      const response = await handleGenerateText(params.id, body, deps, logger, request.signal);
+      const response = await handleGenerateText(
+        params.id,
+        body,
+        deps,
+        logger,
+        request.signal,
+        request.headers,
+      );
       if (!response.success) {
         const { httpStatus, ...details } = response;
         set.status = httpStatus || 500;
@@ -154,7 +161,14 @@ export function registerAgentRoutes(app: Elysia, deps: ServerProviderDeps, logge
   app.post(
     "/agents/:id/stream",
     async ({ params, body, request }) => {
-      const response = await handleStreamText(params.id, body, deps, logger, request.signal);
+      const response = await handleStreamText(
+        params.id,
+        body,
+        deps,
+        logger,
+        request.signal,
+        request.headers,
+      );
       return response;
     },
     {
@@ -172,7 +186,14 @@ export function registerAgentRoutes(app: Elysia, deps: ServerProviderDeps, logge
   app.post(
     "/agents/:id/chat",
     async ({ params, body, request }) => {
-      const response = await handleChatStream(params.id, body, deps, logger, request.signal);
+      const response = await handleChatStream(
+        params.id,
+        body,
+        deps,
+        logger,
+        request.signal,
+        request.headers,
+      );
       return response;
     },
     {
@@ -190,7 +211,14 @@ export function registerAgentRoutes(app: Elysia, deps: ServerProviderDeps, logge
   app.post(
     "/agents/:id/object",
     async ({ params, body, request, set }) => {
-      const response = await handleGenerateObject(params.id, body, deps, logger, request.signal);
+      const response = await handleGenerateObject(
+        params.id,
+        body,
+        deps,
+        logger,
+        request.signal,
+        request.headers,
+      );
       if (!response.success) {
         const { httpStatus, ...details } = response;
         set.status = httpStatus || 500;
@@ -218,7 +246,14 @@ export function registerAgentRoutes(app: Elysia, deps: ServerProviderDeps, logge
   app.post(
     "/agents/:id/stream-object",
     async ({ params, body, request }) => {
-      const response = await handleStreamObject(params.id, body, deps, logger, request.signal);
+      const response = await handleStreamObject(
+        params.id,
+        body,
+        deps,
+        logger,
+        request.signal,
+        request.headers,
+      );
       return response;
     },
     {

--- a/packages/server-hono/src/routes/index.ts
+++ b/packages/server-hono/src/routes/index.ts
@@ -103,7 +103,14 @@ export function registerAgentRoutes(
     const body = await c.req.json();
 
     const signal = c.req.raw.signal;
-    const response = await handleGenerateText(agentId, body, deps, logger, signal);
+    const response = await handleGenerateText(
+      agentId,
+      body,
+      deps,
+      logger,
+      signal,
+      c.req.raw.headers,
+    );
     if (!response.success) {
       const { httpStatus, ...details } = response;
       return c.json(details, httpStatus || 500);
@@ -119,7 +126,7 @@ export function registerAgentRoutes(
     }
     const body = await c.req.json();
     const signal = c.req.raw.signal;
-    const response = await handleStreamText(agentId, body, deps, logger, signal);
+    const response = await handleStreamText(agentId, body, deps, logger, signal, c.req.raw.headers);
 
     // Handler now always returns a Response object
     return response;
@@ -133,7 +140,7 @@ export function registerAgentRoutes(
     }
     const body = await c.req.json();
     const signal = c.req.raw.signal;
-    const response = await handleChatStream(agentId, body, deps, logger, signal);
+    const response = await handleChatStream(agentId, body, deps, logger, signal, c.req.raw.headers);
 
     // Handler now always returns a Response object
     return response;
@@ -159,7 +166,14 @@ export function registerAgentRoutes(
     }
     const body = await c.req.json();
     const signal = c.req.raw.signal;
-    const response = await handleGenerateObject(agentId, body, deps, logger, signal);
+    const response = await handleGenerateObject(
+      agentId,
+      body,
+      deps,
+      logger,
+      signal,
+      c.req.raw.headers,
+    );
     if (!response.success) {
       const { httpStatus, ...details } = response;
       return c.json(details, httpStatus || 500);
@@ -175,7 +189,14 @@ export function registerAgentRoutes(
     }
     const body = await c.req.json();
     const signal = c.req.raw.signal;
-    const response = await handleStreamObject(agentId, body, deps, logger, signal);
+    const response = await handleStreamObject(
+      agentId,
+      body,
+      deps,
+      logger,
+      signal,
+      c.req.raw.headers,
+    );
 
     // Handler now always returns a Response object
     return response;

--- a/packages/serverless-hono/src/routes.ts
+++ b/packages/serverless-hono/src/routes.ts
@@ -141,7 +141,11 @@ function extractHeaders(
   headers: Headers | NodeJS.Dict<string | string[] | undefined>,
 ): Record<string, string> {
   if (headers instanceof Headers) {
-    return Object.fromEntries(headers.entries());
+    const result: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      result[key] = value;
+    });
+    return result;
   }
 
   const result: Record<string, string> = {};
@@ -296,6 +300,7 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       deps,
       logger,
       signal,
+      c.req.raw.headers,
     );
     return c.json(response, response.success ? 200 : 500);
   });
@@ -314,6 +319,7 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       deps,
       logger,
       signal,
+      c.req.raw.headers,
     );
     return response;
   });
@@ -332,6 +338,7 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       deps,
       logger,
       signal,
+      c.req.raw.headers,
     );
   });
 
@@ -362,6 +369,7 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       deps,
       logger,
       signal,
+      c.req.raw.headers,
     );
     return c.json(response, response.success ? 200 : 500);
   });
@@ -380,6 +388,7 @@ export function registerAgentRoutes(app: Hono, deps: ServerProviderDeps, logger:
       deps,
       logger,
       signal,
+      c.req.raw.headers,
     );
   });
 

--- a/website/docs/agents/dynamic-agents.md
+++ b/website/docs/agents/dynamic-agents.md
@@ -39,6 +39,7 @@ type DynamicValue<T> = (options: DynamicValueOptions) => Promise<T> | T;
 
 interface DynamicValueOptions {
   context: Map<string | symbol, unknown>; // Runtime context you provide
+  headers?: Record<string, string>; // HTTP request headers, when called through a server adapter
   prompts: PromptHelper; // VoltOps prompt management
 }
 ```
@@ -103,6 +104,38 @@ const agent = new Agent({
   },
 
   model: "openai/gpt-4o",
+});
+```
+
+### Request Headers
+
+When an agent is called through the built-in HTTP endpoints, VoltAgent exposes the request headers to dynamic `instructions`, `model`, and `tools` functions as `headers`. Header names are normalized to lowercase.
+
+```ts
+const agent = new Agent({
+  name: "Tenant Agent",
+  instructions: "You are a tenant-aware assistant.",
+  model: ({ headers }) => {
+    const tenantId = headers?.["x-tenant-id"];
+
+    return tenantId === "enterprise" ? "openai/gpt-4o" : "openai/gpt-4o-mini";
+  },
+  tools: ({ headers }) => {
+    const token = headers?.authorization;
+
+    return token ? [createTenantTool(token)] : [];
+  },
+});
+```
+
+For direct in-process calls, pass `requestHeaders`:
+
+```ts
+await agent.generateText("Hello", {
+  requestHeaders: {
+    authorization: "Bearer token",
+    "x-tenant-id": "tenant-1",
+  },
 });
 ```
 

--- a/website/docs/agents/prompts.md
+++ b/website/docs/agents/prompts.md
@@ -165,6 +165,7 @@ instructions: (options: DynamicValueOptions) => Promise<string | PromptContent>;
 
 interface DynamicValueOptions {
   context: Map<string | symbol, unknown>;
+  headers?: Record<string, string>;
   prompts: PromptHelper;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Dynamic `instructions`, `model`, and `tools` functions receive runtime `context` and `prompts`, but calls made through the built-in HTTP endpoints do not expose the incoming request headers. Users have to copy auth, tenant, or user headers into `options.context` manually.

## What is the new behavior?

Dynamic agent configuration now receives a `headers` map via `DynamicValueOptions` when request headers are available. The Hono, Elysia, and serverless Hono agent routes attach incoming request headers as `options.requestHeaders`, and core exposes them to dynamic `instructions`, `model`, and `tools` without passing `requestHeaders` through to the AI SDK call.

Also documents `headers` and direct in-process `requestHeaders` usage, and adds tests for both core dynamic resolution and server-core option processing.

fixes #1201

## Notes for reviewers

Validation run:

- `pnpm --filter @voltagent/core typecheck`
- `pnpm --filter @voltagent/server-core typecheck`
- `pnpm --filter @voltagent/server-core test -- src/handlers/agent.handlers.spec.ts`
- `pnpm --filter @voltagent/core test:single -- src/agent/agent.spec.ts`

Adapter package typecheck commands still report existing route typing issues unrelated to this change; the new handler argument compatibility errors were avoided by injecting `requestHeaders` into request options at the adapter layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request headers are now provided to dynamic agent resolvers (instructions, model, tools), normalized to lowercase, enabling tenant- or user-aware model/tool selection. Callers can also pass requestHeaders programmatically to drive the same behavior.
* **Documentation**
  * Docs updated with examples and guidance for header-driven dynamic configuration.
* **Tests**
  * Unit tests added to validate header normalization and propagation to dynamic resolvers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose incoming HTTP request headers to dynamic agent configuration so `instructions`, `model`, and `tools` can be tenant/auth-aware without manual header copying. Headers are normalized to lowercase and are not sent to the AI provider.

- **New Features**
  - `@voltagent/core`: Added `requestHeaders` to generation options; exposed as `headers` in `DynamicValueOptions` for dynamic `instructions`, `model`, and `tools`. `requestHeaders` are stripped before provider calls.
  - `@voltagent/server-core`: Handlers accept raw request headers and normalize them to lowercase (supports `Headers` and Node/edge dicts) via `processAgentOptions`.
  - `@voltagent/server-hono`, `@voltagent/server-elysia`, `@voltagent/serverless-hono`: Routes forward incoming request headers to server-core handlers across text, stream, chat, and object endpoints.
  - Direct in-process calls can pass `requestHeaders` in options.
  - Updated docs and tests to cover normalization and propagation.

<sup>Written for commit 081f16d8c3f5bd7b6bf187e15e099203571a1d27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

