### PR TITLE
fix(core): initialize title generation for default memory

### DIFF
--- a/.changeset/global-memory-title-generation.md
+++ b/.changeset/global-memory-title-generation.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Fix conversation title generation when memory is supplied globally to VoltAgent.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -8199,7 +8199,7 @@ export class Agent {
     if (this.memoryConfigured || this.memory === false) {
       return;
     }
-    this.memoryManager.setMemory(memory);
+    this.memoryManager.setMemory(memory, this.createConversationTitleGenerator(memory));
   }
 
   /**

--- a/packages/core/src/memory/manager/memory-manager.ts
+++ b/packages/core/src/memory/manager/memory-manager.ts
@@ -141,13 +141,26 @@ export class MemoryManager {
               context.input ?? messageWithMetadata,
               "Conversation",
             );
-            await this.conversationMemory?.createConversation({
-              id: conversationId,
-              userId: userId,
-              resourceId: this.resourceId,
-              title,
-              metadata: {},
-            });
+            try {
+              await this.conversationMemory?.createConversation({
+                id: conversationId,
+                userId: userId,
+                resourceId: this.resourceId,
+                title,
+                metadata: {},
+              });
+            } catch (createError) {
+              if (this.isConversationAlreadyExistsError(createError)) {
+                context.logger.debug(
+                  "[Memory] Conversation already exists (race condition handled)",
+                  {
+                    conversationId,
+                  },
+                );
+              } else {
+                throw createError;
+              }
+            }
           }
 
           // Add message to conversation using Memory V2's saveMessageWithContext
@@ -775,14 +788,16 @@ export class MemoryManager {
   /**
    * Replace the Memory instance used for this manager.
    */
-  setMemory(memory: Memory | false): void {
+  setMemory(memory: Memory | false, titleGenerator?: ConversationTitleGenerator): void {
     if (memory === false) {
       this.conversationMemory = undefined;
+      this.titleGenerator = undefined;
       return;
     }
 
     if (memory instanceof Memory) {
       this.conversationMemory = memory;
+      this.titleGenerator = titleGenerator;
     }
   }
 

--- a/packages/core/src/voltagent.spec.ts
+++ b/packages/core/src/voltagent.spec.ts
@@ -1,3 +1,4 @@
+import { MockLanguageModelV3 } from "ai/test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { Agent } from "./agent/agent";
@@ -57,6 +58,66 @@ describe("VoltAgent defaults", () => {
     });
 
     expect(agent.getMemory()).toBe(agentMemory);
+  });
+
+  it("applies title generation when default memory is assigned to a preconstructed agent", async () => {
+    const agentMemory = new Memory({
+      storage: new InMemoryStorageAdapter(),
+      generateTitle: true,
+    });
+    const model = new MockLanguageModelV3({
+      modelId: "title-model",
+      doGenerate: async () => ({
+        content: [{ type: "text", text: "Global Memory Title" }],
+        finishReason: "stop",
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+          inputTokenDetails: {
+            noCacheTokens: 1,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+          },
+          outputTokenDetails: {
+            textTokens: 1,
+            reasoningTokens: 0,
+          },
+        },
+        warnings: [],
+      }),
+    });
+    const agent = new Agent({
+      name: "assistant",
+      instructions: "Be helpful.",
+      model: model as any,
+    });
+
+    const voltAgent = new VoltAgent({
+      agents: { assistant: agent },
+      memory: agentMemory,
+      checkDependencies: false,
+    });
+
+    const operationContext = (agent as any).createOperationContext("Plan a weekend trip to Rome.", {
+      userId: "user-1",
+      conversationId: "conversation-1",
+    });
+    await (agent as any).memoryManager.saveMessage(
+      operationContext,
+      {
+        id: "message-1",
+        role: "assistant",
+        parts: [{ type: "text", text: "Sure, let's plan it." }],
+      },
+      "user-1",
+      "conversation-1",
+    );
+
+    const conversation = await agentMemory.getConversation("conversation-1");
+    expect(conversation?.title).toBe("Global Memory Title");
+
+    await voltAgent.shutdown();
   });
 
   it("applies workspace to preconstructed registered agents without explicit workspace", async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

When `Memory` is passed globally to `VoltAgent`, preconstructed agents receive it later through `__setDefaultMemory`. That updated the `MemoryManager` conversation memory, but did not initialize the conversation title generator, so `generateTitle` fell back to the default title.

## What is the new behavior?

`__setDefaultMemory` now initializes the title generator from the default memory when assigning it to the agent memory manager. The memory manager also clears the generator when memory is disabled and handles concurrent conversation creation races while saving messages.

fixes #1232

## Notes for reviewers

Docs were not updated because this restores the documented `generateTitle` behavior for global memory.

Validated with:

- `pnpm vitest run src/voltagent.spec.ts src/memory/manager/memory-manager.spec.ts --reporter=verbose`
- `pnpm biome check .changeset/global-memory-title-generation.md packages/core/src/agent/agent.ts packages/core/src/memory/manager/memory-manager.ts packages/core/src/voltagent.spec.ts`
- Reproduced from `examples/base` before and after the fix; after the fix the title resolves to the generated title instead of the fallback.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes conversation title generation when global `Memory` is provided to `VoltAgent`, so preconstructed agents now use generated titles instead of the fallback. Also hardens memory handling when disabled and during concurrent conversation creation. Fixes #1232.

- **Bug Fixes**
  - Initialize and manage the title generator via `__setDefaultMemory` and `MemoryManager.setMemory` (set on assign, clear on disable).
  - Handle “conversation already exists” races in `createConversation` to avoid failures.
  - Add a test validating generated titles with global memory.

<sup>Written for commit 9ed9915b2ab2776f183ae40b54ee941f79a8698a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conversation title generation when memory is provided globally to VoltAgent, ensuring proper title initialization and persistence.
  * Improved reliability with better handling of concurrent conversation creation scenarios.

* **Tests**
  * Added test coverage for global memory title generation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->