### PR TITLE
fix(core): register agents before ready resolves

### DIFF
--- a/.changeset/sync-agent-registration-before-ready.md
+++ b/.changeset/sync-agent-registration-before-ready.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Register agents synchronously during VoltAgent construction so getAgent and getAgents can return agents with global defaults before ready resolves.

--- a/packages/core/src/voltagent.spec.ts
+++ b/packages/core/src/voltagent.spec.ts
@@ -82,6 +82,13 @@ describe("VoltAgent defaults", () => {
       expect.arrayContaining(["ls", "read_file", "execute_command", "workspace_search"]),
     );
 
+    const retrievedAgent = voltAgent.getAgent("assistant");
+    expect(retrievedAgent).toBe(agent);
+    expect(retrievedAgent?.getWorkspace()).toBe(workspace);
+    expect(retrievedAgent?.getTools().map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(["ls", "read_file", "execute_command", "workspace_search"]),
+    );
+
     await voltAgent.ready;
     await voltAgent.shutdown();
   });

--- a/packages/core/src/voltagent.ts
+++ b/packages/core/src/voltagent.ts
@@ -129,9 +129,11 @@ export class VoltAgent {
     // Setup graceful shutdown handlers
     this.setupShutdownHandlers();
 
+    // Register agents synchronously so getAgent/getAgents can be used immediately after construction.
+    // Workspace defaults are applied before registration; workspace initialization is still awaited by ready.
+    this.registerAgents(options.agents);
+
     const finalizeInit = () => {
-      // ✅ NOW register agents - they can access global telemetry exporter
-      this.registerAgents(options.agents);
       this.registerTriggers(options.triggers);
 
       // Register workflows if provided


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Agents provided to `new VoltAgent({ agents, workspace })` are only registered during async initialization. This means `volt.getAgent(...)` can return `undefined` before `volt.ready` resolves, and callers using the retrieved agent path can miss the expected global workspace behavior.

## What is the new behavior?

VoltAgent now registers agents synchronously during construction, after global defaults such as workspace are configured. `getAgent` and `getAgents` can be used immediately, and retrieved agents already include inherited workspace tools/settings. Async workspace initialization is still represented by `volt.ready`.

fixes #1242

## Notes for reviewers

Thanks to @diluka-pietra for the clear report. I reproduced this with the workspace example and also verified the LLM path from the issue: the retrieved agent can list workspace files and tools instead of responding that it has no workspace access. We should be able to include this in an upcoming patch release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers agents synchronously in `@voltagent/core` so `getAgent` and `getAgents` work right after creating a `VoltAgent`. Fixes a race where callers could get `undefined` or agents missing workspace defaults before `ready` resolves.

- **Bug Fixes**
  - Register agents during construction after applying global defaults; `ready` still awaits async workspace init.
  - Added tests to ensure retrieved agents include workspace and tools before `ready`.

<sup>Written for commit 5d4715dbb801b9dd0bb620b19398b3e98a09e08c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agents are now immediately available after initialization via `getAgent` and `getAgents` methods, eliminating the need to wait for the `ready` promise to complete before retrieving agent instances.

* **Tests**
  * Added test coverage for agent retrieval and default tool configuration verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->