### PR TITLE
fix(server-core): publish schema factory required by server-hono

### DIFF
--- a/.changeset/silver-rules-report.md
+++ b/.changeset/silver-rules-report.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/server-core": patch
+---
+
+fix(server-core): publish schema factory required by server-hono
+
+Publishes the `createServerCoreSchemas` export used by `@voltagent/server-hono` to build Swagger
+schemas with the active Zod instance. This keeps `server-hono` releases from resolving against a
+`server-core` package that does not provide the required runtime export.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`@voltagent/server-hono@2.0.12` imports the new `createServerCoreSchemas` runtime export from `@voltagent/server-core`, but only `server-hono` was published. The latest published `server-core` is still `2.1.14`, which does not provide that export.

That can fail at startup with:

```txt
The requested module '@voltagent/server-core' does not provide an export named 'createServerCoreSchemas'
```

## What is the new behavior?

This changeset publishes `@voltagent/server-core` as a patch release so the runtime export required by `server-hono` is available from the registry.

`server-hono@2.0.12` already accepts `@voltagent/server-core` through `^2.1.14`, so publishing the patch release is enough for fresh installs and Deno reloads to resolve the matching package.

fixes #1222

## Notes for reviewers

Validation run:

- `pnpm --filter @voltagent/server-core test -- src/schemas/agent.schemas.spec.ts`
- `pnpm exec biome check .changeset/silver-rules-report.md packages/server-core/src/schemas/agent.schemas.ts packages/server-hono/src/routes/agent.routes.ts packages/server-hono/src/app-factory.spec.ts`

Docs were not updated because this is a release coordination hotfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version of `@voltagent/server-core` package. The `createServerCoreSchemas` runtime export is now publicly available for dependent packages requiring schema generation integration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish a patch of `@voltagent/server-core` to expose `createServerCoreSchemas` required by `@voltagent/server-hono@2.0.12`, preventing startup errors from a missing export.

- **Bug Fixes**
  - Exposes `createServerCoreSchemas` so Swagger schemas build with the active Zod instance.
  - Ensures fresh installs and Deno reloads resolve a compatible `server-core` via the existing `^2.1.14` range.

<sup>Written for commit 0f82a1ac4a8cbd90856c6d0cfeab5f5af482cb55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

