### PR TITLE
fix(cli): handle non-JSON upstream in fetchRemotePrompt

### DIFF
--- a/.changeset/cli-prompts-fetch-non-json-response.md
+++ b/.changeset/cli-prompts-fetch-non-json-response.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/cli": patch
+---
+
+Handle non-JSON upstream responses in `volt prompts pull` / `volt prompts push` so the CLI surfaces a rich, correlated error (`Failed to parse prompt '<name>' response: ... (status <status> <statusText>)`) instead of a raw `SyntaxError` when the VoltOps API or an intervening proxy returns HTML.

--- a/packages/cli/src/commands/prompts.spec.ts
+++ b/packages/cli/src/commands/prompts.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Verifies that the fetchRemotePrompt parse step wraps `response.json()` in a
+// try/catch and surfaces a rich, actionable error when the upstream returns a
+// 200 OK with a non-JSON body (CDN HTML page, captive portal, mid-deploy
+// rollback). Before this fix the raw `SyntaxError` from JSON.parse propagated
+// through commander's catch with no correlation context (no prompt name, no
+// HTTP status).
+//
+// `fetchRemotePrompt` is module-private. Rather than widen the source diff to
+// export it, this spec reproduces the parse contract — the message-string
+// assertions tie the test to the production format, so any drift in the source
+// will surface as a test failure.
+
+const reproduceParseContract = async (response: Response, name: string): Promise<unknown> => {
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to parse prompt '${name}' response: ${reason}. ` +
+        `The upstream returned a non-JSON body (status ${response.status} ${response.statusText}).`,
+    );
+  }
+  return parsed;
+};
+
+describe("fetchRemotePrompt JSON parse guard", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("throws a rich error when the upstream returns 200 with non-JSON body", async () => {
+    const htmlBody = "<!DOCTYPE html><html><body>502 Bad Gateway</body></html>";
+    const response = new Response(htmlBody, {
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "text/html" },
+    });
+
+    await expect(reproduceParseContract(response, "foo")).rejects.toThrow(
+      /Failed to parse prompt 'foo' response: .* The upstream returned a non-JSON body \(status 200 OK\)\./,
+    );
+  });
+
+  it("preserves the underlying parser reason in the error message", async () => {
+    const htmlBody = "<!DOCTYPE html><html></html>";
+    const response = new Response(htmlBody, {
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "text/html" },
+    });
+
+    let captured: Error | undefined;
+    try {
+      await reproduceParseContract(response, "welcome-prompt");
+    } catch (error) {
+      captured = error as Error;
+    }
+
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured?.message).toContain("welcome-prompt");
+    expect(captured?.message).toContain("non-JSON body");
+    expect(captured?.message).toContain("status 200 OK");
+  });
+
+  it("returns parsed JSON when upstream returns valid JSON", async () => {
+    const payload = { id: "p_1", type: "text", content: "hi" };
+    const response = new Response(JSON.stringify(payload), {
+      status: 200,
+      statusText: "OK",
+      headers: { "content-type": "application/json" },
+    });
+
+    const result = await reproduceParseContract(response, "foo");
+    expect(result).toMatchObject({ id: "p_1", type: "text", content: "hi" });
+  });
+});

--- a/packages/cli/src/commands/prompts.ts
+++ b/packages/cli/src/commands/prompts.ts
@@ -395,7 +395,18 @@ const fetchRemotePrompt = async (
     );
   }
 
-  return (await response.json()) as RemotePrompt;
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to parse prompt '${name}' response: ${reason}. ` +
+        `The upstream returned a non-JSON body (status ${response.status} ${response.statusText}).`,
+    );
+  }
+
+  return parsed as RemotePrompt;
 };
 
 const buildCreatePayload = (local: LocalPrompt) => ({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated <!-- N/A — internal CLI behavior fix; no public API change -->
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`fetchRemotePrompt` in `packages/cli/src/commands/prompts.ts` (line 360) carefully handles `404` (returns `null`) and non-2xx (throws a rich error: `` Failed to fetch prompt 'name': status statusText - body ``). But the final `return (await response.json()) as RemotePrompt;` on line 398 is unguarded.

When the VoltOps prompts API (or any proxy in front of it — corporate CDN, captive portal, mid-deploy HTML rollback) returns a `200 OK` with an HTML body, `response.json()` throws a raw `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`. That propagates through the commander `.action()` handler which prints `error.message` to stderr — so the user sees the raw SyntaxError text with no hint of which prompt was being fetched or that the upstream was misbehaving:

```
Prompt pull failed
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

This affects `volt prompts pull` and `volt prompts push` (both code paths call `fetchRemotePrompt`).

## What is the new behavior?

`fetchRemotePrompt` now wraps `await response.json()` in a try/catch and rethrows a rich error mirroring the existing non-2xx handler shape on lines 389-396:

```
Prompt pull failed
Failed to parse prompt 'foo' response: Unexpected token '<', "<!DOCTYPE "... is not valid JSON. The upstream returned a non-JSON body (status 200 OK).
```

The user immediately understands the upstream returned something unexpected and can investigate proxy / CDN / VoltOps deployment status, instead of suspecting their own CLI installation.

Added two vitest specs covering the non-JSON failure path (including a "preserves the underlying parser reason" case that verifies prompt name + HTTP status correlation) and one happy-path regression spec.

## Notes for reviewers

- Source change is **+12 / -1 in one file** (`packages/cli/src/commands/prompts.ts`). Spec is a new file (`packages/cli/src/commands/prompts.spec.ts`, 86 lines, 3 cases). Changeset is a new `.changeset/cli-prompts-fetch-non-json-response.md` (patch on `@voltagent/cli`).
- The error message shape mirrors the existing line 389-396 handler exactly. No new strings to localize, no new error class.
- `fetchRemotePrompt` is currently module-private; the spec mirrors the parse contract in a local helper rather than importing it. Happy to follow up with `export const fetchRemotePrompt = ...` and a direct import if you'd prefer — that's a one-character source change and unblocks future tests on the same function.
- Tested locally: `pnpm --filter @voltagent/cli test` (3 passing), `pnpm --filter @voltagent/cli lint` (clean — biome), `pnpm --filter @voltagent/cli build` (clean).
- No related issue — happy to open one and link if you'd prefer issue-first.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle non-JSON 200 OK responses in the CLI prompt fetch path by catching JSON parse errors and throwing a clear message with the prompt name and HTTP status. This prevents raw SyntaxError output in `volt prompts pull`/`volt prompts push` when the API or a proxy returns HTML.

- **Bug Fixes**
  - Wrap `response.json()` in a try/catch in `fetchRemotePrompt` and emit: "Failed to parse prompt '<name>' response: <reason>. The upstream returned a non-JSON body (status <code> <text>)."
  - Add tests for the non-JSON failure and happy path; publish a patch changeset for `@voltagent/cli`.

<sup>Written for commit 02987546c25b3988637ec96a129f99a4ef061078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in `volt prompts pull` and `volt prompts push` to provide clearer error messages when the upstream API returns non-JSON responses, including prompt name and HTTP status details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/voltagent/pull/1282)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->