### PR TITLE
fix(server-hono): require server-core schema factory release

### DIFF
--- a/.changeset/silver-rules-report.md
+++ b/.changeset/silver-rules-report.md
@@ -1,9 +1,10 @@
 ---
 "@voltagent/server-core": patch
+"@voltagent/server-hono": patch
 ---
 
-fix(server-core): publish schema factory required by server-hono
+fix(server-hono): require server-core schema factory release
 
 Publishes the `createServerCoreSchemas` export used by `@voltagent/server-hono` to build Swagger
-schemas with the active Zod instance. This keeps `server-hono` releases from resolving against a
-`server-core` package that does not provide the required runtime export.
+schemas with the active Zod instance, and updates `server-hono` to require a `server-core` release
+that provides the runtime export.

--- a/packages/server-hono/package.json
+++ b/packages/server-hono/package.json
@@ -10,7 +10,7 @@
     "@voltagent/internal": "^1.0.2",
     "@voltagent/mcp-server": "^2.0.2",
     "@voltagent/resumable-streams": "^2.0.1",
-    "@voltagent/server-core": "^2.1.14",
+    "@voltagent/server-core": "^2.1.15",
     "fetch-to-node": "^2.1.0",
     "hono": "^4.7.7",
     "openapi3-ts": "^4.5.0"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`@voltagent/server-hono@2.0.12` imports `createServerCoreSchemas` from `@voltagent/server-core`, but its dependency range still allows installs to resolve a `server-core` version that does not publish that runtime export. That can produce:

```txt
The requested module @voltagent/server-core does not provide an export named createServerCoreSchemas
```

## What is the new behavior?

Updates the existing hotfix changeset so both `@voltagent/server-core` and `@voltagent/server-hono` receive patch releases, and raises the `server-hono` dependency floor for `@voltagent/server-core` to `^2.1.15`.

This makes the follow-up `server-hono` patch release resolve against a `server-core` release that provides `createServerCoreSchemas`.

fixes #1222

## Notes for reviewers

This is a release metadata hotfix only; no runtime code changed in this PR, so no runtime tests were added.

Validation:

- `node -e "JSON.parse(require('fs').readFileSync('packages/server-hono/package.json','utf8'))"`
- `pnpm exec prettier --check .changeset/silver-rules-report.md packages/server-hono/package.json`