### PR TITLE
fix(server-core): preserve abortSignal when resumable streams are enabled

### DIFF
--- a/packages/server-core/src/handlers/agent.handlers.ts
+++ b/packages/server-core/src/handlers/agent.handlers.ts
@@ -314,21 +314,25 @@ export async function handleChatStream(
       );
     }
 
+    const resumableStreamAdapter = deps.resumableStream;
+
     if (resumableStreamEnabled) {
-      options.abortSignal = undefined;
+      // Preserve abortSignal so client can still cancel the LLM stream.
+      const clientSignal = options.abortSignal;
+
+      // Make clearActiveStream fire-and-forget — don't await it on the hot path,
+      // and don't let client abort block this cleanup.
+      if (resumableStreamAdapter && conversationId && userId) {
+        resumableStreamAdapter.clearActiveStream({ conversationId, agentId, userId }).catch((error) => {
+          logger.warn("Failed to clear active resumable stream", { error });
+        });
+      }
+
+      // Restore signal so streamText can still be cancelled by the client.
+      options.abortSignal = clientSignal;
     }
 
     options.resumableStream = resumableStreamEnabled;
-
-    const resumableStreamAdapter = deps.resumableStream;
-    if (resumableStreamEnabled && resumableStreamAdapter && conversationId && userId) {
-      try {
-        await resumableStreamAdapter.clearActiveStream({ conversationId, agentId, userId });
-      } catch (error) {
-        logger.warn("Failed to clear active resumable stream", { error });
-      }
-    }
-
     const result = await agent.streamText(input, options);
     let activeStreamId: string | null = null;
 


### PR DESCRIPTION
## Summary

When `resumableStream` is enabled, the handler was unconditionally clearing the client's `abortSignal` before calling `streamText()`. This made it impossible for clients to cancel an in-progress LLM generation — clicking "Stop" would only stop the client-side display while the backend continued running to completion.

### What changed

**`packages/server-core/src/handlers/agent.handlers.ts`**

1. **Saves and restores `abortSignal`** — stores the client's signal in a local variable before clearing it, then restores it before `streamText()`. The client can now cancel the LLM stream as intended.

2. **Makes `clearActiveStream` fire-and-forget** — instead of `await`ing the cleanup, it calls `.catch()` so the cleanup runs in the background. This means a client abort mid-cleanup cannot block the handler.

3. **Moves `resumableStreamAdapter` declaration earlier** — to make the early fire-and-forget cleanup possible within the `resumableStreamEnabled` block.

### Root cause

```typescript
// Before (buggy)
if (resumableStreamEnabled) {
  options.abortSignal = undefined;  // client can never cancel streamText()
}
options.resumableStream = resumableStreamEnabled;
const result = await agent.streamText(input, options);
```

```typescript
// After (fixed)
const resumableStreamAdapter = deps.resumableStream;

if (resumableStreamEnabled) {
  const clientSignal = options.abortSignal;  // save
  // fire-and-forget cleanup
  resumableStreamAdapter.clearActiveStream({ ... }).catch(...);
  options.abortSignal = clientSignal;         // restore
}
options.resumableStream = resumableStreamEnabled;
const result = await agent.streamText(input, options);  // respects signal
```

Closes https://github.com/VoltAgent/voltagent/issues/1239

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes server-side cancellation when `resumableStream` is enabled by preserving the client `abortSignal` and making stream cleanup non-blocking. Clients can now reliably stop in-progress LLM generations.

- **Bug Fixes**
  - Save and restore the client's `abortSignal` so `agent.streamText()` respects cancellation.
  - Run `resumableStreamAdapter.clearActiveStream(...)` fire-and-forget with `.catch(...)` to avoid blocking on cleanup.

<sup>Written for commit a8d90f8121560bf61b643455aeffc6325f6bc533. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat streaming reliability and performance by optimizing how streaming signals are preserved and asynchronous stream cleanup is managed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/voltagent/pull/1281)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->