### PR TITLE
ci: skip checks for draft PRs

### DIFF
--- a/.changeset/quiet-draft-pr-checks.md
+++ b/.changeset/quiet-draft-pr-checks.md
@@ -1,0 +1,4 @@
+---
+---
+
+Skip PR checks while pull requests are drafts.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,8 +1,11 @@
 name: PR Checks
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   commit-lint:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.ref }}-commit-lint
@@ -12,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: wagoid/commitlint-github-action@v5
   lint:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,6 +42,7 @@ jobs:
       - name: Syncpack
         run: pnpm sp lint
   build:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -65,6 +70,7 @@ jobs:
       #   run: pnpm attw:all
 
   test-packages:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -110,6 +116,7 @@ jobs:
         run: lerna run test --scope "${{ steps.scope.outputs.scope }}"
 
   postgres-integration:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     name: PostgreSQL Integration Tests
     concurrency:
@@ -174,6 +181,7 @@ jobs:
           DATABASE_URL: postgresql://test:test@localhost:5432/voltagent_test
 
   e2e-tests:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     name: E2E Tests
     concurrency:


### PR DESCRIPTION
## Summary
- Skip PR check jobs while a pull request is marked as a draft.
- Run the PR checks when the pull request is marked ready for review.
- Add an empty changeset for the CI-only change.

## Why
CI is currently running on draft PRs, which wastes GitHub Actions minutes and is unnecessary while work is still in draft state.

## Validation
- Parsed `.github/workflows/pull-request.yml` as YAML.
- Ran `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip PR check jobs while a PR is in draft and run them when it’s marked ready for review. This reduces unnecessary GitHub Actions minutes on WIP PRs.

<sup>Written for commit 15a457d3b5721d9903b3d71d7fec73aea6293c22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Draft pull requests now skip automated checks to streamline the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->