### PR TITLE
fix(server-hono): support Zod v4 records in Swagger docs

### DIFF
--- a/.changeset/fix-zod-v4-swagger-records.md
+++ b/.changeset/fix-zod-v4-swagger-records.md
@@ -1,0 +1,8 @@
+---
+"@voltagent/server-hono": patch
+---
+
+fix(server-hono): support Zod v4 record schemas in Swagger docs
+
+The built-in tool OpenAPI schemas now use explicit record key and value schemas so Zod v4 does not
+produce undefined record value types during Swagger document generation.

--- a/packages/server-hono/src/app-factory.spec.ts
+++ b/packages/server-hono/src/app-factory.spec.ts
@@ -1,6 +1,9 @@
+import { TOOL_ROUTES } from "@voltagent/server-core";
 import { cors } from "hono/cors";
 import { describe, expect, it } from "vitest";
+import { z as zodV4 } from "zod/v4";
 import { createApp } from "./app-factory";
+import { OpenApiGeneratorV31 } from "./vendor/zod-to-openapi/v4";
 
 const createDeps = () =>
   ({
@@ -270,6 +273,17 @@ describe("app-factory CORS configuration", () => {
     expect(defaultRes.headers.get("access-control-allow-credentials")).toBe("true");
   });
 
+  it("should generate OpenAPI docs for built-in tool routes", async () => {
+    const { app } = await createApp(createDeps(), {});
+
+    const res = await app.request("/doc");
+    const doc = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(doc.paths[TOOL_ROUTES.listTools.path].get).toBeDefined();
+    expect(doc.paths[TOOL_ROUTES.executeTool.path.replace(":name", "{name}")].post).toBeDefined();
+  });
+
   it("should keep custom routes public in opt-in mode (default)", async () => {
     const mockAuthProvider = {
       verifyToken: async (token: string) => {
@@ -324,5 +338,43 @@ describe("app-factory CORS configuration", () => {
 
     // Auth middleware should execute before custom route
     expect(executionOrder).toEqual(["auth-middleware", "custom-route"]);
+  });
+});
+
+describe("Zod v4 OpenAPI compatibility", () => {
+  it("should generate docs for record schemas with explicit key and value types", () => {
+    const schema = zodV4.object({
+      parameters: zodV4.record(zodV4.string(), zodV4.any()).optional(),
+      context: zodV4.record(zodV4.string(), zodV4.any()).optional().default({}),
+    });
+    const route = {
+      method: "post",
+      path: "/tools/{name}/execute",
+      request: {
+        body: {
+          content: {
+            "application/json": {
+              schema,
+            },
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: "Successful response",
+        },
+      },
+    };
+
+    const doc = new OpenApiGeneratorV31([{ type: "route", route }]).generateDocument({
+      openapi: "3.1.0",
+      info: { title: "Zod v4 regression", version: "1.0.0" },
+    });
+
+    const requestSchema =
+      doc.paths["/tools/{name}/execute"].post.requestBody.content["application/json"].schema;
+
+    expect(requestSchema.properties.parameters.additionalProperties).toEqual({});
+    expect(requestSchema.properties.context.additionalProperties).toEqual({});
   });
 });

--- a/packages/server-hono/src/routes/tool.routes.ts
+++ b/packages/server-hono/src/routes/tool.routes.ts
@@ -16,7 +16,7 @@ const ToolDefinitionSchema = z.object({
   id: z.string().optional(),
   name: z.string(),
   description: z.string().optional(),
-  parameters: z.record(z.any()).optional(),
+  parameters: z.record(z.string(), z.any()).optional(),
   status: z.string().optional(),
   agents: z
     .array(
@@ -37,7 +37,7 @@ const ToolListResponseSchema = z.object({
 const ToolExecuteRequestSchema = z
   .object({
     input: z.any().optional().default({}),
-    context: z.record(z.any()).optional().default({}),
+    context: z.record(z.string(), z.any()).optional().default({}),
     userId: z.string().optional(),
     conversationId: z.string().optional(),
   })


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Swagger/OpenAPI generation can fail under Zod v4 for the built-in tool routes. The tool route schemas used single-argument `z.record(z.any())`, which Zod v4 treats differently and leaves the record value type undefined. The vendored OpenAPI generator then throws `Cannot use 'in' operator to search for 'def' in undefined` when `/doc` is requested by Swagger UI.

## What is the new behavior?

The built-in tool route schemas now use explicit record key and value schemas via `z.record(z.string(), z.any())`, which works with both Zod v3 and Zod v4. Added coverage for built-in tool route OpenAPI docs and a Zod v4 record-schema OpenAPI regression test.

fixes Zod v4 Swagger UI crash for built-in tool route schemas

## Notes for reviewers

Validated with:

- `pnpm --filter @voltagent/server-hono test -- --run`
- `pnpm biome check packages/server-hono/src/routes/tool.routes.ts packages/server-hono/src/app-factory.spec.ts`
- `pnpm --filter @voltagent/server-hono build`
- Temp `zod@4.3.6` OpenAPI generation check

`pnpm --filter @voltagent/server-hono typecheck` currently fails in this checkout on pre-existing Hono typed-response/status-code route errors outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Swagger/OpenAPI generation crash under Zod v4 for built-in tool routes in `@voltagent/server-hono`. `/doc` now renders correctly with Zod v3 and v4.

- **Bug Fixes**
  - Use explicit record schemas: `parameters` and `context` now use `z.record(z.string(), z.any())` instead of `z.record(z.any())`.
  - Add tests to verify built-in tool routes appear in generated OpenAPI and a Zod v4 record-schema regression test with `OpenApiGeneratorV31`.
  - Resolves the Swagger UI `/doc` error: Cannot use 'in' operator to search for 'def' in undefined.

<sup>Written for commit 07512995500f88aa14fa1a679c233d16263f3d28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAPI/Swagger documentation generation to correctly handle Zod v4 record schemas, ensuring accurate schema definitions in generated API documentation.

* **Tests**
  * Added test coverage for OpenAPI schema generation and Zod v4 compatibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->