### PR TITLE
fix(server-hono): reuse active Zod instance for Swagger schemas

### DIFF
--- a/.changeset/smart-swagger-paths.md
+++ b/.changeset/smart-swagger-paths.md
@@ -2,7 +2,8 @@
 "@voltagent/server-hono": patch
 ---
 
-fix(server-hono): keep Swagger docs populated when OpenAPI generation falls back
+fix(server-hono): generate Swagger schemas with a single Zod instance
 
-Swagger now falls back to registered VoltAgent and custom route metadata when schema generation
-throws, so `/ui` and `/doc` still list available APIs instead of rendering an empty spec.
+Built-in Swagger route schemas now reuse the same schema definitions with the Zod instance selected
+by server-hono's OpenAPI compatibility layer. This avoids mixing Zod v3/v4 schema instances and
+prevents `/doc` from failing during OpenAPI generation.

--- a/.changeset/smart-swagger-paths.md
+++ b/.changeset/smart-swagger-paths.md
@@ -1,0 +1,8 @@
+---
+"@voltagent/server-hono": patch
+---
+
+fix(server-hono): keep Swagger docs populated when OpenAPI generation falls back
+
+Swagger now falls back to registered VoltAgent and custom route metadata when schema generation
+throws, so `/ui` and `/doc` still list available APIs instead of rendering an empty spec.

--- a/packages/server-core/src/schemas/agent.schemas.ts
+++ b/packages/server-core/src/schemas/agent.schemas.ts
@@ -1,586 +1,679 @@
-import { z } from "zod";
+import { z as defaultZ } from "zod";
 
-// Common schemas
-export const ParamsSchema = z.object({
-  id: z.string().describe("The ID of the agent"),
-});
+type ZodNamespace = typeof defaultZ;
 
-// Parameter schemas for different endpoints
-export const AgentParamsSchema = z.object({
-  id: z.string().describe("The ID of the agent"),
-});
+export function createServerCoreSchemas(zod: ZodNamespace = defaultZ) {
+  const z = zod;
 
-export const WorkflowParamsSchema = z.object({
-  id: z.string().describe("The ID of the workflow"),
-});
+  // Common schemas
+  const ParamsSchema = z.object({
+    id: z.string().describe("The ID of the agent"),
+  });
 
-export const WorkflowExecutionParamsSchema = z.object({
-  id: z.string().describe("The ID of the workflow"),
-  executionId: z.string().describe("The ID of the execution to operate on"),
-});
+  // Parameter schemas for different endpoints
+  const AgentParamsSchema = z.object({
+    id: z.string().describe("The ID of the agent"),
+  });
 
-export const ErrorSchema = z.object({
-  success: z.literal(false),
-  error: z.string().describe("Error message"),
-});
+  const WorkflowParamsSchema = z.object({
+    id: z.string().describe("The ID of the workflow"),
+  });
 
-// Agent schemas
-export const SubAgentResponseSchema = z
-  .object({
+  const WorkflowExecutionParamsSchema = z.object({
+    id: z.string().describe("The ID of the workflow"),
+    executionId: z.string().describe("The ID of the execution to operate on"),
+  });
+
+  const ErrorSchema = z.object({
+    success: z.literal(false),
+    error: z.string().describe("Error message"),
+  });
+
+  // Agent schemas
+  const SubAgentResponseSchema = z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      description: z.string(),
+      status: z.string().describe("Current status of the sub-agent"),
+      model: z.string(),
+      tools: z.array(z.any()).optional(),
+      memory: z.any().optional(),
+    })
+    .passthrough();
+
+  const AgentResponseSchema = z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      description: z.string(),
+      status: z.string().describe("Current status of the agent"),
+      model: z.string(),
+      tools: z.array(z.any()),
+      subAgents: z.array(SubAgentResponseSchema).optional().describe("List of sub-agents"),
+      memory: z.any().optional(),
+      isTelemetryEnabled: z
+        .boolean()
+        .describe("Indicates if telemetry is configured for the agent"),
+    })
+    .passthrough();
+
+  // Response list schemas
+  const AgentListSchema = z
+    .array(AgentResponseSchema)
+    .describe("Array of agent objects with their configurations");
+
+  // Workspace schemas
+  const WorkspaceInfoSchema = z.object({
+    id: z.string().describe("Workspace ID"),
+    name: z.string().optional().describe("Workspace name"),
+    scope: z.enum(["agent", "conversation"]).optional().describe("Workspace scope"),
+    capabilities: z.object({
+      filesystem: z.boolean().describe("Filesystem access enabled"),
+      sandbox: z.boolean().describe("Sandbox execution enabled"),
+      search: z.boolean().describe("Search enabled"),
+      skills: z.boolean().describe("Skills enabled"),
+    }),
+  });
+
+  const WorkspaceFileInfoSchema = z.object({
+    path: z.string(),
+    is_dir: z.boolean(),
+    size: z.number().optional(),
+    modified_at: z.string().optional(),
+  });
+
+  const WorkspaceFileListSchema = z.object({
+    path: z.string(),
+    entries: z.array(WorkspaceFileInfoSchema),
+  });
+
+  const WorkspaceReadFileSchema = z.object({
+    path: z.string(),
+    content: z.string(),
+  });
+
+  const WorkspaceSkillMetadataSchema = z.object({
     id: z.string(),
     name: z.string(),
-    description: z.string(),
-    status: z.string().describe("Current status of the sub-agent"),
-    model: z.string(),
-    tools: z.array(z.any()).optional(),
-    memory: z.any().optional(),
-  })
-  .passthrough();
+    description: z.string().optional(),
+    version: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    path: z.string(),
+    root: z.string(),
+    references: z.array(z.string()).optional(),
+    scripts: z.array(z.string()).optional(),
+    assets: z.array(z.string()).optional(),
+  });
 
-export const AgentResponseSchema = z
-  .object({
-    id: z.string(),
-    name: z.string(),
-    description: z.string(),
-    status: z.string().describe("Current status of the agent"),
-    model: z.string(),
-    tools: z.array(z.any()),
-    subAgents: z.array(SubAgentResponseSchema).optional().describe("List of sub-agents"),
-    memory: z.any().optional(),
-    isTelemetryEnabled: z.boolean().describe("Indicates if telemetry is configured for the agent"),
-  })
-  .passthrough();
+  const WorkspaceSkillListItemSchema = WorkspaceSkillMetadataSchema.extend({
+    active: z.boolean().describe("Whether the skill is currently activated"),
+  });
 
-// Response list schemas
-export const AgentListSchema = z
-  .array(AgentResponseSchema)
-  .describe("Array of agent objects with their configurations");
+  const WorkspaceSkillListSchema = z.object({
+    skills: z.array(WorkspaceSkillListItemSchema),
+  });
 
-// Workspace schemas
-export const WorkspaceInfoSchema = z.object({
-  id: z.string().describe("Workspace ID"),
-  name: z.string().optional().describe("Workspace name"),
-  scope: z.enum(["agent", "conversation"]).optional().describe("Workspace scope"),
-  capabilities: z.object({
-    filesystem: z.boolean().describe("Filesystem access enabled"),
-    sandbox: z.boolean().describe("Sandbox execution enabled"),
-    search: z.boolean().describe("Search enabled"),
-    skills: z.boolean().describe("Skills enabled"),
-  }),
-});
+  const WorkspaceSkillSchema = WorkspaceSkillMetadataSchema.extend({
+    instructions: z.string(),
+  });
 
-export const WorkspaceFileInfoSchema = z.object({
-  path: z.string(),
-  is_dir: z.boolean(),
-  size: z.number().optional(),
-  modified_at: z.string().optional(),
-});
+  // Basic JSON schema for structured output (used in both output and object generation)
+  const BasicJsonSchema = z
+    .object({
+      type: z.literal("object"),
+      properties: z
+        .record(z.string(), z.unknown())
+        .nullish()
+        .describe("A dictionary defining each property of the object and its type"),
+      required: z
+        .array(z.string())
+        .optional()
+        .describe("List of required property names in the object"),
+    })
+    .passthrough()
+    .describe("The Zod schema for the desired object output (passed as JSON)");
 
-export const WorkspaceFileListSchema = z.object({
-  path: z.string(),
-  entries: z.array(WorkspaceFileInfoSchema),
-});
+  const FeedbackConfigSchema = z
+    .object({
+      type: z.enum(["continuous", "categorical", "freeform"]),
+      min: z.number().optional(),
+      max: z.number().optional(),
+      categories: z
+        .array(
+          z.object({
+            value: z.union([z.string(), z.number()]),
+            label: z.string().optional(),
+            description: z.string().optional(),
+          }),
+        )
+        .optional(),
+    })
+    .passthrough()
+    .describe("Feedback configuration for the trace");
 
-export const WorkspaceReadFileSchema = z.object({
-  path: z.string(),
-  content: z.string(),
-});
+  const FeedbackExpiresInSchema = z
+    .object({
+      days: z.number().int().optional(),
+      hours: z.number().int().optional(),
+      minutes: z.number().int().optional(),
+    })
+    .passthrough()
+    .describe("Relative expiration for feedback tokens");
 
-export const WorkspaceSkillMetadataSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  description: z.string().optional(),
-  version: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  path: z.string(),
-  root: z.string(),
-  references: z.array(z.string()).optional(),
-  scripts: z.array(z.string()).optional(),
-  assets: z.array(z.string()).optional(),
-});
+  const FeedbackOptionsSchema = z
+    .object({
+      key: z.string().optional().describe("Feedback key for the trace"),
+      feedbackConfig: FeedbackConfigSchema.nullish().optional(),
+      expiresAt: z.string().optional().describe("Absolute expiration timestamp (ISO 8601)"),
+      expiresIn: FeedbackExpiresInSchema.optional(),
+    })
+    .passthrough()
+    .describe("Feedback options for the generated trace");
 
-export const WorkspaceSkillListItemSchema = WorkspaceSkillMetadataSchema.extend({
-  active: z.boolean().describe("Whether the skill is currently activated"),
-});
-
-export const WorkspaceSkillListSchema = z.object({
-  skills: z.array(WorkspaceSkillListItemSchema),
-});
-
-export const WorkspaceSkillSchema = WorkspaceSkillMetadataSchema.extend({
-  instructions: z.string(),
-});
-
-// Basic JSON schema for structured output (used in both output and object generation)
-export const BasicJsonSchema = z
-  .object({
-    type: z.literal("object"),
-    properties: z
-      .record(z.string(), z.unknown())
-      .nullish()
-      .describe("A dictionary defining each property of the object and its type"),
-    required: z
-      .array(z.string())
-      .optional()
-      .describe("List of required property names in the object"),
-  })
-  .passthrough()
-  .describe("The Zod schema for the desired object output (passed as JSON)");
-
-const FeedbackConfigSchema = z
-  .object({
-    type: z.enum(["continuous", "categorical", "freeform"]),
-    min: z.number().optional(),
-    max: z.number().optional(),
-    categories: z
-      .array(
-        z.object({
-          value: z.union([z.string(), z.number()]),
-          label: z.string().optional(),
-          description: z.string().optional(),
-        }),
-      )
-      .optional(),
-  })
-  .passthrough()
-  .describe("Feedback configuration for the trace");
-
-const FeedbackExpiresInSchema = z
-  .object({
-    days: z.number().int().optional(),
-    hours: z.number().int().optional(),
-    minutes: z.number().int().optional(),
-  })
-  .passthrough()
-  .describe("Relative expiration for feedback tokens");
-
-const FeedbackOptionsSchema = z
-  .object({
-    key: z.string().optional().describe("Feedback key for the trace"),
-    feedbackConfig: FeedbackConfigSchema.nullish().optional(),
-    expiresAt: z.string().optional().describe("Absolute expiration timestamp (ISO 8601)"),
-    expiresIn: FeedbackExpiresInSchema.optional(),
-  })
-  .passthrough()
-  .describe("Feedback options for the generated trace");
-
-const SemanticMemoryOptionsSchema = z
-  .object({
-    enabled: z
-      .boolean()
-      .optional()
-      .describe(
-        "Enable semantic retrieval for this call (default: auto when vectors are available)",
-      ),
-    semanticLimit: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .describe("Number of similar messages to retrieve"),
-    semanticThreshold: z
-      .number()
-      .min(0)
-      .max(1)
-      .optional()
-      .describe("Minimum similarity score (0-1)"),
-    mergeStrategy: z
-      .enum(["prepend", "append", "interleave"])
-      .optional()
-      .describe("How semantic results merge with recent history"),
-  })
-  .passthrough();
-
-const ConversationPersistenceOptionsSchema = z
-  .object({
-    mode: z
-      .enum(["step", "finish"])
-      .optional()
-      .describe("Persistence strategy: checkpoint by step or persist on finish"),
-    debounceMs: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .describe("Debounce window for step checkpoint persistence"),
-    flushOnToolResult: z
-      .boolean()
-      .optional()
-      .describe("Flush immediately on tool-result/tool-error in step mode"),
-  })
-  .passthrough();
-
-const MessageMetadataPersistenceOptionsSchema = z
-  .object({
-    usage: z
-      .boolean()
-      .optional()
-      .describe("Persist resolved token usage under message.metadata.usage"),
-    finishReason: z
-      .boolean()
-      .optional()
-      .describe("Persist the final finish reason under message.metadata.finishReason"),
-  })
-  .passthrough();
-
-const MessageMetadataPersistenceConfigSchema = z
-  .union([z.boolean(), MessageMetadataPersistenceOptionsSchema])
-  .describe("Controls which assistant message metadata fields are persisted to memory");
-
-const RuntimeMemoryBehaviorOptionsSchema = z
-  .object({
-    contextLimit: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .describe("Number of previous messages to include from memory"),
-    readOnly: z
-      .boolean()
-      .optional()
-      .describe("When true, memory reads are allowed but no memory writes are persisted"),
-    semanticMemory: SemanticMemoryOptionsSchema.optional().describe(
-      "Semantic retrieval configuration for this call",
-    ),
-    conversationPersistence: ConversationPersistenceOptionsSchema.optional().describe(
-      "Per-call conversation persistence behavior",
-    ),
-    messageMetadataPersistence: MessageMetadataPersistenceConfigSchema.optional().describe(
-      "Per-call persisted assistant message metadata behavior",
-    ),
-  })
-  .passthrough();
-
-const RuntimeMemoryEnvelopeSchema = z
-  .object({
-    conversationId: z.string().optional().describe("Conversation identifier for memory scoping"),
-    userId: z.string().optional().describe("User identifier for memory scoping"),
-    options: RuntimeMemoryBehaviorOptionsSchema.optional().describe(
-      "Per-call memory behavior overrides",
-    ),
-  })
-  .passthrough();
-
-// Generation options schema
-export const GenerateOptionsSchema = z
-  .object({
-    memory: RuntimeMemoryEnvelopeSchema.optional().describe(
-      "Runtime memory envelope (preferred): memory.userId/memory.conversationId + memory.options.*",
-    ),
-    userId: z.string().optional().describe("Deprecated: use options.memory.userId"),
-    conversationId: z.string().optional().describe("Deprecated: use options.memory.conversationId"),
-    context: z
-      .record(z.string(), z.unknown())
-      .nullish()
-      .describe("User context for dynamic agent behavior"),
-    contextLimit: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .default(10)
-      .describe("Deprecated: use options.memory.options.contextLimit"),
-    semanticMemory: SemanticMemoryOptionsSchema.optional().describe(
-      "Deprecated: use options.memory.options.semanticMemory",
-    ),
-    conversationPersistence: ConversationPersistenceOptionsSchema.optional().describe(
-      "Deprecated: use options.memory.options.conversationPersistence",
-    ),
-    messageMetadataPersistence: MessageMetadataPersistenceConfigSchema.optional().describe(
-      "Deprecated: use options.memory.options.messageMetadataPersistence",
-    ),
-    maxSteps: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .describe("Maximum number of steps for this request"),
-    temperature: z
-      .number()
-      .min(0)
-      .max(1)
-      .optional()
-      .default(0.7)
-      .describe("Controls randomness (0-1)"),
-    maxOutputTokens: z
-      .number()
-      .int()
-      .positive()
-      .optional()
-      .default(4000)
-      .describe("Maximum tokens to generate"),
-    topP: z
-      .number()
-      .min(0)
-      .max(1)
-      .optional()
-      .default(1.0)
-      .describe("Controls diversity via nucleus sampling (0-1)"),
-    frequencyPenalty: z
-      .number()
-      .min(0)
-      .max(2)
-      .optional()
-      .default(0.0)
-      .describe("Penalizes repeated tokens (0-2)"),
-    presencePenalty: z
-      .number()
-      .min(0)
-      .max(2)
-      .optional()
-      .default(0.0)
-      .describe("Penalizes tokens based on presence (0-2)"),
-    seed: z.number().int().optional().describe("Optional seed for reproducible results"),
-    stopSequences: z.array(z.string()).optional().describe("Stop sequences to end generation"),
-    providerOptions: z
-      .record(z.string(), z.unknown())
-      .nullish()
-      .describe("Provider-specific options for AI SDK providers (e.g., OpenAI's reasoningEffort)"),
-    resumableStream: z
-      .boolean()
-      .optional()
-      .describe(
-        "When true, avoids wiring the HTTP abort signal into streams so they can be resumed (requires resumable streams and conversation/user IDs via options.memory or top-level legacy fields). If omitted, server defaults may apply.",
-      ),
-    output: z
-      .object({
-        type: z
-          .enum(["object", "text"])
-          .describe("Output type: 'object' for structured JSON, 'text' for text-only output"),
-        schema: BasicJsonSchema.optional().describe(
-          "JSON schema for structured output (required when type is 'object')",
+  const SemanticMemoryOptionsSchema = z
+    .object({
+      enabled: z
+        .boolean()
+        .optional()
+        .describe(
+          "Enable semantic retrieval for this call (default: auto when vectors are available)",
         ),
-      })
-      .optional()
-      .describe("Structured output configuration for schema-guided generation"),
-    feedback: z
-      .union([z.boolean(), FeedbackOptionsSchema])
-      .optional()
-      .describe("Enable or configure feedback tokens for the trace"),
-  })
-  .passthrough();
-
-// Text generation schemas
-export const TextRequestSchema = z.object({
-  input: z
-    .union([
-      z.string().describe("Direct text input"),
-      z.array(z.any()).describe("AI SDK message array (UIMessage or ModelMessage format)"),
-    ])
-    .describe("Input text or messages array - accepts string, UIMessage[], or ModelMessage[]"),
-  options: GenerateOptionsSchema.optional().describe("Optional generation parameters"),
-});
-
-export const TextResponseSchema = z.object({
-  success: z.literal(true),
-  data: z.union([
-    z.string().describe("Generated text response (legacy)"),
-    z
-      .object({
-        text: z.string(),
-        usage: z
-          .object({
-            promptTokens: z.number(),
-            completionTokens: z.number(),
-            totalTokens: z.number(),
-            cachedInputTokens: z.number().optional(),
-            reasoningTokens: z.number().optional(),
-          })
-          .optional(),
-        finishReason: z.string().optional(),
-        toolCalls: z.array(z.any()).optional(),
-        toolResults: z.array(z.any()).optional(),
-        output: z.any().optional().describe("Structured output when output is used"),
-        feedback: z
-          .object({
-            traceId: z.string(),
-            key: z.string(),
-            url: z.string(),
-            tokenId: z.string().optional(),
-            expiresAt: z.string().optional(),
-            feedbackConfig: FeedbackConfigSchema.nullish().optional(),
-            provided: z.boolean().optional(),
-            providedAt: z.string().optional(),
-            feedbackId: z.string().optional(),
-          })
-          .nullable()
-          .optional()
-          .describe("Feedback metadata for the trace"),
-      })
-      .describe("AI SDK formatted response"),
-  ]),
-});
-
-// Stream schemas
-export const StreamTextEventSchema = z.object({
-  text: z.string().optional(),
-  timestamp: z.string().datetime().optional(),
-  type: z.enum(["text", "completion", "error"]).optional(),
-  done: z.boolean().optional(),
-  error: z.string().optional(),
-});
-
-// Object generation schemas
-export const ObjectRequestSchema = z.object({
-  input: z
-    .union([
-      z.string().describe("Direct text input"),
-      z.array(z.any()).describe("AI SDK message array (UIMessage or ModelMessage format)"),
-    ])
-    .describe("Input text or messages array - accepts string, UIMessage[], or ModelMessage[]"),
-  schema: BasicJsonSchema,
-  options: GenerateOptionsSchema.optional().describe("Optional object generation parameters"),
-});
-
-export const ObjectResponseSchema = z.object({
-  success: z.literal(true),
-  data: z.object({}).passthrough().describe("Generated object response"),
-});
-
-export const StreamObjectEventSchema = z
-  .any()
-  .describe("Streamed object parts or the final object");
-
-// Workflow schemas
-export const WorkflowResponseSchema = z.object({
-  id: z.string().describe("Unique workflow identifier"),
-  name: z.string().describe("Human-readable workflow name"),
-  purpose: z.string().describe("Description of what the workflow does"),
-  stepsCount: z.number().int().describe("Number of steps in the workflow"),
-  status: z
-    .enum(["idle", "running", "completed", "error"])
-    .describe("Current status of the workflow"),
-});
-
-export const WorkflowListSchema = z
-  .array(WorkflowResponseSchema)
-  .describe("Array of workflow objects with their configurations");
-
-export const WorkflowExecutionRequestSchema = z.object({
-  input: z.any().describe("Input data for the workflow"),
-  options: z
-    .object({
-      userId: z.string().optional(),
-      conversationId: z.string().optional(),
-      executionId: z.string().optional(),
-      context: z.any().optional(),
-      workflowState: z.record(z.string(), z.any()).optional(),
-      metadata: z.record(z.string(), z.any()).optional(),
+      semanticLimit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Number of similar messages to retrieve"),
+      semanticThreshold: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("Minimum similarity score (0-1)"),
+      mergeStrategy: z
+        .enum(["prepend", "append", "interleave"])
+        .optional()
+        .describe("How semantic results merge with recent history"),
     })
-    .optional()
-    .describe("Optional execution options"),
-});
+    .passthrough();
 
-export const WorkflowExecutionResponseSchema = z.object({
-  success: z.literal(true),
-  data: z
+  const ConversationPersistenceOptionsSchema = z
     .object({
-      executionId: z.string(),
-      startAt: z.string(),
-      endAt: z.string(),
-      status: z.literal("completed"),
-      result: z.any(),
+      mode: z
+        .enum(["step", "finish"])
+        .optional()
+        .describe("Persistence strategy: checkpoint by step or persist on finish"),
+      debounceMs: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Debounce window for step checkpoint persistence"),
+      flushOnToolResult: z
+        .boolean()
+        .optional()
+        .describe("Flush immediately on tool-result/tool-error in step mode"),
     })
-    .describe("Workflow execution result"),
-});
+    .passthrough();
 
-export const WorkflowStreamEventSchema = z.object({
-  type: z.string().describe("Event type"),
-  executionId: z.string().describe("Workflow execution ID"),
-  from: z.string().describe("Source of the event"),
-  input: z.any().optional(),
-  output: z.any().optional(),
-  status: z.enum(["pending", "running", "success", "error", "suspended", "cancelled"]),
-  timestamp: z.string(),
-  stepIndex: z.number().optional(),
-  metadata: z.record(z.string(), z.any()).nullish(),
-  error: z.any().optional(),
-});
-
-export const WorkflowSuspendRequestSchema = z.object({
-  reason: z.string().optional().describe("Reason for suspension"),
-});
-
-export const WorkflowSuspendResponseSchema = z.object({
-  success: z.literal(true),
-  data: z
+  const MessageMetadataPersistenceOptionsSchema = z
     .object({
-      executionId: z.string(),
-      status: z.literal("suspended"),
-      suspension: z.object({
-        suspendedAt: z.string(),
-        reason: z.string().optional(),
-      }),
+      usage: z
+        .boolean()
+        .optional()
+        .describe("Persist resolved token usage under message.metadata.usage"),
+      finishReason: z
+        .boolean()
+        .optional()
+        .describe("Persist the final finish reason under message.metadata.finishReason"),
     })
-    .describe("Workflow suspension result"),
-});
+    .passthrough();
 
-export const WorkflowCancelRequestSchema = z.object({
-  reason: z.string().optional().describe("Reason for cancellation"),
-});
+  const MessageMetadataPersistenceConfigSchema = z
+    .union([z.boolean(), MessageMetadataPersistenceOptionsSchema])
+    .describe("Controls which assistant message metadata fields are persisted to memory");
 
-export const WorkflowCancelResponseSchema = z.object({
-  success: z.literal(true),
-  data: z
+  const RuntimeMemoryBehaviorOptionsSchema = z
     .object({
-      executionId: z.string(),
-      status: z.literal("cancelled"),
-      cancelledAt: z.string(),
-      reason: z.string().optional(),
+      contextLimit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Number of previous messages to include from memory"),
+      readOnly: z
+        .boolean()
+        .optional()
+        .describe("When true, memory reads are allowed but no memory writes are persisted"),
+      semanticMemory: SemanticMemoryOptionsSchema.optional().describe(
+        "Semantic retrieval configuration for this call",
+      ),
+      conversationPersistence: ConversationPersistenceOptionsSchema.optional().describe(
+        "Per-call conversation persistence behavior",
+      ),
+      messageMetadataPersistence: MessageMetadataPersistenceConfigSchema.optional().describe(
+        "Per-call persisted assistant message metadata behavior",
+      ),
     })
-    .describe("Workflow cancellation result"),
-});
+    .passthrough();
 
-export const WorkflowResumeRequestSchema = z
-  .object({
-    resumeData: z
-      .any()
-      .optional()
-      .describe("Data to pass to the resumed step (validated against step's resumeSchema)"),
+  const RuntimeMemoryEnvelopeSchema = z
+    .object({
+      conversationId: z.string().optional().describe("Conversation identifier for memory scoping"),
+      userId: z.string().optional().describe("User identifier for memory scoping"),
+      options: RuntimeMemoryBehaviorOptionsSchema.optional().describe(
+        "Per-call memory behavior overrides",
+      ),
+    })
+    .passthrough();
+
+  // Generation options schema
+  const GenerateOptionsSchema = z
+    .object({
+      memory: RuntimeMemoryEnvelopeSchema.optional().describe(
+        "Runtime memory envelope (preferred): memory.userId/memory.conversationId + memory.options.*",
+      ),
+      userId: z.string().optional().describe("Deprecated: use options.memory.userId"),
+      conversationId: z
+        .string()
+        .optional()
+        .describe("Deprecated: use options.memory.conversationId"),
+      context: z
+        .record(z.string(), z.unknown())
+        .nullish()
+        .describe("User context for dynamic agent behavior"),
+      contextLimit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(10)
+        .describe("Deprecated: use options.memory.options.contextLimit"),
+      semanticMemory: SemanticMemoryOptionsSchema.optional().describe(
+        "Deprecated: use options.memory.options.semanticMemory",
+      ),
+      conversationPersistence: ConversationPersistenceOptionsSchema.optional().describe(
+        "Deprecated: use options.memory.options.conversationPersistence",
+      ),
+      messageMetadataPersistence: MessageMetadataPersistenceConfigSchema.optional().describe(
+        "Deprecated: use options.memory.options.messageMetadataPersistence",
+      ),
+      maxSteps: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Maximum number of steps for this request"),
+      temperature: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .default(0.7)
+        .describe("Controls randomness (0-1)"),
+      maxOutputTokens: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(4000)
+        .describe("Maximum tokens to generate"),
+      topP: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .default(1.0)
+        .describe("Controls diversity via nucleus sampling (0-1)"),
+      frequencyPenalty: z
+        .number()
+        .min(0)
+        .max(2)
+        .optional()
+        .default(0.0)
+        .describe("Penalizes repeated tokens (0-2)"),
+      presencePenalty: z
+        .number()
+        .min(0)
+        .max(2)
+        .optional()
+        .default(0.0)
+        .describe("Penalizes tokens based on presence (0-2)"),
+      seed: z.number().int().optional().describe("Optional seed for reproducible results"),
+      stopSequences: z.array(z.string()).optional().describe("Stop sequences to end generation"),
+      providerOptions: z
+        .record(z.string(), z.unknown())
+        .nullish()
+        .describe(
+          "Provider-specific options for AI SDK providers (e.g., OpenAI's reasoningEffort)",
+        ),
+      resumableStream: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, avoids wiring the HTTP abort signal into streams so they can be resumed (requires resumable streams and conversation/user IDs via options.memory or top-level legacy fields). If omitted, server defaults may apply.",
+        ),
+      output: z
+        .object({
+          type: z
+            .enum(["object", "text"])
+            .describe("Output type: 'object' for structured JSON, 'text' for text-only output"),
+          schema: BasicJsonSchema.optional().describe(
+            "JSON schema for structured output (required when type is 'object')",
+          ),
+        })
+        .optional()
+        .describe("Structured output configuration for schema-guided generation"),
+      feedback: z
+        .union([z.boolean(), FeedbackOptionsSchema])
+        .optional()
+        .describe("Enable or configure feedback tokens for the trace"),
+    })
+    .passthrough();
+
+  // Text generation schemas
+  const TextRequestSchema = z.object({
+    input: z
+      .union([
+        z.string().describe("Direct text input"),
+        z.array(z.any()).describe("AI SDK message array (UIMessage or ModelMessage format)"),
+      ])
+      .describe("Input text or messages array - accepts string, UIMessage[], or ModelMessage[]"),
+    options: GenerateOptionsSchema.optional().describe("Optional generation parameters"),
+  });
+
+  const TextResponseSchema = z.object({
+    success: z.literal(true),
+    data: z.union([
+      z.string().describe("Generated text response (legacy)"),
+      z
+        .object({
+          text: z.string(),
+          usage: z
+            .object({
+              promptTokens: z.number(),
+              completionTokens: z.number(),
+              totalTokens: z.number(),
+              cachedInputTokens: z.number().optional(),
+              reasoningTokens: z.number().optional(),
+            })
+            .optional(),
+          finishReason: z.string().optional(),
+          toolCalls: z.array(z.any()).optional(),
+          toolResults: z.array(z.any()).optional(),
+          output: z.any().optional().describe("Structured output when output is used"),
+          feedback: z
+            .object({
+              traceId: z.string(),
+              key: z.string(),
+              url: z.string(),
+              tokenId: z.string().optional(),
+              expiresAt: z.string().optional(),
+              feedbackConfig: FeedbackConfigSchema.nullish().optional(),
+              provided: z.boolean().optional(),
+              providedAt: z.string().optional(),
+              feedbackId: z.string().optional(),
+            })
+            .nullable()
+            .optional()
+            .describe("Feedback metadata for the trace"),
+        })
+        .describe("AI SDK formatted response"),
+    ]),
+  });
+
+  // Stream schemas
+  const StreamTextEventSchema = z.object({
+    text: z.string().optional(),
+    timestamp: z.string().datetime().optional(),
+    type: z.enum(["text", "completion", "error"]).optional(),
+    done: z.boolean().optional(),
+    error: z.string().optional(),
+  });
+
+  // Object generation schemas
+  const ObjectRequestSchema = z.object({
+    input: z
+      .union([
+        z.string().describe("Direct text input"),
+        z.array(z.any()).describe("AI SDK message array (UIMessage or ModelMessage format)"),
+      ])
+      .describe("Input text or messages array - accepts string, UIMessage[], or ModelMessage[]"),
+    schema: BasicJsonSchema,
+    options: GenerateOptionsSchema.optional().describe("Optional object generation parameters"),
+  });
+
+  const ObjectResponseSchema = z.object({
+    success: z.literal(true),
+    data: z.object({}).passthrough().describe("Generated object response"),
+  });
+
+  const StreamObjectEventSchema = z.any().describe("Streamed object parts or the final object");
+
+  // Workflow schemas
+  const WorkflowResponseSchema = z.object({
+    id: z.string().describe("Unique workflow identifier"),
+    name: z.string().describe("Human-readable workflow name"),
+    purpose: z.string().describe("Description of what the workflow does"),
+    stepsCount: z.number().int().describe("Number of steps in the workflow"),
+    status: z
+      .enum(["idle", "running", "completed", "error"])
+      .describe("Current status of the workflow"),
+  });
+
+  const WorkflowListSchema = z
+    .array(WorkflowResponseSchema)
+    .describe("Array of workflow objects with their configurations");
+
+  const WorkflowExecutionRequestSchema = z.object({
+    input: z.any().describe("Input data for the workflow"),
     options: z
       .object({
-        stepId: z
-          .string()
-          .optional()
-          .describe("Optional step ID to resume from a specific step instead of the suspended one"),
+        userId: z.string().optional(),
+        conversationId: z.string().optional(),
+        executionId: z.string().optional(),
+        context: z.any().optional(),
+        workflowState: z.record(z.string(), z.any()).optional(),
+        metadata: z.record(z.string(), z.any()).optional(),
       })
       .optional()
-      .describe("Optional resume options"),
-  })
-  .optional();
+      .describe("Optional execution options"),
+  });
 
-export const WorkflowResumeResponseSchema = z.object({
-  success: z.literal(true),
-  data: z
+  const WorkflowExecutionResponseSchema = z.object({
+    success: z.literal(true),
+    data: z
+      .object({
+        executionId: z.string(),
+        startAt: z.string(),
+        endAt: z.string(),
+        status: z.literal("completed"),
+        result: z.any(),
+      })
+      .describe("Workflow execution result"),
+  });
+
+  const WorkflowStreamEventSchema = z.object({
+    type: z.string().describe("Event type"),
+    executionId: z.string().describe("Workflow execution ID"),
+    from: z.string().describe("Source of the event"),
+    input: z.any().optional(),
+    output: z.any().optional(),
+    status: z.enum(["pending", "running", "success", "error", "suspended", "cancelled"]),
+    timestamp: z.string(),
+    stepIndex: z.number().optional(),
+    metadata: z.record(z.string(), z.any()).nullish(),
+    error: z.any().optional(),
+  });
+
+  const WorkflowSuspendRequestSchema = z.object({
+    reason: z.string().optional().describe("Reason for suspension"),
+  });
+
+  const WorkflowSuspendResponseSchema = z.object({
+    success: z.literal(true),
+    data: z
+      .object({
+        executionId: z.string(),
+        status: z.literal("suspended"),
+        suspension: z.object({
+          suspendedAt: z.string(),
+          reason: z.string().optional(),
+        }),
+      })
+      .describe("Workflow suspension result"),
+  });
+
+  const WorkflowCancelRequestSchema = z.object({
+    reason: z.string().optional().describe("Reason for cancellation"),
+  });
+
+  const WorkflowCancelResponseSchema = z.object({
+    success: z.literal(true),
+    data: z
+      .object({
+        executionId: z.string(),
+        status: z.literal("cancelled"),
+        cancelledAt: z.string(),
+        reason: z.string().optional(),
+      })
+      .describe("Workflow cancellation result"),
+  });
+
+  const WorkflowResumeRequestSchema = z
     .object({
-      executionId: z.string(),
-      startAt: z.string(),
-      endAt: z.string().optional(),
-      status: z.string(),
-      result: z.any(),
+      resumeData: z
+        .any()
+        .optional()
+        .describe("Data to pass to the resumed step (validated against step's resumeSchema)"),
+      options: z
+        .object({
+          stepId: z
+            .string()
+            .optional()
+            .describe(
+              "Optional step ID to resume from a specific step instead of the suspended one",
+            ),
+        })
+        .optional()
+        .describe("Optional resume options"),
     })
-    .describe("Workflow resume result"),
-});
+    .optional();
 
-export const WorkflowReplayRequestSchema = z.object({
-  stepId: z.string().min(1).describe("Step ID to replay from"),
-  inputData: z.any().optional().describe("Optional input override for the selected step"),
-  resumeData: z.any().optional().describe("Optional resume payload override"),
-  workflowStateOverride: z
-    .record(z.string(), z.any())
-    .optional()
-    .describe("Optional workflow state override for replay run"),
-});
+  const WorkflowResumeResponseSchema = z.object({
+    success: z.literal(true),
+    data: z
+      .object({
+        executionId: z.string(),
+        startAt: z.string(),
+        endAt: z.string().optional(),
+        status: z.string(),
+        result: z.any(),
+      })
+      .describe("Workflow resume result"),
+  });
 
-export const WorkflowReplayResponseSchema = z.object({
-  success: z.literal(true),
-  data: z
-    .object({
-      executionId: z.string(),
-      startAt: z.string(),
-      endAt: z.string().optional(),
-      status: z.string(),
-      result: z.any(),
-    })
-    .describe("Workflow replay result"),
-});
+  const WorkflowReplayRequestSchema = z.object({
+    stepId: z.string().min(1).describe("Step ID to replay from"),
+    inputData: z.any().optional().describe("Optional input override for the selected step"),
+    resumeData: z.any().optional().describe("Optional resume payload override"),
+    workflowStateOverride: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe("Optional workflow state override for replay run"),
+  });
+
+  const WorkflowReplayResponseSchema = z.object({
+    success: z.literal(true),
+    data: z
+      .object({
+        executionId: z.string(),
+        startAt: z.string(),
+        endAt: z.string().optional(),
+        status: z.string(),
+        result: z.any(),
+      })
+      .describe("Workflow replay result"),
+  });
+
+  return {
+    ParamsSchema,
+    AgentParamsSchema,
+    WorkflowParamsSchema,
+    WorkflowExecutionParamsSchema,
+    ErrorSchema,
+    SubAgentResponseSchema,
+    AgentResponseSchema,
+    AgentListSchema,
+    WorkspaceInfoSchema,
+    WorkspaceFileInfoSchema,
+    WorkspaceFileListSchema,
+    WorkspaceReadFileSchema,
+    WorkspaceSkillMetadataSchema,
+    WorkspaceSkillListItemSchema,
+    WorkspaceSkillListSchema,
+    WorkspaceSkillSchema,
+    BasicJsonSchema,
+    GenerateOptionsSchema,
+    TextRequestSchema,
+    TextResponseSchema,
+    StreamTextEventSchema,
+    ObjectRequestSchema,
+    ObjectResponseSchema,
+    StreamObjectEventSchema,
+    WorkflowResponseSchema,
+    WorkflowListSchema,
+    WorkflowExecutionRequestSchema,
+    WorkflowExecutionResponseSchema,
+    WorkflowStreamEventSchema,
+    WorkflowSuspendRequestSchema,
+    WorkflowSuspendResponseSchema,
+    WorkflowCancelRequestSchema,
+    WorkflowCancelResponseSchema,
+    WorkflowResumeRequestSchema,
+    WorkflowResumeResponseSchema,
+    WorkflowReplayRequestSchema,
+    WorkflowReplayResponseSchema,
+  };
+}
+
+export const {
+  ParamsSchema,
+  AgentParamsSchema,
+  WorkflowParamsSchema,
+  WorkflowExecutionParamsSchema,
+  ErrorSchema,
+  SubAgentResponseSchema,
+  AgentResponseSchema,
+  AgentListSchema,
+  WorkspaceInfoSchema,
+  WorkspaceFileInfoSchema,
+  WorkspaceFileListSchema,
+  WorkspaceReadFileSchema,
+  WorkspaceSkillMetadataSchema,
+  WorkspaceSkillListItemSchema,
+  WorkspaceSkillListSchema,
+  WorkspaceSkillSchema,
+  BasicJsonSchema,
+  GenerateOptionsSchema,
+  TextRequestSchema,
+  TextResponseSchema,
+  StreamTextEventSchema,
+  ObjectRequestSchema,
+  ObjectResponseSchema,
+  StreamObjectEventSchema,
+  WorkflowResponseSchema,
+  WorkflowListSchema,
+  WorkflowExecutionRequestSchema,
+  WorkflowExecutionResponseSchema,
+  WorkflowStreamEventSchema,
+  WorkflowSuspendRequestSchema,
+  WorkflowSuspendResponseSchema,
+  WorkflowCancelRequestSchema,
+  WorkflowCancelResponseSchema,
+  WorkflowResumeRequestSchema,
+  WorkflowResumeResponseSchema,
+  WorkflowReplayRequestSchema,
+  WorkflowReplayResponseSchema,
+} = createServerCoreSchemas();

--- a/packages/server-hono/src/app-factory.spec.ts
+++ b/packages/server-hono/src/app-factory.spec.ts
@@ -1,4 +1,4 @@
-import { TOOL_ROUTES } from "@voltagent/server-core";
+import { TOOL_ROUTES, createServerCoreSchemas } from "@voltagent/server-core";
 import { cors } from "hono/cors";
 import { describe, expect, it } from "vitest";
 import { z as zodV4 } from "zod/v4";
@@ -284,21 +284,6 @@ describe("app-factory CORS configuration", () => {
     expect(doc.paths[TOOL_ROUTES.executeTool.path.replace(":name", "{name}")].post).toBeDefined();
   });
 
-  it("should keep Swagger paths populated when OpenAPI schema generation fails", async () => {
-    const { app } = await createApp(createDeps(), {});
-    app.getOpenAPIDocument = () => {
-      throw new Error("OpenAPI generation failed");
-    };
-
-    const res = await app.request("/doc");
-    const doc = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(doc.paths["/agents"].get).toBeDefined();
-    expect(doc.paths[TOOL_ROUTES.listTools.path].get).toBeDefined();
-    expect(doc.paths[TOOL_ROUTES.executeTool.path.replace(":name", "{name}")].post).toBeDefined();
-  });
-
   it("should keep custom routes public in opt-in mode (default)", async () => {
     const mockAuthProvider = {
       verifyToken: async (token: string) => {
@@ -357,6 +342,34 @@ describe("app-factory CORS configuration", () => {
 });
 
 describe("Zod v4 OpenAPI compatibility", () => {
+  it("should generate docs for server-core schemas created with the active Zod instance", () => {
+    const { AgentListSchema } = createServerCoreSchemas(zodV4 as any);
+    const route = {
+      method: "get",
+      path: "/agents",
+      responses: {
+        200: {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: zodV4.object({
+                success: zodV4.literal(true),
+                data: AgentListSchema,
+              }),
+            },
+          },
+        },
+      },
+    };
+
+    const doc = new OpenApiGeneratorV31([{ type: "route", route }]).generateDocument({
+      openapi: "3.1.0",
+      info: { title: "Server core schema factory regression", version: "1.0.0" },
+    });
+
+    expect(doc.paths["/agents"].get.responses[200]).toBeDefined();
+  });
+
   it("should generate docs for record schemas with explicit key and value types", () => {
     const schema = zodV4.object({
       parameters: zodV4.record(zodV4.string(), zodV4.any()).optional(),

--- a/packages/server-hono/src/app-factory.spec.ts
+++ b/packages/server-hono/src/app-factory.spec.ts
@@ -284,6 +284,21 @@ describe("app-factory CORS configuration", () => {
     expect(doc.paths[TOOL_ROUTES.executeTool.path.replace(":name", "{name}")].post).toBeDefined();
   });
 
+  it("should keep Swagger paths populated when OpenAPI schema generation fails", async () => {
+    const { app } = await createApp(createDeps(), {});
+    app.getOpenAPIDocument = () => {
+      throw new Error("OpenAPI generation failed");
+    };
+
+    const res = await app.request("/doc");
+    const doc = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(doc.paths["/agents"].get).toBeDefined();
+    expect(doc.paths[TOOL_ROUTES.listTools.path].get).toBeDefined();
+    expect(doc.paths[TOOL_ROUTES.executeTool.path.replace(":name", "{name}")].post).toBeDefined();
+  });
+
   it("should keep custom routes public in opt-in mode (default)", async () => {
     const mockAuthProvider = {
       verifyToken: async (token: string) => {

--- a/packages/server-hono/src/routes/agent.routes.ts
+++ b/packages/server-hono/src/routes/agent.routes.ts
@@ -1,24 +1,32 @@
-import {
-  AGENT_ROUTES,
-  AgentListSchema,
+import { AGENT_ROUTES, WORKFLOW_ROUTES, createServerCoreSchemas } from "@voltagent/server-core";
+import { createRoute, z } from "../zod-openapi-compat";
+import { createPathParam } from "./path-params";
+
+const {
+  ParamsSchema,
+  AgentParamsSchema,
+  WorkflowParamsSchema,
+  WorkflowExecutionParamsSchema,
   ErrorSchema,
+  AgentResponseSchema,
+  AgentListSchema,
+  TextRequestSchema,
+  TextResponseSchema,
+  StreamTextEventSchema,
   ObjectRequestSchema,
   ObjectResponseSchema,
   StreamObjectEventSchema,
-  StreamTextEventSchema,
-  TextRequestSchema,
-  TextResponseSchema,
-  WORKFLOW_ROUTES,
-  WorkflowCancelRequestSchema,
-  WorkflowCancelResponseSchema,
+  WorkflowResponseSchema,
+  WorkflowListSchema,
   WorkflowExecutionRequestSchema,
   WorkflowExecutionResponseSchema,
-  WorkflowListSchema,
+  WorkflowStreamEventSchema,
+  WorkflowCancelRequestSchema,
+  WorkflowCancelResponseSchema,
   WorkflowReplayRequestSchema,
   WorkflowReplayResponseSchema,
   WorkflowResumeRequestSchema,
   WorkflowResumeResponseSchema,
-  WorkflowStreamEventSchema,
   WorkflowSuspendRequestSchema,
   WorkflowSuspendResponseSchema,
   WorkspaceFileListSchema,
@@ -26,9 +34,7 @@ import {
   WorkspaceReadFileSchema,
   WorkspaceSkillListSchema,
   WorkspaceSkillSchema,
-} from "@voltagent/server-core";
-import { createRoute, z } from "../zod-openapi-compat";
-import { createPathParam } from "./path-params";
+} = createServerCoreSchemas(z);
 
 const agentIdParam = () => createPathParam("id", "The ID of the agent", "my-agent-123");
 const conversationIdParam = () =>
@@ -37,7 +43,7 @@ const workflowIdParam = () => createPathParam("id", "The ID of the workflow", "m
 const executionIdParam = () =>
   createPathParam("executionId", "The ID of the execution to operate on", "exec_1234567890_abc123");
 
-// Re-export schemas from server-core for backward compatibility
+// Re-export schemas for backward compatibility.
 export {
   ParamsSchema,
   AgentParamsSchema,
@@ -65,7 +71,7 @@ export {
   WorkflowReplayResponseSchema,
   WorkflowResumeRequestSchema,
   WorkflowResumeResponseSchema,
-} from "@voltagent/server-core";
+};
 
 // --- Route Definitions ---
 

--- a/packages/server-hono/src/utils/custom-endpoints.ts
+++ b/packages/server-hono/src/utils/custom-endpoints.ts
@@ -6,6 +6,17 @@ import type { ServerEndpointSummary } from "@voltagent/server-core";
 import { A2A_ROUTES, ALL_ROUTES, MCP_ROUTES } from "@voltagent/server-core";
 import type { OpenAPIHonoType } from "../zod-openapi-compat";
 
+const OPENAPI_METHODS = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
+const OPENAPI_METHOD_SET = new Set(OPENAPI_METHODS.map((method) => method.toUpperCase()));
+const BUILT_IN_ROUTE_DEFINITIONS = [
+  ...Object.values(ALL_ROUTES),
+  ...Object.values(MCP_ROUTES),
+  ...Object.values(A2A_ROUTES),
+];
+const BUILT_IN_ROUTE_MAP = new Map(
+  BUILT_IN_ROUTE_DEFINITIONS.map((route) => [`${route.method.toUpperCase()}:${route.path}`, route]),
+);
+
 /**
  * Known VoltAgent built-in paths that should be excluded when extracting custom endpoints
  */
@@ -79,8 +90,7 @@ export function extractCustomEndpoints(app: OpenAPIHonoType): ServerEndpointSumm
         }
 
         // Check each HTTP method for this path
-        const methods = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
-        methods.forEach((method) => {
+        OPENAPI_METHODS.forEach((method) => {
           const operation = (pathItem as any)[method];
           if (operation) {
             const routeKey = `${method.toUpperCase()}:${path}`;
@@ -144,6 +154,230 @@ function isBuiltInPath(path: string): boolean {
   return false;
 }
 
+function getRoutePath(route: { path: string; basePath?: string }): string {
+  const rawPath = route.basePath ? `${route.basePath}${route.path}` : route.path;
+  return rawPath.replace(/\/+/g, "/");
+}
+
+function toOpenApiPath(path: string): string {
+  return path.replace(/:([a-zA-Z0-9_]+)/g, "{$1}");
+}
+
+function toRouteDefinitionPath(path: string): string {
+  return path.replace(/\{([^}]+)\}/g, ":$1");
+}
+
+function getFallbackTag(path: string): string {
+  if (path.startsWith("/agents")) {
+    return "Agents";
+  }
+  if (path.startsWith("/workflows")) {
+    return "Workflows";
+  }
+  if (path.startsWith("/tools")) {
+    return "Tools";
+  }
+  if (path.startsWith("/api/logs")) {
+    return "Logs";
+  }
+  if (path.startsWith("/observability")) {
+    return "Observability";
+  }
+  if (path.startsWith("/memory")) {
+    return "Memory";
+  }
+  if (path.startsWith("/mcp")) {
+    return "MCP";
+  }
+  if (path.startsWith("/.well-known") || path.startsWith("/a2a")) {
+    return "A2A";
+  }
+  if (path.startsWith("/updates")) {
+    return "Updates";
+  }
+  return isBuiltInPath(path) ? "VoltAgent API" : "Custom Endpoints";
+}
+
+function addEndpointToDoc(doc: any, endpoint: ServerEndpointSummary, pathOverride?: string) {
+  const path = pathOverride ?? endpoint.path;
+  const method = endpoint.method.toLowerCase();
+
+  if (!OPENAPI_METHODS.includes(method as (typeof OPENAPI_METHODS)[number])) {
+    return;
+  }
+
+  doc.paths = doc.paths || {};
+
+  if (!doc.paths[path]) {
+    doc.paths[path] = {};
+  }
+
+  const pathObj = doc.paths[path] as any;
+  if (pathObj[method]) {
+    return;
+  }
+
+  const tag = endpoint.group || getFallbackTag(path);
+  const descriptionPrefix = tag === "Custom Endpoints" ? "Custom endpoint" : `${tag} endpoint`;
+  pathObj[method] = {
+    tags: [tag],
+    summary: endpoint.description || `${endpoint.method} ${path}`,
+    description: endpoint.description || `${descriptionPrefix}: ${endpoint.method} ${path}`,
+    responses: {
+      200: {
+        description: "Successful response",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              additionalProperties: true,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const pathWithBraces = toOpenApiPath(path);
+  if (pathWithBraces.includes("{")) {
+    const params = pathWithBraces.match(/\{([^}]+)\}/g);
+    if (params) {
+      pathObj[method].parameters = params.map((param: string) => {
+        const paramName = param.slice(1, -1);
+        return {
+          name: paramName,
+          in: "path",
+          required: true,
+          schema: { type: "string" },
+          description: `Path parameter: ${paramName}`,
+        };
+      });
+    }
+  }
+
+  if (["post", "put", "patch"].includes(method)) {
+    pathObj[method].requestBody = {
+      content: {
+        "application/json": {
+          schema: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+      },
+    };
+  }
+}
+
+function applyRouteDefinitionMetadata(
+  doc: any,
+  route: (typeof BUILT_IN_ROUTE_DEFINITIONS)[number],
+) {
+  const path = toOpenApiPath(route.path);
+  const method = route.method;
+  const operation = doc.paths?.[path]?.[method];
+  if (!operation) {
+    return;
+  }
+
+  operation.tags = [...route.tags];
+  operation.summary = route.summary;
+  operation.description = route.description;
+  if (route.operationId) {
+    operation.operationId = route.operationId;
+  }
+
+  if (route.responses) {
+    operation.responses = {};
+    Object.entries(route.responses).forEach(([statusCode, response]) => {
+      operation.responses[statusCode] = {
+        description: response.description,
+        ...(response.contentType
+          ? {
+              content: {
+                [response.contentType]: {
+                  schema: {
+                    type: "object",
+                    additionalProperties: true,
+                  },
+                },
+              },
+            }
+          : {}),
+      };
+    });
+  }
+}
+
+function getFallbackOpenApiDocFromRoutes(app: OpenAPIHonoType, baseDoc: any): any {
+  try {
+    if (!app.routes || !Array.isArray(app.routes)) {
+      return baseDoc;
+    }
+
+    const fallbackDoc = {
+      ...baseDoc,
+      openapi: baseDoc.openapi || "3.1.0",
+      paths: { ...(baseDoc.paths || {}) },
+    };
+    const seenRoutes = new Set<string>();
+
+    app.routes.forEach((route) => {
+      const method = route.method.toUpperCase();
+      if (!OPENAPI_METHOD_SET.has(method)) {
+        return;
+      }
+
+      const routePath = getRoutePath(route);
+      if (!routePath || routePath === "*" || routePath === "/" || routePath === "/doc") {
+        return;
+      }
+
+      if (toOpenApiPath(routePath) === "/ui") {
+        return;
+      }
+
+      const routeDefinitionPath = toRouteDefinitionPath(routePath);
+      const routeDefinition = BUILT_IN_ROUTE_MAP.get(`${method}:${routeDefinitionPath}`);
+      if (!routeDefinition) {
+        return;
+      }
+
+      const openApiPath = toOpenApiPath(routeDefinition.path);
+      const routeKey = `${method}:${openApiPath}`;
+      if (seenRoutes.has(routeKey)) {
+        return;
+      }
+
+      seenRoutes.add(routeKey);
+      addEndpointToDoc(
+        fallbackDoc,
+        {
+          method,
+          path: openApiPath,
+          group: routeDefinition.tags[0] || getFallbackTag(routePath),
+        },
+        openApiPath,
+      );
+      applyRouteDefinitionMetadata(fallbackDoc, routeDefinition);
+    });
+
+    extractCustomEndpoints(app).forEach((endpoint) => {
+      const routeKey = `${endpoint.method}:${endpoint.path}`;
+      if (seenRoutes.has(routeKey)) {
+        return;
+      }
+
+      seenRoutes.add(routeKey);
+      addEndpointToDoc(fallbackDoc, endpoint);
+    });
+
+    return seenRoutes.size > 0 ? fallbackDoc : baseDoc;
+  } catch (_fallbackError) {
+    return baseDoc;
+  }
+}
+
 /**
  * Get enhanced OpenAPI document that includes custom endpoints
  * @param app The Hono OpenAPI app instance
@@ -164,84 +398,14 @@ export function getEnhancedOpenApiDoc(app: OpenAPIHonoType, baseDoc: any): any {
     // Add custom endpoints to the OpenAPI document
     fullDoc.paths = fullDoc.paths || {};
 
-    customEndpoints.forEach((endpoint) => {
-      const path = endpoint.path;
-      const method = endpoint.method.toLowerCase();
-
-      // Initialize path object if it doesn't exist
-      if (!fullDoc.paths[path]) {
-        fullDoc.paths[path] = {};
-      }
-
-      // Skip if this operation already exists in OpenAPI doc (don't overwrite)
-      const pathObj = fullDoc.paths[path] as any;
-      if (pathObj[method]) {
-        return;
-      }
-
-      // Add the operation for this method (only for routes not in OpenAPI doc)
-      pathObj[method] = {
-        tags: ["Custom Endpoints"],
-        summary: endpoint.description || `${endpoint.method} ${path}`,
-        description: endpoint.description || `Custom endpoint: ${endpoint.method} ${path}`,
-        responses: {
-          200: {
-            description: "Successful response",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    success: { type: "boolean" },
-                    data: { type: "object" },
-                  },
-                },
-              },
-            },
-          },
-        },
-      };
-
-      // Add parameters for path variables (support both :param and {param} formats)
-      const pathWithBraces = path.replace(/:([a-zA-Z0-9_]+)/g, "{$1}");
-      if (pathWithBraces.includes("{")) {
-        const params = pathWithBraces.match(/\{([^}]+)\}/g);
-        if (params) {
-          pathObj[method].parameters = params.map((param: string) => {
-            const paramName = param.slice(1, -1); // Remove { and }
-            return {
-              name: paramName,
-              in: "path",
-              required: true,
-              schema: { type: "string" },
-              description: `Path parameter: ${paramName}`,
-            };
-          });
-        }
-      }
-
-      // Add request body for POST/PUT/PATCH methods
-      if (["post", "put", "patch"].includes(method)) {
-        pathObj[method].requestBody = {
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                additionalProperties: true,
-              },
-            },
-          },
-        };
-      }
-    });
+    customEndpoints.forEach((endpoint) => addEndpointToDoc(fullDoc, endpoint));
 
     // Ensure proper tags for organization of existing routes
     if (fullDoc.paths) {
       Object.entries(fullDoc.paths).forEach(([path, pathItem]) => {
         if (pathItem && !isBuiltInPath(path)) {
           // Add "Custom Endpoints" tag to custom routes for better organization
-          const methods = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
-          methods.forEach((method) => {
+          OPENAPI_METHODS.forEach((method) => {
             const operation = (pathItem as any)[method];
             if (operation) {
               operation.tags = operation.tags || [];
@@ -257,6 +421,6 @@ export function getEnhancedOpenApiDoc(app: OpenAPIHonoType, baseDoc: any): any {
     return fullDoc;
   } catch (error) {
     console.warn("Failed to enhance OpenAPI document with custom endpoints:", error);
-    return baseDoc;
+    return getFallbackOpenApiDocFromRoutes(app, baseDoc);
   }
 }

--- a/packages/server-hono/src/utils/custom-endpoints.ts
+++ b/packages/server-hono/src/utils/custom-endpoints.ts
@@ -6,17 +6,6 @@ import type { ServerEndpointSummary } from "@voltagent/server-core";
 import { A2A_ROUTES, ALL_ROUTES, MCP_ROUTES } from "@voltagent/server-core";
 import type { OpenAPIHonoType } from "../zod-openapi-compat";
 
-const OPENAPI_METHODS = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
-const OPENAPI_METHOD_SET = new Set(OPENAPI_METHODS.map((method) => method.toUpperCase()));
-const BUILT_IN_ROUTE_DEFINITIONS = [
-  ...Object.values(ALL_ROUTES),
-  ...Object.values(MCP_ROUTES),
-  ...Object.values(A2A_ROUTES),
-];
-const BUILT_IN_ROUTE_MAP = new Map(
-  BUILT_IN_ROUTE_DEFINITIONS.map((route) => [`${route.method.toUpperCase()}:${route.path}`, route]),
-);
-
 /**
  * Known VoltAgent built-in paths that should be excluded when extracting custom endpoints
  */
@@ -90,7 +79,8 @@ export function extractCustomEndpoints(app: OpenAPIHonoType): ServerEndpointSumm
         }
 
         // Check each HTTP method for this path
-        OPENAPI_METHODS.forEach((method) => {
+        const methods = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
+        methods.forEach((method) => {
           const operation = (pathItem as any)[method];
           if (operation) {
             const routeKey = `${method.toUpperCase()}:${path}`;
@@ -154,230 +144,6 @@ function isBuiltInPath(path: string): boolean {
   return false;
 }
 
-function getRoutePath(route: { path: string; basePath?: string }): string {
-  const rawPath = route.basePath ? `${route.basePath}${route.path}` : route.path;
-  return rawPath.replace(/\/+/g, "/");
-}
-
-function toOpenApiPath(path: string): string {
-  return path.replace(/:([a-zA-Z0-9_]+)/g, "{$1}");
-}
-
-function toRouteDefinitionPath(path: string): string {
-  return path.replace(/\{([^}]+)\}/g, ":$1");
-}
-
-function getFallbackTag(path: string): string {
-  if (path.startsWith("/agents")) {
-    return "Agents";
-  }
-  if (path.startsWith("/workflows")) {
-    return "Workflows";
-  }
-  if (path.startsWith("/tools")) {
-    return "Tools";
-  }
-  if (path.startsWith("/api/logs")) {
-    return "Logs";
-  }
-  if (path.startsWith("/observability")) {
-    return "Observability";
-  }
-  if (path.startsWith("/memory")) {
-    return "Memory";
-  }
-  if (path.startsWith("/mcp")) {
-    return "MCP";
-  }
-  if (path.startsWith("/.well-known") || path.startsWith("/a2a")) {
-    return "A2A";
-  }
-  if (path.startsWith("/updates")) {
-    return "Updates";
-  }
-  return isBuiltInPath(path) ? "VoltAgent API" : "Custom Endpoints";
-}
-
-function addEndpointToDoc(doc: any, endpoint: ServerEndpointSummary, pathOverride?: string) {
-  const path = pathOverride ?? endpoint.path;
-  const method = endpoint.method.toLowerCase();
-
-  if (!OPENAPI_METHODS.includes(method as (typeof OPENAPI_METHODS)[number])) {
-    return;
-  }
-
-  doc.paths = doc.paths || {};
-
-  if (!doc.paths[path]) {
-    doc.paths[path] = {};
-  }
-
-  const pathObj = doc.paths[path] as any;
-  if (pathObj[method]) {
-    return;
-  }
-
-  const tag = endpoint.group || getFallbackTag(path);
-  const descriptionPrefix = tag === "Custom Endpoints" ? "Custom endpoint" : `${tag} endpoint`;
-  pathObj[method] = {
-    tags: [tag],
-    summary: endpoint.description || `${endpoint.method} ${path}`,
-    description: endpoint.description || `${descriptionPrefix}: ${endpoint.method} ${path}`,
-    responses: {
-      200: {
-        description: "Successful response",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              additionalProperties: true,
-            },
-          },
-        },
-      },
-    },
-  };
-
-  const pathWithBraces = toOpenApiPath(path);
-  if (pathWithBraces.includes("{")) {
-    const params = pathWithBraces.match(/\{([^}]+)\}/g);
-    if (params) {
-      pathObj[method].parameters = params.map((param: string) => {
-        const paramName = param.slice(1, -1);
-        return {
-          name: paramName,
-          in: "path",
-          required: true,
-          schema: { type: "string" },
-          description: `Path parameter: ${paramName}`,
-        };
-      });
-    }
-  }
-
-  if (["post", "put", "patch"].includes(method)) {
-    pathObj[method].requestBody = {
-      content: {
-        "application/json": {
-          schema: {
-            type: "object",
-            additionalProperties: true,
-          },
-        },
-      },
-    };
-  }
-}
-
-function applyRouteDefinitionMetadata(
-  doc: any,
-  route: (typeof BUILT_IN_ROUTE_DEFINITIONS)[number],
-) {
-  const path = toOpenApiPath(route.path);
-  const method = route.method;
-  const operation = doc.paths?.[path]?.[method];
-  if (!operation) {
-    return;
-  }
-
-  operation.tags = [...route.tags];
-  operation.summary = route.summary;
-  operation.description = route.description;
-  if (route.operationId) {
-    operation.operationId = route.operationId;
-  }
-
-  if (route.responses) {
-    operation.responses = {};
-    Object.entries(route.responses).forEach(([statusCode, response]) => {
-      operation.responses[statusCode] = {
-        description: response.description,
-        ...(response.contentType
-          ? {
-              content: {
-                [response.contentType]: {
-                  schema: {
-                    type: "object",
-                    additionalProperties: true,
-                  },
-                },
-              },
-            }
-          : {}),
-      };
-    });
-  }
-}
-
-function getFallbackOpenApiDocFromRoutes(app: OpenAPIHonoType, baseDoc: any): any {
-  try {
-    if (!app.routes || !Array.isArray(app.routes)) {
-      return baseDoc;
-    }
-
-    const fallbackDoc = {
-      ...baseDoc,
-      openapi: baseDoc.openapi || "3.1.0",
-      paths: { ...(baseDoc.paths || {}) },
-    };
-    const seenRoutes = new Set<string>();
-
-    app.routes.forEach((route) => {
-      const method = route.method.toUpperCase();
-      if (!OPENAPI_METHOD_SET.has(method)) {
-        return;
-      }
-
-      const routePath = getRoutePath(route);
-      if (!routePath || routePath === "*" || routePath === "/" || routePath === "/doc") {
-        return;
-      }
-
-      if (toOpenApiPath(routePath) === "/ui") {
-        return;
-      }
-
-      const routeDefinitionPath = toRouteDefinitionPath(routePath);
-      const routeDefinition = BUILT_IN_ROUTE_MAP.get(`${method}:${routeDefinitionPath}`);
-      if (!routeDefinition) {
-        return;
-      }
-
-      const openApiPath = toOpenApiPath(routeDefinition.path);
-      const routeKey = `${method}:${openApiPath}`;
-      if (seenRoutes.has(routeKey)) {
-        return;
-      }
-
-      seenRoutes.add(routeKey);
-      addEndpointToDoc(
-        fallbackDoc,
-        {
-          method,
-          path: openApiPath,
-          group: routeDefinition.tags[0] || getFallbackTag(routePath),
-        },
-        openApiPath,
-      );
-      applyRouteDefinitionMetadata(fallbackDoc, routeDefinition);
-    });
-
-    extractCustomEndpoints(app).forEach((endpoint) => {
-      const routeKey = `${endpoint.method}:${endpoint.path}`;
-      if (seenRoutes.has(routeKey)) {
-        return;
-      }
-
-      seenRoutes.add(routeKey);
-      addEndpointToDoc(fallbackDoc, endpoint);
-    });
-
-    return seenRoutes.size > 0 ? fallbackDoc : baseDoc;
-  } catch (_fallbackError) {
-    return baseDoc;
-  }
-}
-
 /**
  * Get enhanced OpenAPI document that includes custom endpoints
  * @param app The Hono OpenAPI app instance
@@ -398,14 +164,84 @@ export function getEnhancedOpenApiDoc(app: OpenAPIHonoType, baseDoc: any): any {
     // Add custom endpoints to the OpenAPI document
     fullDoc.paths = fullDoc.paths || {};
 
-    customEndpoints.forEach((endpoint) => addEndpointToDoc(fullDoc, endpoint));
+    customEndpoints.forEach((endpoint) => {
+      const path = endpoint.path;
+      const method = endpoint.method.toLowerCase();
+
+      // Initialize path object if it doesn't exist
+      if (!fullDoc.paths[path]) {
+        fullDoc.paths[path] = {};
+      }
+
+      // Skip if this operation already exists in OpenAPI doc (don't overwrite)
+      const pathObj = fullDoc.paths[path] as any;
+      if (pathObj[method]) {
+        return;
+      }
+
+      // Add the operation for this method (only for routes not in OpenAPI doc)
+      pathObj[method] = {
+        tags: ["Custom Endpoints"],
+        summary: endpoint.description || `${endpoint.method} ${path}`,
+        description: endpoint.description || `Custom endpoint: ${endpoint.method} ${path}`,
+        responses: {
+          200: {
+            description: "Successful response",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean" },
+                    data: { type: "object" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      // Add parameters for path variables (support both :param and {param} formats)
+      const pathWithBraces = path.replace(/:([a-zA-Z0-9_]+)/g, "{$1}");
+      if (pathWithBraces.includes("{")) {
+        const params = pathWithBraces.match(/\{([^}]+)\}/g);
+        if (params) {
+          pathObj[method].parameters = params.map((param: string) => {
+            const paramName = param.slice(1, -1); // Remove { and }
+            return {
+              name: paramName,
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: `Path parameter: ${paramName}`,
+            };
+          });
+        }
+      }
+
+      // Add request body for POST/PUT/PATCH methods
+      if (["post", "put", "patch"].includes(method)) {
+        pathObj[method].requestBody = {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                additionalProperties: true,
+              },
+            },
+          },
+        };
+      }
+    });
 
     // Ensure proper tags for organization of existing routes
     if (fullDoc.paths) {
       Object.entries(fullDoc.paths).forEach(([path, pathItem]) => {
         if (pathItem && !isBuiltInPath(path)) {
           // Add "Custom Endpoints" tag to custom routes for better organization
-          OPENAPI_METHODS.forEach((method) => {
+          const methods = ["get", "post", "put", "patch", "delete", "options", "head"] as const;
+          methods.forEach((method) => {
             const operation = (pathItem as any)[method];
             if (operation) {
               operation.tags = operation.tags || [];
@@ -421,6 +257,6 @@ export function getEnhancedOpenApiDoc(app: OpenAPIHonoType, baseDoc: any): any {
     return fullDoc;
   } catch (error) {
     console.warn("Failed to enhance OpenAPI document with custom endpoints:", error);
-    return getFallbackOpenApiDocFromRoutes(app, baseDoc);
+    return baseDoc;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`server-hono` composes some OpenAPI route schemas with its own `zod-openapi-compat` Zod instance, while nested schemas are imported as already-created Zod schemas from `server-core`.

When package resolution gives those packages different Zod instances or major versions, the Zod v4 OpenAPI generator can reject nested schemas with errors like `Invalid element at key "data": expected a Zod schema`. That causes `/doc` generation to fail and Swagger UI to show an empty API list.

## What is the new behavior?

`server-core` schema definitions can now be created through a schema factory. `server-hono` uses that factory with the active Zod instance from `zod-openapi-compat`, so built-in Swagger route schemas are composed from one compatible Zod instance.

This fixes the OpenAPI generation failure directly instead of adding a Swagger fallback path.

fixes #1222

## Notes for reviewers

Validation run:

- `pnpm --filter @voltagent/server-core build`
- `pnpm --filter @voltagent/server-hono build`
- `pnpm --filter @voltagent/server-hono test -- src/app-factory.spec.ts src/utils/custom-endpoints.spec.ts`
- `pnpm --filter @voltagent/server-core test -- src/schemas/agent.schemas.spec.ts`
- `pnpm exec biome check .changeset/smart-swagger-paths.md packages/server-core/src/schemas/agent.schemas.ts packages/server-hono/src/routes/agent.routes.ts packages/server-hono/src/app-factory.spec.ts`

I also reproduced the issue from `examples/base` and verified `/doc` stays populated with Zod v3, Zod v4, and the previously failing mixed Zod resolution case.

Docs were not updated because this is a runtime bug fix for existing Swagger behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved API documentation endpoint stability and reliability by implementing consistent schema handling across the application to prevent documentation generation failures that could occur from conflicting schema instances or version mismatches.

* **Tests**
  * Added OpenAPI compatibility tests to validate that the documentation endpoint functions properly and schemas are managed consistently throughout the application platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->