### PR TITLE
fix(core): retry workspace search auto-index with context

### DIFF
--- a/.changeset/tenant-auto-index-workspace-search.md
+++ b/.changeset/tenant-auto-index-workspace-search.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Fix workspace search auto-index retry behavior for tenant-aware filesystems that require operation context.

--- a/packages/core/src/workspace/search/index.spec.ts
+++ b/packages/core/src/workspace/search/index.spec.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import { Workspace } from "..";
 import type { EmbeddingAdapter } from "../../memory/adapters/embedding/types";
 import { InMemoryVectorAdapter } from "../../memory/adapters/vector/in-memory";
-import { WorkspaceFilesystem } from "../filesystem";
+import { InMemoryFilesystemBackend, WorkspaceFilesystem } from "../filesystem";
+import type { FileData, FilesystemBackendContext } from "../filesystem";
 import { WorkspaceSearch, createWorkspaceSearchToolkit } from "./index";
 
 const createExecuteOptions = () => ({
@@ -20,6 +21,60 @@ const buildFileData = (content: string) => {
 };
 
 describe("WorkspaceSearch", () => {
+  it("retries auto-index with operation context for tenant-aware filesystems", async () => {
+    const timestamp = new Date().toISOString();
+    const tenantFiles = new Map<string, Record<string, FileData>>([
+      [
+        "conv-a",
+        {
+          "/workspace/a.ts": {
+            content: ["export const tenant = 'a';", "export const value = 1;"],
+            created_at: timestamp,
+            modified_at: timestamp,
+          },
+        },
+      ],
+    ]);
+    const backendCalls: Array<string | undefined> = [];
+    const filesystem = new WorkspaceFilesystem({
+      backend: (context: FilesystemBackendContext) => {
+        const conversationId = context.operationContext?.conversationId;
+        backendCalls.push(conversationId);
+        if (!conversationId) {
+          throw new Error("Tenant filesystem requires operationContext.conversationId");
+        }
+
+        return new InMemoryFilesystemBackend(
+          tenantFiles.get(conversationId) ?? {},
+          new Set(["/workspace/"]),
+        );
+      },
+    });
+    const search = new WorkspaceSearch({
+      filesystem,
+      autoIndexPaths: [{ path: "/workspace", glob: "**/*.ts" }],
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      await search.init();
+      const results = await search.search("tenant", {
+        path: "/workspace",
+        context: {
+          operationContext: {
+            conversationId: "conv-a",
+          } as any,
+        },
+      });
+
+      expect(backendCalls).toContain(undefined);
+      expect(backendCalls).toContain("conv-a");
+      expect(results.map((result) => result.path)).toEqual(["/workspace/a.ts"]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("forwards operation context from toolkit to search calls", async () => {
     const indexPaths = vi.fn(async () => ({
       indexed: 0,

--- a/packages/core/src/workspace/search/index.ts
+++ b/packages/core/src/workspace/search/index.ts
@@ -231,15 +231,6 @@ export class WorkspaceSearch {
       lexicalWeight: options.hybrid?.lexicalWeight ?? DEFAULT_HYBRID_LEXICAL_WEIGHT,
       vectorWeight: options.hybrid?.vectorWeight ?? DEFAULT_HYBRID_VECTOR_WEIGHT,
     };
-
-    if (this.autoIndexPaths && this.autoIndexPaths.length > 0) {
-      this.autoIndexPromise = this.indexPaths(this.autoIndexPaths)
-        .then(() => undefined)
-        .catch((error) => {
-          console.error("Workspace search auto-index failed:", error);
-          return undefined;
-        });
-    }
   }
 
   async init(): Promise<void> {
@@ -276,12 +267,22 @@ export class WorkspaceSearch {
       return;
     }
     if (!this.autoIndexPromise) {
-      this.autoIndexPromise = this.indexPaths(this.autoIndexPaths, { context })
+      const promise = this.indexPaths(this.autoIndexPaths, { context })
+        .then((summary) => {
+          if (summary.indexed === 0 && summary.errors.length > 0) {
+            throw new Error(summary.errors.join("; "));
+          }
+          return undefined;
+        })
         .then(() => undefined)
         .catch((error) => {
           console.error("Workspace search auto-index failed:", error);
+          if (this.autoIndexPromise === promise) {
+            this.autoIndexPromise = undefined;
+          }
           return undefined;
         });
+      this.autoIndexPromise = promise;
     }
     await this.autoIndexPromise;
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Workspace search auto-index starts without operation context and caches the failed attempt. Tenant-aware filesystem backends that require `operationContext.conversationId` cannot auto-index, and later context-aware searches return no results.

## What is the new behavior?

Workspace search auto-index runs lazily and retries after failures, so a later search with operation context can index tenant-scoped files successfully.

fixes #1252

## Notes for reviewers

Validated with:

- `pnpm -C packages/core test -- src/workspace/search/index.spec.ts`
- `pnpm exec biome check packages/core/src/workspace/search/index.ts packages/core/src/workspace/search/index.spec.ts .changeset/tenant-auto-index-workspace-search.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-indexing in workspace search to retry with operation context. Prevents caching a failed, context-less index for tenant-aware filesystems that require `operationContext.conversationId` (fixes #1252).

- **Bug Fixes**
  - Auto-index runs lazily and retries on the first context-aware search instead of caching a failure.
  - Clears a failed auto-index attempt so future searches can retry; treats “indexed=0 with errors” as a failure.
  - Added tests covering tenant-aware filesystem behavior and context forwarding.

<sup>Written for commit 51004a54e31d894360fae22b206fbb6186d79351. Summary will update on new commits. <a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1257?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace search auto-indexing for tenant-aware filesystems
  * Improved retry behavior and error handling for failed auto-index operations, preventing stale operations from overwriting recent state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->