### PR TITLE
fix(server-hono): don't double-prefix basePath when Hono already merged it into route.path

### DIFF
--- a/.changeset/custom-routes-no-double-prefix.md
+++ b/.changeset/custom-routes-no-double-prefix.md
@@ -1,0 +1,13 @@
+---
+"@voltagent/server-hono": patch
+---
+
+fix(server-hono): don't double-prefix basePath when Hono already merged it into route.path
+
+When a sub-app is mounted via `app.route(basePath, subApp)` or `app.basePath(basePath)`,
+Hono's internal `_addRoute` calls `mergePath(basePath, path)` and stores the merged
+result in `route.path`, while still keeping `basePath` on the route as metadata.
+`extractCustomEndpoints` blindly prepended `basePath` to `route.path`, so a route
+registered as `/api/hello` with `basePath: "/api"` was logged as `GET /api/api/hello`
+even though Hono served it correctly at `/api/hello`. Only prepend `basePath` when
+`route.path` does not already include it.

--- a/packages/server-hono/src/utils/custom-endpoints.spec.ts
+++ b/packages/server-hono/src/utils/custom-endpoints.spec.ts
@@ -76,6 +76,35 @@ describe("extractCustomEndpoints", () => {
       expect(endpoints[0].path).toBe("/api/health");
     });
 
+    it("should not double-prefix basePath when Hono already merged it into path", () => {
+      // Real Hono v4 shape for `app.route('/api', routes)` + `routes.get('/hello')`:
+      // Hono's _addRoute calls mergePath(basePath, path) and stores the merged
+      // result in route.path, while also keeping basePath on the route for
+      // metadata. Blindly prepending basePath produced /api/api/hello.
+      const app = createMockApp({
+        routes: [{ method: "GET", path: "/api/hello", basePath: "/api" }],
+      });
+
+      const endpoints = extractCustomEndpoints(app);
+
+      expect(endpoints).toHaveLength(1);
+      expect(endpoints[0].path).toBe("/api/hello");
+    });
+
+    it("should handle nested sub-apps without double-prefixing", () => {
+      // e.g. app.route('/api', sub); sub.route('/sub', inner); inner.get('/x')
+      // Hono merges all the way down, so the final route.path already holds
+      // the absolute path.
+      const app = createMockApp({
+        routes: [{ method: "GET", path: "/api/sub/inner", basePath: "/api" }],
+      });
+
+      const endpoints = extractCustomEndpoints(app);
+
+      expect(endpoints).toHaveLength(1);
+      expect(endpoints[0].path).toBe("/api/sub/inner");
+    });
+
     it("should deduplicate routes", () => {
       const app = createMockApp({
         routes: [

--- a/packages/server-hono/src/utils/custom-endpoints.ts
+++ b/packages/server-hono/src/utils/custom-endpoints.ts
@@ -39,8 +39,15 @@ export function extractCustomEndpoints(app: OpenAPIHonoType): ServerEndpointSumm
     try {
       if (app.routes && Array.isArray(app.routes)) {
         app.routes.forEach((route) => {
-          // Construct full path and normalize it
-          const rawPath = route.basePath ? `${route.basePath}${route.path}` : route.path;
+          // Hono merges basePath into route.path when a sub-app is mounted via
+          // app.route(basePath, subApp) or app.basePath(basePath), so route.path
+          // can already be the full path. Only prepend basePath when path does
+          // not already include it, otherwise we end up with /api/api/hello.
+          const basePath = route.basePath && route.basePath !== "/" ? route.basePath : "";
+          const rawPath =
+            basePath && !route.path.startsWith(basePath)
+              ? `${basePath}${route.path}`
+              : route.path;
           const fullPath = rawPath.replace(/\/+/g, "/"); // Remove duplicate slashes
 
           // Skip built-in VoltAgent paths


### PR DESCRIPTION
Fixes #1238.

## Root cause

When a sub-app is mounted via `app.route(basePath, subApp)` or `app.basePath(basePath)`, Hono's internal `_addRoute` calls `mergePath(this._basePath, path)` and stores the merged result in `route.path`, while still keeping `basePath` on the route as metadata:

```ts
// from hono/src/hono-base.ts _addRoute
path = mergePath(this._basePath, path)
const r: RouterRoute = { basePath: this._basePath, path, method, handler }
```

So for the reporter's setup:

```ts
const routes = new Hono();
routes.get("/hello", ...);
app.route("/api", routes);
```

the entry that lands in `app.routes` is `{ method: "GET", path: "/api/hello", basePath: "/api" }`. `extractCustomEndpoints` then did:

```ts
const rawPath = route.basePath ? `${route.basePath}${route.path}` : route.path;
// => "/api" + "/api/hello" = "/api/api/hello"
```

Normalized that to `/api/api/hello`, which is what shows up in the startup log. The actual request still worked because Hono itself routes by `route.path`; only the logging / OpenAPI side was wrong.

## Fix

Only prepend `basePath` when `route.path` does not already include it:

```ts
const basePath = route.basePath && route.basePath !== "/" ? route.basePath : "";
const rawPath =
  basePath && !route.path.startsWith(basePath)
    ? `${basePath}${route.path}`
    : route.path;
```

This keeps the existing behavior for the defensive mock case `{ path: "/health", basePath: "/api" }` (still becomes `/api/health`), while producing `/api/hello` for the shape Hono actually hands us.

## Tests

Two regression tests added to `custom-endpoints.spec.ts`:

1. `should not double-prefix basePath when Hono already merged it into path` - models `app.route('/api', routes); routes.get('/hello')`.
2. `should handle nested sub-apps without double-prefixing` - models `app.route('/api', sub); sub.route('/sub', inner); inner.get('/x')`.

Both fail without the fix (producing `/api/api/hello` and `/api/api/sub/inner` respectively). All 44 existing tests still pass. Full spec: 46/46 green.

```
 ✓ src/utils/custom-endpoints.spec.ts (46 tests) 25ms
 Test Files  1 passed (1)
      Tests  46 passed (46)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom endpoint extraction in `@voltagent/server-hono` to avoid double-prefixing `basePath` when Hono already merged it into `route.path`. Logs and OpenAPI now show correct paths for sub-apps; request routing was unaffected.

- **Bug Fixes**
  - Only prepend `basePath` when `route.path` doesn’t start with it.
  - Added regression tests for sub-app and nested sub-app cases.

<sup>Written for commit 85cae43c156a2965b2e520364df52e938ec41b59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route path logging that was incorrectly duplicating the base path prefix (e.g., `/api/api/hello` now logs as `/api/hello`)

* **Tests**
  * Added test coverage for path normalization in nested routing scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->