### PR TITLE
fix(core): initialize titleGenerator in __setDefaultMemory

### DIFF
--- a/.changeset/fix-set-default-memory-title-generator.md
+++ b/.changeset/fix-set-default-memory-title-generator.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix(core): initialize titleGenerator when memory is set via __setDefaultMemory

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8200,6 +8200,7 @@ export class Agent {
       return;
     }
     this.memoryManager.setMemory(memory);
+    this.memoryManager.setTitleGenerator(this.createConversationTitleGenerator(memory));
   }
 
   /**

--- a/packages/core/src/memory/manager/memory-manager.ts
+++ b/packages/core/src/memory/manager/memory-manager.ts
@@ -786,6 +786,13 @@ export class MemoryManager {
     }
   }
 
+  /**
+   * Replace the title generator used for this manager.
+   */
+  setTitleGenerator(titleGenerator: ConversationTitleGenerator | undefined): void {
+    this.titleGenerator = titleGenerator;
+  }
+
   // ============================================================================
   // Working Memory Proxy Methods
   // ============================================================================


### PR DESCRIPTION
## Summary

Closes #1232

When `Memory` is passed globally to `VoltAgent` (via the `memory` option), `__setDefaultMemory` updates `conversationMemory` but does **not** initialize `titleGenerator`. This causes `generateTitle` to silently fail — all conversations receive the fallback title `"Conversation"`.

## Changes

- **`MemoryManager`**: Added `setTitleGenerator()` method to allow updating the title generator after construction.
- **`Agent.__setDefaultMemory()`**: After calling `setMemory()`, now also calls `createConversationTitleGenerator()` and passes the result to `setTitleGenerator()`, ensuring title generation works regardless of whether memory is passed globally or per-agent.

## Testing

- All 13 existing `memory-manager.spec.ts` tests pass.
- Verified via code inspection that the fix addresses the exact gap described in the issue: `setMemory` only set `conversationMemory`, leaving `titleGenerator` as `undefined`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures conversation titles are correctly initialized and updated when default memory is applied so titles display reliably.
  * Allows the title-generation strategy to be updated at runtime so changes to how titles are created take effect immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize the conversation title generator when memory is set via `VoltAgent.__setDefaultMemory`, fixing #1232. Titles now generate correctly when memory is provided globally or per-agent, instead of the "Conversation" fallback.

- **Bug Fixes**
  - Added `setTitleGenerator()` to `MemoryManager`.
  - `Agent.__setDefaultMemory()` now sets the title generator with `createConversationTitleGenerator(memory)` after `setMemory()`.

<sup>Written for commit 02b7c4a3020905557d7b65999573448ddbbd5744. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

