### PR TITLE
fix(core): apply global workspace to registered agents

### DIFF
--- a/.changeset/global-workspace-default.md
+++ b/.changeset/global-workspace-default.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Apply VoltAgent global workspace defaults to agents that are constructed before registration.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -544,9 +544,14 @@ const isWorkspaceSkillsToolkitEnabled = (options: AgentOptions["workspaceToolkit
   return options.skills !== false;
 };
 
+type WorkspaceSkillsPromptResolutionOptions = Pick<
+  AgentOptions,
+  "hooks" | "workspaceSkillsPrompt" | "workspaceToolkits"
+>;
+
 const resolveWorkspaceSkillsPromptHook = (
   workspace: Workspace | undefined,
-  options: AgentOptions,
+  options: WorkspaceSkillsPromptResolutionOptions,
 ): AgentHooks["onPrepareMessages"] | undefined => {
   const existingHook = options.hooks?.onPrepareMessages;
   if (!workspace?.skills) {
@@ -973,10 +978,10 @@ export class Agent {
   readonly instructions: InstructionsDynamicValue;
   readonly model: AgentModelValue;
   readonly dynamicTools?: DynamicValue<(Tool<any, any> | Toolkit)[]>;
-  readonly hooks: AgentHooks;
+  hooks: AgentHooks;
   readonly temperature?: number;
   readonly maxOutputTokens?: number;
-  readonly maxSteps: number;
+  maxSteps: number;
   readonly maxRetries: number;
   readonly stopWhen?: StopWhen;
   readonly prepareStep?: PrepareStep;
@@ -995,7 +1000,12 @@ export class Agent {
   private conversationPersistence: ResolvedConversationPersistenceOptions;
   private readonly messageMetadataPersistence: ResolvedMessageMetadataPersistenceOptions;
   private conversationPersistenceConfigured: boolean;
-  private readonly workspace?: Workspace;
+  private workspace?: Workspace;
+  private readonly workspaceConfigured: boolean;
+  private readonly workspaceToolkitOptions: AgentOptions["workspaceToolkits"];
+  private readonly workspaceSkillsPromptOption: AgentOptions["workspaceSkillsPrompt"];
+  private readonly configuredHooks?: AgentHooks;
+  private readonly maxStepsConfigured: boolean;
   private defaultObservability?: VoltAgentObservability;
   private readonly toolManager: ToolManager;
   private readonly toolPoolManager: ToolManager;
@@ -1025,6 +1035,11 @@ export class Agent {
     this.instructions = options.instructions;
     this.model = options.model;
     this.dynamicTools = typeof options.tools === "function" ? options.tools : undefined;
+    this.workspaceConfigured = options.workspace !== undefined;
+    this.workspaceToolkitOptions = options.workspaceToolkits;
+    this.workspaceSkillsPromptOption = options.workspaceSkillsPrompt;
+    this.configuredHooks = options.hooks;
+    this.maxStepsConfigured = options.maxSteps !== undefined;
     const globalWorkspace = AgentRegistry.getInstance().getGlobalWorkspace();
     const workspaceOption = options.workspace === undefined ? globalWorkspace : options.workspace;
     this.workspace = resolveWorkspace(workspaceOption);
@@ -8199,6 +8214,38 @@ export class Agent {
 
     this.conversationPersistence =
       this.normalizeConversationPersistenceOptions(conversationPersistence);
+  }
+
+  /**
+   * Internal: apply a default Workspace instance when none was configured explicitly.
+   */
+  public __setDefaultWorkspace(workspace: Workspace): void {
+    if (this.workspaceConfigured || this.workspace) {
+      return;
+    }
+
+    this.workspace = workspace;
+    if (!this.maxStepsConfigured) {
+      this.maxSteps = 100;
+    }
+
+    const hookOptions = {
+      hooks: this.configuredHooks,
+      workspaceToolkits: this.workspaceToolkitOptions,
+      workspaceSkillsPrompt: this.workspaceSkillsPromptOption,
+    };
+    const onPrepareMessages = resolveWorkspaceSkillsPromptHook(this.workspace, hookOptions);
+    this.hooks = onPrepareMessages
+      ? { ...(this.configuredHooks || {}), onPrepareMessages }
+      : this.configuredHooks || {};
+
+    const workspaceToolkits = buildWorkspaceToolkits(this.workspace, this.workspaceToolkitOptions);
+    if (workspaceToolkits.length > 0) {
+      this.toolManager.addItems(workspaceToolkits);
+      if (this.toolRouting && !this.toolRoutingPoolExplicit) {
+        this.toolPoolManager.addItems(workspaceToolkits);
+      }
+    }
   }
 
   /**

--- a/packages/core/src/voltagent.spec.ts
+++ b/packages/core/src/voltagent.spec.ts
@@ -10,6 +10,7 @@ import { VoltOpsClient } from "./voltops/client";
 import { createWorkflow } from "./workflow";
 import { WorkflowRegistry } from "./workflow/registry";
 import { andThen } from "./workflow/steps";
+import { Workspace } from "./workspace";
 
 const resetRegistries = () => {
   const agentRegistry = AgentRegistry.getInstance() as {
@@ -21,6 +22,8 @@ const resetRegistries = () => {
   AgentRegistry.getInstance().setGlobalAgentMemory(undefined);
   AgentRegistry.getInstance().setGlobalWorkflowMemory(undefined);
   AgentRegistry.getInstance().setGlobalMemory(undefined);
+  AgentRegistry.getInstance().setGlobalWorkspace(undefined);
+  AgentRegistry.getInstance().setGlobalToolRouting(undefined);
 
   const workflowRegistry = WorkflowRegistry.getInstance() as {
     workflows?: Map<string, unknown>;
@@ -54,6 +57,33 @@ describe("VoltAgent defaults", () => {
     });
 
     expect(agent.getMemory()).toBe(agentMemory);
+  });
+
+  it("applies workspace to preconstructed registered agents without explicit workspace", async () => {
+    const workspace = new Workspace({ id: "global-workspace" });
+    const agent = new Agent({
+      name: "assistant",
+      instructions: "Be helpful.",
+      model: "openai/gpt-4o-mini",
+    });
+
+    expect(agent.getWorkspace()).toBeUndefined();
+    expect(agent.getTools()).toHaveLength(0);
+
+    const voltAgent = new VoltAgent({
+      agents: { assistant: agent },
+      workspace,
+      checkDependencies: false,
+    });
+
+    expect(agent.getWorkspace()).toBe(workspace);
+    expect(agent.maxSteps).toBe(100);
+    expect(agent.getTools().map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(["ls", "read_file", "execute_command", "workspace_search"]),
+    );
+
+    await voltAgent.ready;
+    await voltAgent.shutdown();
   });
 
   it("applies workflowMemory to registered workflows without explicit memory", () => {

--- a/packages/core/src/voltagent.ts
+++ b/packages/core/src/voltagent.ts
@@ -85,6 +85,7 @@ export class VoltAgent {
           ? options.workspace
           : new Workspace(options.workspace);
       this.registry.setGlobalWorkspace(workspaceInstance);
+      this.applyDefaultWorkspaceToAgents(options.agents);
       workspaceInitPromise = workspaceInstance.init();
     }
 
@@ -519,6 +520,21 @@ export class VoltAgent {
     agent.__setDefaultConversationPersistence?.(this.defaultAgentConversationPersistence);
   }
 
+  private applyDefaultWorkspaceToAgent(agent: Agent): void {
+    const workspace = this.registry.getGlobalWorkspace();
+    if (!workspace) {
+      return;
+    }
+    agent.__setDefaultWorkspace?.(workspace);
+  }
+
+  private applyDefaultWorkspaceToAgents(agents?: Record<string, Agent>): void {
+    if (!agents) {
+      return;
+    }
+    Object.values(agents).forEach((agent) => this.applyDefaultWorkspaceToAgent(agent));
+  }
+
   private applyDefaultMemoryToWorkflow(
     workflow: Workflow<
       DangerouslyAllowAny,
@@ -540,6 +556,7 @@ export class VoltAgent {
     // Register the agent
     this.applyDefaultMemoryToAgent(agent);
     this.applyDefaultConversationPersistenceToAgent(agent);
+    this.applyDefaultWorkspaceToAgent(agent);
     agent.__setDefaultToolRouting?.(this.registry.getGlobalToolRouting());
     this.registry.registerAgent(agent);
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not needed for this bug fix)
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Agents constructed before `new VoltAgent({ workspace })` do not inherit the global workspace. This means workspace toolkits are missing unless the workspace is passed directly to the `Agent` constructor.

## What is the new behavior?

`VoltAgent` now applies the configured global workspace to registered agents that did not explicitly configure a workspace. This adds the workspace toolkits, preserves explicit `workspace: false`, and keeps workspace defaults such as `maxSteps`.

fixes #1227

## Notes for reviewers

Reproduced in `examples/with-workspace`: before the fix the agent had `workspace missing` and only `currentDate`; after the fix it has the workspace id and the expected workspace tools.

Validation run:

- `pnpm --filter @voltagent/core test:single -- src/voltagent.spec.ts src/workspace/index.spec.ts`
- `pnpm --filter @voltagent/core typecheck`
- `pnpm --filter @voltagent/core build`
- `pnpm --dir examples/with-workspace build`
- `pnpm biome check .changeset/global-workspace-default.md packages/core/src/agent/agent.ts packages/core/src/voltagent.ts packages/core/src/voltagent.spec.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agents created before registration not inheriting the global workspace. Registered agents without an explicit workspace now get workspace defaults and toolkits. Fixes #1227 in `@voltagent/core`.

- **Bug Fixes**
  - Apply global workspace to preconstructed agents that didn’t set one.
  - Preserve explicit workspace settings, including `workspace: false`.
  - Add workspace toolkits (and tool routing pool when enabled).
  - Set default `maxSteps` (100) and apply the workspace skills prompt hook when applicable.

<sup>Written for commit 6b2552faf40d6d90317550a3695f47754d056b50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents created without an explicit workspace now automatically inherit workspace configuration from their parent VoltAgent, including when created before registration.
  * Default maximum steps automatically configured to 100 for agents using inherited workspace settings, reducing manual configuration overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->