### PR TITLE
fix(core): support reasoning models in generateTitle by making temperature configurable

### DIFF
--- a/.changeset/fix-generatetitle-reasoning-models.md
+++ b/.changeset/fix-generatetitle-reasoning-models.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/core": patch
+---
+
+fix(core): support reasoning models in generateTitle by making temperature configurable
+
+Reasoning models (gpt-5-mini, o1, o3) reject the `temperature` parameter. Previously, `generateTitle` hardcoded `temperature: 0`, causing silent failures that fell back to the default "Conversation" title.
+
+Temperature is now omitted by default (letting the AI SDK / provider decide), and can be explicitly set via `generateTitle.temperature` in `ConversationTitleConfig`. The error log level is also upgraded from `debug` to `warn` for better visibility.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4789,7 +4789,10 @@ export class Agent {
         }
       } catch (error) {
         context.logger.warn("[Memory] Failed to generate conversation title", {
-          error: safeStringify(error),
+          error:
+            error instanceof Error
+              ? { name: error.name, message: error.message }
+              : safeStringify(error),
         });
         return null;
       }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4723,6 +4723,7 @@ export class Agent {
         : DEFAULT_CONVERSATION_TITLE_MAX_CHARS;
 
     const modelOverride = normalized.model;
+    const titleTemperature = normalized.temperature;
 
     return async ({ input, context }) => {
       const inputForQuery = typeof input === "string" || Array.isArray(input) ? input : [input];
@@ -4751,7 +4752,7 @@ export class Agent {
           isStreaming: false,
           messages,
           callOptions: {
-            temperature: 0,
+            ...(titleTemperature !== undefined ? { temperature: titleTemperature } : {}),
             maxOutputTokens,
           },
           label: "Generate Conversation Title",
@@ -4764,7 +4765,7 @@ export class Agent {
             generateText({
               model: resolvedModel,
               messages,
-              temperature: 0,
+              ...(titleTemperature !== undefined ? { temperature: titleTemperature } : {}),
               maxOutputTokens,
               abortSignal: context.abortController.signal,
             }),
@@ -4787,7 +4788,7 @@ export class Agent {
           throw error;
         }
       } catch (error) {
-        context.logger.debug("[Memory] Failed to generate conversation title", {
+        context.logger.warn("[Memory] Failed to generate conversation title", {
           error: safeStringify(error),
         });
         return null;

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -107,6 +107,7 @@ export type ConversationTitleConfig = {
   maxOutputTokens?: number;
   maxLength?: number;
   systemPrompt?: string | null;
+  temperature?: number;
 };
 
 export type ConversationTitleGenerator = (params: {


### PR DESCRIPTION
## Summary

Fixes #1233

`generateTitle` silently fails with reasoning models (`gpt-5-mini`, `o1`, `o3`) because `temperature: 0` is hardcoded in the `generateText` call. Reasoning models reject the `temperature` parameter, causing the call to error and fall back to the default `"Conversation"` title.

## Changes

- **Remove hardcoded `temperature: 0`** from `createConversationTitleGenerator` — temperature is now omitted by default, letting the AI SDK / provider use its own default
- **Add `temperature` field to `ConversationTitleConfig`** — users who want deterministic titles with non-reasoning models can explicitly set `temperature: 0`
- **Upgrade error log from `debug` to `warn`** — makes title generation failures visible without enabling debug logging

## How to test

1. Configure an agent with a reasoning model (e.g. `openai/gpt-5-mini`)
2. Enable `generateTitle: true` on Memory
3. Start a conversation → title should now be generated instead of falling back to `"Conversation"`
4. Optionally set `generateTitle: { temperature: 0 }` with a non-reasoning model to verify explicit temperature still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `generateTitle` failures with reasoning models by making temperature optional and omitted by default. Titles now generate correctly instead of defaulting to "Conversation".

- **Bug Fixes**
  - Omit `temperature` unless provided; provider uses its default.
  - Added `temperature` to `ConversationTitleConfig` (`generateTitle.temperature`) for optional control.
  - Improved failure logging in `@voltagent/core`: use `warn` and preserve `Error` name/message.

<sup>Written for commit 2d0d865fe947594648bc4ed3ec1901911a8c65b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation title generation no longer forces a fixed temperature and now respects when no temperature is provided.
  * Title-generation failures are logged at warn level for better visibility; error output is simplified for readability.

* **New Features**
  * Added an optional temperature setting for conversation title configuration to allow per-title temperature control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->