### PR TITLE
fix(server-core): throw error when user-specified port is occupied

### DIFF
--- a/.changeset/port-in-use-error.md
+++ b/.changeset/port-in-use-error.md
@@ -1,0 +1,5 @@
+---
+'@voltagent/server-core': patch
+---
+
+fix(server-core): throw error when user-specified port is occupied instead of silently falling back

--- a/packages/server-core/src/server/base-provider.ts
+++ b/packages/server-core/src/server/base-provider.ts
@@ -74,8 +74,7 @@ export abstract class BaseServerProvider implements IServerProvider {
     }
 
     // Allocate port from central manager
-    // Use strict mode when user explicitly specified a port
-    const port = await portManager.allocatePort(this.config.port, this.config.port !== undefined);
+    const port = await portManager.allocatePort(this.config.port);
     this.allocatedPort = port;
 
     try {

--- a/packages/server-core/src/server/base-provider.ts
+++ b/packages/server-core/src/server/base-provider.ts
@@ -74,7 +74,8 @@ export abstract class BaseServerProvider implements IServerProvider {
     }
 
     // Allocate port from central manager
-    const port = await portManager.allocatePort(this.config.port);
+    // Use strict mode when user explicitly specified a port
+    const port = await portManager.allocatePort(this.config.port, this.config.port !== undefined);
     this.allocatedPort = port;
 
     try {

--- a/packages/server-core/src/utils/port-manager.spec.ts
+++ b/packages/server-core/src/utils/port-manager.spec.ts
@@ -390,6 +390,78 @@ describe("PortManager", () => {
     });
   });
 
+  describe("Strict Mode", () => {
+    it("should throw error when strict=true and preferred port is unavailable", async () => {
+      let portBeingTested: number | undefined;
+
+      (createNetServer as any).mockImplementation(() => {
+        const mockServer = {
+          once: vi.fn(),
+          listen: vi.fn((port: number) => {
+            portBeingTested = port;
+          }),
+          close: vi.fn((callback?: () => void) => callback?.()),
+        };
+
+        const handlers: Record<string, (...args: any[]) => void> = {};
+        mockServer.once.mockImplementation((event: string, handler: (...args: any[]) => void) => {
+          handlers[event] = handler;
+          if (Object.keys(handlers).length === 2) {
+            setTimeout(() => {
+              if (portBeingTested === 3141) {
+                handlers.error({ code: "EADDRINUSE" });
+              } else {
+                handlers.listening();
+              }
+            }, 0);
+          }
+          return mockServer;
+        });
+
+        return mockServer;
+      });
+
+      await expect(portManager.allocatePort(3141, true)).rejects.toThrow(
+        "Port 3141 is already in use",
+      );
+    });
+
+    it("should fallback to other ports when strict=false (default behavior)", async () => {
+      let portBeingTested: number | undefined;
+
+      (createNetServer as any).mockImplementation(() => {
+        const mockServer = {
+          once: vi.fn(),
+          listen: vi.fn((port: number) => {
+            portBeingTested = port;
+          }),
+          close: vi.fn((callback?: () => void) => callback?.()),
+        };
+
+        const handlers: Record<string, (...args: any[]) => void> = {};
+        mockServer.once.mockImplementation((event: string, handler: (...args: any[]) => void) => {
+          handlers[event] = handler;
+          if (Object.keys(handlers).length === 2) {
+            setTimeout(() => {
+              if (portBeingTested === 3141) {
+                handlers.error({ code: "EADDRINUSE" });
+              } else {
+                handlers.listening();
+              }
+            }, 0);
+          }
+          return mockServer;
+        });
+
+        return mockServer;
+      });
+
+      const port = await portManager.allocatePort(3141, false);
+      expect(port).not.toBe(3141);
+      expect(port).toBe(4310);
+    });
+  });
+
   describe("Edge Cases", () => {
     it("should handle server close callback properly", async () => {
       let closeCalled = false;

--- a/packages/server-core/src/utils/port-manager.spec.ts
+++ b/packages/server-core/src/utils/port-manager.spec.ts
@@ -106,10 +106,8 @@ describe("PortManager", () => {
         }
       });
 
-      // Try to allocate again - should get next port
-      const port2 = await portManager.allocatePort(3141);
-      expect(port2).not.toBe(3141);
-      expect(port2).toBe(4310); // Next preferred port
+      // Try to allocate again - should throw since port was explicitly specified
+      await expect(portManager.allocatePort(3141)).rejects.toThrow("Port 3141 is already in use");
     });
 
     it("should handle port in use (EADDRINUSE)", async () => {
@@ -145,9 +143,7 @@ describe("PortManager", () => {
         return mockServer;
       });
 
-      const port = await portManager.allocatePort(3141);
-      expect(port).not.toBe(3141);
-      expect(port).toBe(4310); // Should try next port after skipping duplicate 3141
+      await expect(portManager.allocatePort(3141)).rejects.toThrow("Port 3141 is already in use");
     });
 
     it("should handle permission denied (EACCES)", async () => {
@@ -183,9 +179,7 @@ describe("PortManager", () => {
         return mockServer;
       });
 
-      const port = await portManager.allocatePort(80); // Low port, likely EACCES
-      expect(port).not.toBe(80);
-      expect(port).toBe(3141); // Should try next port
+      await expect(portManager.allocatePort(80)).rejects.toThrow("Port 80 is already in use");
     });
 
     it("should throw error when no ports are available", async () => {
@@ -269,12 +263,12 @@ describe("PortManager", () => {
       await delay(10); // Small delay to ensure first check is in progress
       const promise2 = portManager.allocatePort(5000);
 
-      const [port1, port2] = await Promise.all([promise1, promise2]);
+      const [port1] = await Promise.allSettled([promise1, promise2]);
 
       // First should get the requested port
-      expect(port1).toBe(5000);
-      // Second should get a different port (since first is checking/allocated)
-      expect(port2).not.toBe(5000);
+      expect((port1 as PromiseFulfilledResult<number>).value).toBe(5000);
+      // Second should throw since port 5000 is explicitly requested but already being checked
+      await expect(promise2).rejects.toThrow("Port 5000 is already in use");
       expect(checkCompleted).toBe(true);
     });
   });
@@ -390,15 +384,15 @@ describe("PortManager", () => {
     });
   });
 
-  describe("Strict Mode", () => {
-    it("should throw error when strict=true and preferred port is unavailable", async () => {
-      let portBeingTested: number | undefined;
+  describe("Explicit Port", () => {
+    it("should throw error when preferred port is specified but unavailable", async () => {
+      let _portBeingTested: number | undefined;
 
       (createNetServer as any).mockImplementation(() => {
         const mockServer = {
           once: vi.fn(),
           listen: vi.fn((port: number) => {
-            portBeingTested = port;
+            _portBeingTested = port;
           }),
           close: vi.fn((callback?: () => void) => callback?.()),
         };
@@ -408,11 +402,7 @@ describe("PortManager", () => {
           handlers[event] = handler;
           if (Object.keys(handlers).length === 2) {
             setTimeout(() => {
-              if (portBeingTested === 3141) {
-                handlers.error({ code: "EADDRINUSE" });
-              } else {
-                handlers.listening();
-              }
+              handlers.error({ code: "EADDRINUSE" });
             }, 0);
           }
           return mockServer;
@@ -421,12 +411,24 @@ describe("PortManager", () => {
         return mockServer;
       });
 
-      await expect(portManager.allocatePort(3141, true)).rejects.toThrow(
-        "Port 3141 is already in use",
-      );
+      await expect(portManager.allocatePort(3141)).rejects.toThrow("Port 3141 is already in use");
     });
 
-    it("should fallback to other ports when strict=false (default behavior)", async () => {
+    it("should throw error when preferred port is already allocated", async () => {
+      // First allocate a port
+      mockServer.once.mockImplementation((event: string, handler: (...args: any[]) => void) => {
+        if (event === "listening") {
+          setTimeout(() => handler(), 0);
+        }
+      });
+
+      await portManager.allocatePort(3141);
+
+      // Now trying to allocate the same port should throw
+      await expect(portManager.allocatePort(3141)).rejects.toThrow("Port 3141 is already in use");
+    });
+
+    it("should fallback to other ports when no preferred port is specified", async () => {
       let portBeingTested: number | undefined;
 
       (createNetServer as any).mockImplementation(() => {
@@ -456,7 +458,8 @@ describe("PortManager", () => {
         return mockServer;
       });
 
-      const port = await portManager.allocatePort(3141, false);
+      // No preferred port — should fallback when default port (3141) is busy
+      const port = await portManager.allocatePort();
       expect(port).not.toBe(3141);
       expect(port).toBe(4310);
     });
@@ -515,9 +518,7 @@ describe("PortManager", () => {
         return mockServer;
       });
 
-      const port = await portManager.allocatePort(3000);
-      expect(port).not.toBe(3000);
-      expect(port).toBe(3141); // Should try the first preferred port
+      await expect(portManager.allocatePort(3000)).rejects.toThrow("Port 3000 is already in use");
     });
 
     it("should cleanup promises map even on error", async () => {

--- a/packages/server-core/src/utils/port-manager.ts
+++ b/packages/server-core/src/utils/port-manager.ts
@@ -81,14 +81,18 @@ class PortManager {
   /**
    * Allocate an available port
    * @param preferredPort Optional preferred port to try first
+   * @param strict If true, throw error when preferred port is unavailable instead of trying fallbacks
    * @returns The allocated port number
    */
-  public async allocatePort(preferredPort?: number): Promise<number> {
+  public async allocatePort(preferredPort?: number, strict = false): Promise<number> {
     const portsToTry = getPortsToTry(preferredPort);
 
     for (const port of portsToTry) {
       // Skip if already allocated
       if (this.allocatedPorts.has(port)) {
+        if (strict && port === preferredPort) {
+          throw new Error(`Port ${preferredPort} is already in use`);
+        }
         continue;
       }
 
@@ -97,6 +101,11 @@ class PortManager {
         // Reserve this port
         this.allocatedPorts.add(port);
         return port;
+      }
+
+      // In strict mode, throw error if preferred port is unavailable
+      if (strict && port === preferredPort) {
+        throw new Error(`Port ${preferredPort} is already in use`);
       }
     }
 

--- a/packages/server-core/src/utils/port-manager.ts
+++ b/packages/server-core/src/utils/port-manager.ts
@@ -80,19 +80,26 @@ class PortManager {
 
   /**
    * Allocate an available port
-   * @param preferredPort Optional preferred port to try first
-   * @param strict If true, throw error when preferred port is unavailable instead of trying fallbacks
+   * @param preferredPort Optional preferred port to try first.
+   *   When specified, the port is required — throws if unavailable.
+   *   When omitted, falls back through default ports.
    * @returns The allocated port number
    */
-  public async allocatePort(preferredPort?: number, strict = false): Promise<number> {
-    const portsToTry = getPortsToTry(preferredPort);
+  public async allocatePort(preferredPort?: number): Promise<number> {
+    // When user explicitly specifies a port, fail fast instead of silently falling back
+    if (preferredPort !== undefined) {
+      if (this.allocatedPorts.has(preferredPort) || !(await this.isPortAvailable(preferredPort))) {
+        throw new Error(`Port ${preferredPort} is already in use`);
+      }
+      this.allocatedPorts.add(preferredPort);
+      return preferredPort;
+    }
+
+    const portsToTry = getPortsToTry();
 
     for (const port of portsToTry) {
       // Skip if already allocated
       if (this.allocatedPorts.has(port)) {
-        if (strict && port === preferredPort) {
-          throw new Error(`Port ${preferredPort} is already in use`);
-        }
         continue;
       }
 
@@ -101,11 +108,6 @@ class PortManager {
         // Reserve this port
         this.allocatedPorts.add(port);
         return port;
-      }
-
-      // In strict mode, throw error if preferred port is unavailable
-      if (strict && port === preferredPort) {
-        throw new Error(`Port ${preferredPort} is already in use`);
       }
     }
 


### PR DESCRIPTION
## Summary

When a user explicitly specifies a port (e.g., `port: 3141`) and that port is already in use, the server now throws a clear error instead of silently falling back to another port.

## Related Issue

Closes #1236

## Changes

- Added `strict` parameter to `portManager.allocatePort()` (default `false`, backward-compatible)
- When `strict=true` and the preferred port is unavailable (already allocated or bound by another process), throws `Error('Port <N> is already in use')`
- `BaseServerProvider.start()` passes `strict=true` when `config.port` is explicitly set
- Default behavior (no port specified) is unchanged — still falls back through preferred ports and 4300–4400 range

## Testing

- Added 2 new tests for strict mode in `port-manager.spec.ts` (21/21 pass)
- Verified lint passes (`biome check`)

## Reproduction

```ts
import { createServer } from 'node:http';
import VoltAgent from '@voltagent/core';
import honoServer from '@voltagent/server-hono';

createServer((_, res) => {
  res.writeHead(200);
  res.end('3141 is occupied');
}).listen(3141, () => {
  // Before: silently starts on 4310
  // After: throws 'Port 3141 is already in use'
  new VoltAgent({
    agents: {},
    server: honoServer({ port: 3141 }),
  });
});
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When a user sets a specific port and it’s already taken, `@voltagent/server-core` now throws a clear error instead of silently picking another port. Default fallback behavior is unchanged when no port is set.

- **Bug Fixes**
  - `portManager.allocatePort(preferredPort?)` now fails fast when a preferred port is provided; removed the `strict` flag.
  - Throws `Error('Port <N> is already in use')` if the port is occupied or already allocated; all providers inherit this automatically.

<sup>Written for commit fb01886d5585de92358013723dad804381f49e5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Server now throws an error when a user-specified port is already in use, instead of silently falling back to a different port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->