### PR TITLE
fix(server-core): add cancel endpoint for resumable chat streams

### DIFF
--- a/.changeset/brave-squids-trade.md
+++ b/.changeset/brave-squids-trade.md
@@ -1,0 +1,16 @@
+---
+"@voltagent/server-core": patch
+"@voltagent/server-elysia": patch
+"@voltagent/server-hono": patch
+---
+
+fix(server-core): enable explicit cancellation for resumable chat streams
+
+When resumableStream is enabled, the AbortSignal was unconditionally cleared, preventing clients from explicitly cancelling ongoing chat streams. This update replaces the cleared signal with an internal AbortController that can be triggered via a new cancel endpoint.
+
+Adds:
+- `handleCancelChat` handler in server-core
+- `POST /agents/:id/chat/:conversationId/cancel` route in server-elysia and server-hono
+- Internal AbortController management keyed by `${agentId}:${conversationId}:${userId}`
+
+The cancel endpoint aborts the stream and cleans up both the AbortController and the resumable stream adapter state.

--- a/.changeset/brave-squids-trade.md
+++ b/.changeset/brave-squids-trade.md
@@ -14,3 +14,5 @@ Adds:
 - Internal AbortController management keyed by `${agentId}:${conversationId}:${userId}`
 
 The cancel endpoint aborts the stream and cleans up both the AbortController and the resumable stream adapter state.
+
+Note: The in-memory AbortController map only supports single-instance deployments; horizontally scaled environments require external coordination.

--- a/packages/server-core/src/handlers/agent.handlers.ts
+++ b/packages/server-core/src/handlers/agent.handlers.ts
@@ -317,9 +317,10 @@ export async function handleChatStream(
       );
     }
 
+    let controllerKey: string | null = null;
     if (resumableStreamEnabled) {
       const internalController = new AbortController();
-      const controllerKey = `${agentId}:${conversationId}:${userId}`;
+      controllerKey = `${agentId}:${conversationId}:${userId}`;
       activeAbortControllers.set(controllerKey, internalController);
       options.abortSignal = internalController.signal;
     }
@@ -335,7 +336,15 @@ export async function handleChatStream(
       }
     }
 
-    const result = await agent.streamText(input, options);
+    let result: Awaited<ReturnType<typeof agent.streamText>>;
+    try {
+      result = await agent.streamText(input, options);
+    } catch (error) {
+      if (controllerKey) {
+        activeAbortControllers.delete(controllerKey);
+      }
+      throw error;
+    }
     let activeStreamId: string | null = null;
 
     // Use the built-in toUIMessageStreamResponse - it handles errors properly
@@ -377,8 +386,9 @@ export async function handleChatStream(
         }
 
         // Clean up AbortController
-        const controllerKey = `${agentId}:${conversationId}:${userId}`;
-        activeAbortControllers.delete(controllerKey);
+        if (controllerKey) {
+          activeAbortControllers.delete(controllerKey);
+        }
       },
     });
   } catch (error) {
@@ -508,7 +518,7 @@ export async function handleCancelChat(
     if (!controller) {
       return {
         success: false,
-        error: "No active chat stream found",
+        error: "Chat stream not found",
       };
     }
 

--- a/packages/server-core/src/handlers/agent.handlers.ts
+++ b/packages/server-core/src/handlers/agent.handlers.ts
@@ -8,8 +8,17 @@ import { convertJsonSchemaToZod as convertJsonSchemaToZodV3 } from "zod-from-jso
 import type { ApiResponse } from "../types";
 import { processAgentOptions } from "../utils/options";
 
-// Store active AbortControllers for resumable streams
+// Store active AbortControllers for resumable streams.
+// NOTE: This in-memory Map only works for single-instance deployments.
+// Horizontally scaled environments need an external coordination mechanism.
 const activeAbortControllers = new Map<string, AbortController>();
+
+/**
+ * Typed body for the cancel chat endpoint.
+ */
+export interface CancelChatBody {
+  userId?: string;
+}
 
 /**
  * Handler for listing all agents
@@ -321,6 +330,11 @@ export async function handleChatStream(
     if (resumableStreamEnabled) {
       const internalController = new AbortController();
       controllerKey = `${agentId}:${conversationId}:${userId}`;
+      // Abort any existing controller for this key to prevent stale leaks
+      const existing = activeAbortControllers.get(controllerKey);
+      if (existing) {
+        existing.abort();
+      }
       activeAbortControllers.set(controllerKey, internalController);
       options.abortSignal = internalController.signal;
     }
@@ -367,6 +381,12 @@ export async function handleChatStream(
           });
         } catch (error) {
           logger.error("Failed to persist resumable chat stream", { error });
+        }
+      },
+      onError: async () => {
+        // Clean up AbortController on error (mirrors onFinish cleanup)
+        if (controllerKey) {
+          activeAbortControllers.delete(controllerKey);
         }
       },
       onFinish: async () => {
@@ -498,17 +518,18 @@ export async function handleResumeChatStream(
 export async function handleCancelChat(
   agentId: string,
   conversationId: string,
-  body: any,
+  body: CancelChatBody,
   deps: ServerProviderDeps,
   logger: Logger,
 ): Promise<ApiResponse> {
   try {
     const { userId } = body || {};
 
-    if (!userId) {
+    if (typeof userId !== "string" || userId.trim().length === 0) {
       return {
         success: false,
         error: "userId is required for cancelling chat streams",
+        httpStatus: 400,
       };
     }
 
@@ -519,6 +540,7 @@ export async function handleCancelChat(
       return {
         success: false,
         error: "Chat stream not found",
+        httpStatus: 404,
       };
     }
 
@@ -553,6 +575,7 @@ export async function handleCancelChat(
     return {
       success: false,
       error: error instanceof Error ? error.message : "Failed to cancel chat stream",
+      httpStatus: 500,
     };
   }
 }

--- a/packages/server-core/src/handlers/agent.handlers.ts
+++ b/packages/server-core/src/handlers/agent.handlers.ts
@@ -8,6 +8,9 @@ import { convertJsonSchemaToZod as convertJsonSchemaToZodV3 } from "zod-from-jso
 import type { ApiResponse } from "../types";
 import { processAgentOptions } from "../utils/options";
 
+// Store active AbortControllers for resumable streams
+const activeAbortControllers = new Map<string, AbortController>();
+
 /**
  * Handler for listing all agents
  * Returns agent data array
@@ -315,7 +318,10 @@ export async function handleChatStream(
     }
 
     if (resumableStreamEnabled) {
-      options.abortSignal = undefined;
+      const internalController = new AbortController();
+      const controllerKey = `${agentId}:${conversationId}:${userId}`;
+      activeAbortControllers.set(controllerKey, internalController);
+      options.abortSignal = internalController.signal;
     }
 
     options.resumableStream = resumableStreamEnabled;
@@ -369,6 +375,10 @@ export async function handleChatStream(
         } catch (error) {
           logger.error("Failed to clear resumable chat stream", { error });
         }
+
+        // Clean up AbortController
+        const controllerKey = `${agentId}:${conversationId}:${userId}`;
+        activeAbortControllers.delete(controllerKey);
       },
     });
   } catch (error) {
@@ -468,6 +478,72 @@ export async function handleResumeChatStream(
         },
       },
     );
+  }
+}
+
+/**
+ * Handler for cancelling a chat stream
+ * Returns cancellation result
+ */
+export async function handleCancelChat(
+  agentId: string,
+  conversationId: string,
+  body: any,
+  deps: ServerProviderDeps,
+  logger: Logger,
+): Promise<ApiResponse> {
+  try {
+    const { userId } = body || {};
+
+    if (!userId) {
+      return {
+        success: false,
+        error: "userId is required for cancelling chat streams",
+      };
+    }
+
+    const controllerKey = `${agentId}:${conversationId}:${userId}`;
+    const controller = activeAbortControllers.get(controllerKey);
+
+    if (!controller) {
+      return {
+        success: false,
+        error: "No active chat stream found",
+      };
+    }
+
+    controller.abort();
+    activeAbortControllers.delete(controllerKey);
+
+    // Clear the resumable stream
+    if (deps.resumableStream) {
+      try {
+        await deps.resumableStream.clearActiveStream({
+          conversationId,
+          agentId,
+          userId,
+        });
+      } catch (error) {
+        logger.warn("Failed to clear resumable stream on cancel", { error });
+      }
+    }
+
+    return {
+      success: true,
+      data: {
+        agentId,
+        conversationId,
+        userId,
+        status: "cancelled" as const,
+        cancelledAt: new Date().toISOString(),
+      },
+    };
+  } catch (error) {
+    logger.error("Failed to cancel chat stream", { error });
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to cancel chat stream",
+    };
   }
 }
 

--- a/packages/server-elysia/src/routes/agent.routes.ts
+++ b/packages/server-elysia/src/routes/agent.routes.ts
@@ -1,6 +1,7 @@
 import type { ServerProviderDeps } from "@voltagent/core";
 import type { Logger } from "@voltagent/internal";
 import {
+  handleCancelChat,
   handleChatStream,
   handleGenerateObject,
   handleGenerateText,
@@ -37,6 +38,17 @@ import {
 // Agent ID parameter
 const AgentIdParam = t.Object({
   id: t.String(),
+});
+
+// Agent chat cancel parameters
+const ChatCancelParams = t.Object({
+  id: t.String(),
+  conversationId: t.String(),
+});
+
+// Chat cancel body
+const ChatCancelBody = t.Object({
+  userId: t.String(),
 });
 
 // History query parameters
@@ -202,6 +214,41 @@ export function registerAgentRoutes(app: Elysia, deps: ServerProviderDeps, logge
       detail: {
         summary: "Stream chat messages",
         description: "Stream chat messages using the specified agent (UI message stream SSE)",
+        tags: ["Agents"],
+      },
+    },
+  );
+
+  // POST /agents/:id/chat/:conversationId/cancel - Cancel chat stream
+  app.post(
+    "/agents/:id/chat/:conversationId/cancel",
+    async ({ params, body, set }) => {
+      const response = await handleCancelChat(params.id, params.conversationId, body, deps, logger);
+      if (!response.success) {
+        set.status = response.error?.includes("not found") ? 404 : 500;
+      }
+      return response;
+    },
+    {
+      params: ChatCancelParams,
+      body: ChatCancelBody,
+      response: {
+        200: t.Object({
+          success: t.Literal(true),
+          data: t.Object({
+            agentId: t.String(),
+            conversationId: t.String(),
+            userId: t.String(),
+            status: t.Literal("cancelled"),
+            cancelledAt: t.String(),
+          }),
+        }),
+        404: ErrorSchema,
+        500: ErrorSchema,
+      },
+      detail: {
+        summary: "Cancel chat stream",
+        description: "Cancel an active chat stream for the specified agent and conversation",
         tags: ["Agents"],
       },
     },

--- a/packages/server-elysia/src/routes/agent.routes.ts
+++ b/packages/server-elysia/src/routes/agent.routes.ts
@@ -225,7 +225,7 @@ export function registerAgentRoutes(app: Elysia, deps: ServerProviderDeps, logge
     async ({ params, body, set }) => {
       const response = await handleCancelChat(params.id, params.conversationId, body, deps, logger);
       if (!response.success) {
-        set.status = response.error?.includes("not found") ? 404 : 500;
+        set.status = response.httpStatus ?? 500;
       }
       return response;
     },

--- a/packages/server-elysia/src/routes/agent.routes.ts
+++ b/packages/server-elysia/src/routes/agent.routes.ts
@@ -48,7 +48,7 @@ const ChatCancelParams = t.Object({
 
 // Chat cancel body
 const ChatCancelBody = t.Object({
-  userId: t.String(),
+  userId: t.String({ minLength: 1 }),
 });
 
 // History query parameters

--- a/packages/server-hono/src/routes/index.ts
+++ b/packages/server-hono/src/routes/index.ts
@@ -174,7 +174,7 @@ export function registerAgentRoutes(
     }
     const response = await handleCancelChat(agentId, conversationId, body, deps, logger);
     if (!response.success) {
-      const status = response.error?.includes("not found") ? 404 : 500;
+      const status = response.httpStatus ?? 500;
       return c.json(response, status);
     }
     return c.json(response, 200);

--- a/packages/server-hono/src/routes/index.ts
+++ b/packages/server-hono/src/routes/index.ts
@@ -166,7 +166,12 @@ export function registerAgentRoutes(
     if (!agentId || !conversationId) {
       return c.json({ success: false, error: "Missing agent or conversation id parameter" }, 400);
     }
-    const body = await c.req.json();
+    let body: any;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ success: false, error: "Invalid or missing JSON body" }, 400);
+    }
     const response = await handleCancelChat(agentId, conversationId, body, deps, logger);
     if (!response.success) {
       const status = response.error?.includes("not found") ? 404 : 500;

--- a/packages/server-hono/src/routes/index.ts
+++ b/packages/server-hono/src/routes/index.ts
@@ -3,6 +3,7 @@ import type { Logger } from "@voltagent/internal";
 import {
   UPDATE_ROUTES,
   handleAttachWorkflowStream,
+  handleCancelChat,
   handleCancelWorkflow,
   handleChatStream,
   handleCheckUpdates,
@@ -156,6 +157,22 @@ export function registerAgentRoutes(
     }
 
     return handleResumeChatStream(agentId, conversationId, deps, logger, userId);
+  });
+
+  // POST /agents/:id/chat/:conversationId/cancel - Cancel chat stream
+  app.post("/agents/:id/chat/:conversationId/cancel", async (c) => {
+    const agentId = c.req.param("id");
+    const conversationId = c.req.param("conversationId");
+    if (!agentId || !conversationId) {
+      return c.json({ success: false, error: "Missing agent or conversation id parameter" }, 400);
+    }
+    const body = await c.req.json();
+    const response = await handleCancelChat(agentId, conversationId, body, deps, logger);
+    if (!response.success) {
+      const status = response.error?.includes("not found") ? 404 : 500;
+      return c.json(response, status);
+    }
+    return c.json(response, 200);
   });
 
   // POST /agents/:id/object - Generate object


### PR DESCRIPTION
## Summary

Fixes #1239 — AbortSignal is unconditionally cleared when `resumableStream` is enabled, making stop/cancel non-functional.

## Problem

When `resumableStream` is enabled, the handler sets `options.abortSignal = undefined` to prevent HTTP disconnection from killing in-progress LLM generations (correct for resumability). However, this also makes it impossible for clients to explicitly cancel a generation — clicking "Stop" in the UI has no effect on the backend.

## Changes

1. **Internal AbortController** — Instead of clearing the signal entirely, an internal `AbortController` is created when `resumableStreamEnabled` is true. Its signal replaces the HTTP signal, decoupling cancellation from HTTP disconnection while keeping the generation cancellable.

2. **Cancel endpoint** — Added `POST /agents/:id/chat/:conversationId/cancel` (following the existing workflow cancel pattern from `handleCancelWorkflow`). Accepts `{ userId }` in the body, aborts the stored controller, and clears the resumable stream.

3. **Lifecycle cleanup** — The `AbortController` is automatically removed from the map in the `onFinish` callback.

### Files changed

- `packages/server-core/src/handlers/agent.handlers.ts` — AbortController management + `handleCancelChat` handler
- `packages/server-elysia/src/routes/agent.routes.ts` — Route registration with typed schemas
- `packages/server-hono/src/routes/index.ts` — Route registration

## Usage

```bash
# Cancel an active chat stream
POST /agents/:agentId/chat/:conversationId/cancel
Content-Type: application/json

{ "userId": "user-123" }
```

Response:
```json
{
  "success": true,
  "data": {
    "agentId": "...",
    "conversationId": "...",
    "userId": "...",
    "status": "cancelled",
    "cancelledAt": "2026-04-24T..."
  }
}
```

## Testing

- Biome check passes on all changed files
- Existing handler tests continue to pass (they don't reference `abortSignal`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore cancellation for resumable chat streams. “Stop” now cancels without breaking resumability by using an internal AbortController and a new cancel endpoint.

- **Bug Fixes**
  - Use an internal AbortController per stream (keyed by agentId:conversationId:userId); abort any existing controller for that key; decouple from HTTP disconnects.
  - Add `POST /agents/:id/chat/:conversationId/cancel`; Elysia schema enforces non-empty `userId` (`t.String({ minLength: 1 })`); Hono rejects malformed JSON and invalid `userId`; routes registered in `@voltagent/server-elysia` and `@voltagent/server-hono`.
  - Clean up controllers on finish, on error, and if `streamText` throws to prevent leaks.
  - Set status via `httpStatus`: 404 when stream not found; 400 for invalid `userId` or malformed JSON in Hono.

- **Migration**
  - For resumable chats, cancel explicitly rather than relying on HTTP disconnects.

<sup>Written for commit 50e9d99cd05f310d9b54cb64238d68df2c304dd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /agents/:id/chat/:conversationId/cancel to explicitly cancel active/resumable chat streams; returns structured success/error responses.

* **Bug Fixes**
  * Restored reliable client-initiated cancellation for resumable chats: invoking cancel aborts the in-flight stream and ensures server-side cleanup of associated resumable stream state.

Note: server-side cancellation cleanup applies to single-instance deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->