### PR TITLE
fix(core): defer WorkspaceSearch auto-index to support tenant-aware filesystems

### DIFF
--- a/.changeset/fix-auto-index-tenant-context.md
+++ b/.changeset/fix-auto-index-tenant-context.md
@@ -1,0 +1,9 @@
+---
+"@voltagent/core": patch
+---
+
+fix(core): defer WorkspaceSearch auto-index to support tenant-aware filesystems
+
+Auto-indexing now runs lazily on the first `search()` or `init()` call instead of eagerly in the constructor. This ensures tenant-aware filesystem backends that require `operationContext` (e.g. `conversationId`) receive the context from the caller. If auto-indexing fails (e.g. missing context), subsequent calls with valid context will retry automatically.
+
+Fixes #1252

--- a/packages/core/src/workspace/search/index.spec.ts
+++ b/packages/core/src/workspace/search/index.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Workspace } from "..";
 import type { EmbeddingAdapter } from "../../memory/adapters/embedding/types";
 import { InMemoryVectorAdapter } from "../../memory/adapters/vector/in-memory";
-import { WorkspaceFilesystem } from "../filesystem";
+import { InMemoryFilesystemBackend, WorkspaceFilesystem } from "../filesystem";
 import { WorkspaceSearch, createWorkspaceSearchToolkit } from "./index";
 
 const createExecuteOptions = () => ({
@@ -198,6 +198,109 @@ describe("WorkspaceSearch", () => {
     expect(modelOutput?.value).toContain("Found 1 result(s):");
     expect(modelOutput?.value).toContain("lines 2-3");
     expect(modelOutput?.value).toContain("bm25=");
+  });
+
+  it("defers auto-index until search provides context for tenant-aware filesystem", async () => {
+    const files = {
+      "/workspace/a.ts": buildFileData("export const tenant = 'a';"),
+    };
+    const dirs = new Set(["/workspace/"]);
+
+    let callCount = 0;
+    const tenantBackend = (ctx: any) => {
+      callCount++;
+      const cid = ctx?.operationContext?.conversationId;
+      if (!cid) {
+        throw new Error("Tenant filesystem requires operationContext.conversationId");
+      }
+      return new InMemoryFilesystemBackend(files, dirs);
+    };
+
+    const filesystem = new WorkspaceFilesystem({ backend: tenantBackend as any });
+    const search = new WorkspaceSearch({
+      filesystem,
+      autoIndexPaths: [{ path: "/workspace", glob: "**/*.ts" }],
+    });
+
+    // Constructor should NOT have called the backend
+    expect(callCount).toBe(0);
+
+    // Search with proper context should trigger auto-index and succeed
+    const results = await search.search("tenant", {
+      path: "/workspace",
+      context: {
+        operationContext: { conversationId: "conv-a" } as any,
+      },
+    });
+
+    expect(callCount).toBeGreaterThan(0);
+    expect(results.length).toBe(1);
+    expect(results[0].path).toBe("/workspace/a.ts");
+  });
+
+  it("retries auto-index when previous attempt failed without context", async () => {
+    const files = {
+      "/workspace/b.ts": buildFileData("export const value = 2;"),
+    };
+    const dirs = new Set(["/workspace/"]);
+
+    let attempt = 0;
+    const tenantBackend = (ctx: any) => {
+      attempt++;
+      const cid = ctx?.operationContext?.conversationId;
+      if (!cid) {
+        throw new Error("Missing conversationId");
+      }
+      return new InMemoryFilesystemBackend(files, dirs);
+    };
+
+    const filesystem = new WorkspaceFilesystem({ backend: tenantBackend as any });
+    const search = new WorkspaceSearch({
+      filesystem,
+      autoIndexPaths: [{ path: "/workspace", glob: "**/*.ts" }],
+    });
+
+    // First search without context — auto-index should fail and allow retry
+    const empty = await search.search("value", { path: "/workspace" });
+    expect(empty.length).toBe(0);
+
+    // Second search with context — should retry auto-index and succeed
+    const results = await search.search("value", {
+      path: "/workspace",
+      context: {
+        operationContext: { conversationId: "conv-b" } as any,
+      },
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0].path).toBe("/workspace/b.ts");
+  });
+
+  it("does not re-run auto-index after successful completion", async () => {
+    let indexCallCount = 0;
+    const filesystem = new WorkspaceFilesystem({
+      files: {
+        "/workspace/c.ts": buildFileData("export const c = 3;"),
+      },
+    });
+
+    const search = new WorkspaceSearch({
+      filesystem,
+      autoIndexPaths: [{ path: "/workspace", glob: "**/*.ts" }],
+    });
+
+    const origIndexPaths = search.indexPaths.bind(search);
+    search.indexPaths = async (...args: any[]) => {
+      indexCallCount++;
+      return origIndexPaths(...args);
+    };
+
+    await search.search("c", { path: "/workspace" });
+    const firstCount = indexCallCount;
+
+    await search.search("c", { path: "/workspace" });
+    // indexPaths should not have been called again
+    expect(indexCallCount).toBe(firstCount);
   });
 
   it("can return snippet-only output when include_content is false", async () => {

--- a/packages/core/src/workspace/search/index.ts
+++ b/packages/core/src/workspace/search/index.ts
@@ -216,6 +216,7 @@ export class WorkspaceSearch {
   private readonly defaultMode: WorkspaceSearchMode;
   private readonly defaultWeights: { lexicalWeight: number; vectorWeight: number };
   private autoIndexPromise?: Promise<void>;
+  private autoIndexDone = false;
   status: WorkspaceComponentStatus = "idle";
 
   constructor(options: WorkspaceSearchConfig & { filesystem: WorkspaceFilesystem }) {
@@ -232,14 +233,9 @@ export class WorkspaceSearch {
       vectorWeight: options.hybrid?.vectorWeight ?? DEFAULT_HYBRID_VECTOR_WEIGHT,
     };
 
-    if (this.autoIndexPaths && this.autoIndexPaths.length > 0) {
-      this.autoIndexPromise = this.indexPaths(this.autoIndexPaths)
-        .then(() => undefined)
-        .catch((error) => {
-          console.error("Workspace search auto-index failed:", error);
-          return undefined;
-        });
-    }
+    // Auto-indexing is deferred to ensureAutoIndex() so that
+    // tenant-aware filesystems receive the operationContext
+    // supplied by the first search() or init() call.
   }
 
   async init(): Promise<void> {
@@ -275,12 +271,25 @@ export class WorkspaceSearch {
     if (!this.autoIndexPaths || this.autoIndexPaths.length === 0) {
       return;
     }
+    if (this.autoIndexDone) {
+      return;
+    }
     if (!this.autoIndexPromise) {
       this.autoIndexPromise = this.indexPaths(this.autoIndexPaths, { context })
-        .then(() => undefined)
+        .then((summary) => {
+          // Mark complete only if something was indexed or no errors occurred.
+          // When all paths error (e.g. missing context for tenant FS),
+          // allow retry on the next call with potentially valid context.
+          if (summary.indexed > 0 || summary.errors.length === 0) {
+            this.autoIndexDone = true;
+          } else {
+            this.autoIndexPromise = undefined;
+          }
+        })
         .catch((error) => {
           console.error("Workspace search auto-index failed:", error);
-          return undefined;
+          // Allow retry on next call with potentially valid context
+          this.autoIndexPromise = undefined;
         });
     }
     await this.autoIndexPromise;


### PR DESCRIPTION
## Summary

`WorkspaceSearch` auto-indexing now runs lazily on the first `search()` or `init()` call instead of eagerly in the constructor. This ensures tenant-aware filesystem backends that require `operationContext` (e.g. `conversationId`) receive the context from the caller.

## Problem

When `autoIndexPaths` is configured with a tenant-aware filesystem backend (one that requires `operationContext.conversationId`), the constructor immediately calls `indexPaths()` without any context. This causes the backend factory to throw, and subsequent `search()` calls with valid context never retry because `autoIndexPromise` is already set.

As a result, auto-indexed search always returns empty results for tenant-aware filesystems, forcing users to manually call `indexPaths()` as a workaround.

## Changes

- **Constructor**: Removed eager auto-index call. Added comment explaining the deferral.
- **`ensureAutoIndex()`**: Now tracks completion with `autoIndexDone` flag. If auto-indexing fails (all paths error with 0 files indexed), clears `autoIndexPromise` to allow retry on the next call with valid context.
- **Tests**: Added 3 new tests:
  - Defers auto-index until `search()` provides context
  - Retries auto-index when previous attempt failed without context
  - Does not re-run auto-index after successful completion

## Testing

All 44 workspace tests pass (10 in search module, including 3 new ones).

Closes #1252

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers `WorkspaceSearch` auto-indexing to the first `search()` or `init()` so tenant-aware filesystems receive the caller’s `operationContext` (e.g., `conversationId`). Adds retry logic so failed attempts without context don’t block future runs.

- **Bug Fixes**
  - Move auto-index from constructor to `ensureAutoIndex()`; runs with context from `search()`/`init()`.
  - Add retry behavior: if indexing indexes 0 files and errors, clear `autoIndexPromise`; otherwise set `autoIndexDone`.
  - Add tests for deferral with context, retry after no-context failure, and no re-run after success.

<sup>Written for commit b3f47befe4c4ebf8e82e42ea0c449945505f9b54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace search auto-indexing to respect operation context, ensuring tenant-aware filesystem backends receive proper caller context. Auto-indexing now defers from initialization to the first search call and automatically retries if initial attempts fail due to missing context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->