### PR TITLE
fix(server-elysia): update tests to mock node:http instead of app.listen

### DIFF
--- a/packages/server-elysia/src/elysia-server-provider.spec.ts
+++ b/packages/server-elysia/src/elysia-server-provider.spec.ts
@@ -3,7 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as appFactory from "./app-factory";
 import { ElysiaServerProvider } from "./elysia-server-provider";
 
-// Mock dependencies
+const mockHttpServer = {
+  listen: vi.fn((_port: number, _host: string, cb: () => void) => {
+    cb();
+  }),
+  close: vi.fn((cb: (err?: Error) => void) => {
+    cb();
+  }),
+  once: vi.fn(),
+  listening: true,
+};
+
+vi.mock("node:http", () => ({
+  createServer: vi.fn(() => mockHttpServer),
+}));
+
 vi.mock("@voltagent/server-core", async () => {
   const actual = await vi.importActual("@voltagent/server-core");
   return {
@@ -22,10 +36,10 @@ vi.mock("@voltagent/server-core", async () => {
 describe("ElysiaServerProvider", () => {
   let provider: ElysiaServerProvider;
   const mockApp = {
-    listen: vi.fn().mockReturnValue({}),
     stop: vi.fn(),
-    routes: [], // For extractCustomEndpoints
-    get: vi.fn(), // For configureApp test
+    fetch: vi.fn(),
+    routes: [],
+    get: vi.fn(),
   };
 
   const mockDeps = {
@@ -53,18 +67,18 @@ describe("ElysiaServerProvider", () => {
   });
 
   it("should start the server", async () => {
+    const { createServer } = await import("node:http");
     await provider.start();
     expect(appFactory.createApp).toHaveBeenCalled();
-    expect(mockApp.listen).toHaveBeenCalledWith({
-      port: 3000,
-      hostname: "0.0.0.0",
-    });
+    expect(createServer).toHaveBeenCalled();
+    expect(mockHttpServer.listen).toHaveBeenCalledWith(3000, "0.0.0.0", expect.any(Function));
   });
 
   it("should stop the server", async () => {
     await provider.start();
     await provider.stop();
     expect(mockApp.stop).toHaveBeenCalled();
+    expect(mockHttpServer.close).toHaveBeenCalled();
   });
 
   it("should throw if already running", async () => {
@@ -82,10 +96,9 @@ describe("ElysiaServerProvider", () => {
   it("should extract and display custom endpoints from configureApp", async () => {
     const { printServerStartup } = await import("@voltagent/server-core");
 
-    // Create a fresh mock app for this test to avoid pollution
     const localMockApp = {
-      listen: vi.fn().mockReturnValue({}),
       stop: vi.fn(),
+      fetch: vi.fn(),
       routes: [{ method: "GET", path: "/custom-test" }],
       get: vi.fn(),
     };
@@ -112,8 +125,7 @@ describe("ElysiaServerProvider", () => {
   });
 
   it("should handle startup errors and release port", async () => {
-    // Mock app.listen to throw
-    mockApp.listen.mockImplementationOnce(() => {
+    mockHttpServer.listen.mockImplementationOnce(() => {
       throw new Error("Startup failed");
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the conventional-commit convention

## Bugs / Features

- [x] Related issue linked (#1204)
- [x] Tests for the changes have been added / fixed
- [ ] Docs have been added / updated
- [ ] Changeset added

## What is the current behavior?

All 6 tests in `elysia-server-provider.spec.ts` fail with `EADDRINUSE: address already in use 0.0.0.0:3000`.

`startServer()` was refactored to use `node:http.createServer()` + `server.listen()` because Elysia's `app.listen()` only works on Bun. The test file still mocked `mockApp.listen`, which is never called by the new implementation. With no mock in place, `server.listen` tried to bind a real port and hit `EADDRINUSE`.

## What is the new behavior?

- Add `vi.mock("node:http", ...)` that returns a fake HTTP server whose `listen()` invokes the success callback synchronously and whose `close()` calls its callback immediately.
- Remove the dead `mockApp.listen` mock and its corresponding assertions.
- The "startup errors" test now makes the fake server's `listen` throw synchronously, which is how `startServer` surfaces the error back to `start()`.
- All 6 tests pass.

Closes #1204

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Elysia server tests to mock `node:http` instead of `app.listen`, preventing real port binding and fixing EADDRINUSE; all 6 tests now pass. Closes #1204.

- **Bug Fixes**
  - Mock `node:http` to return a fake server with sync `listen` and `close`.
  - Remove dead `mockApp.listen` and related assertions; assert `createServer`, `listen`, and `close` instead.
  - Make the startup error test throw from `server.listen` to reflect `startServer` behavior.

<sup>Written for commit f5d766e669b8634832fc3585c24df4b2f1890e31. Summary will update on new commits. <a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1284?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite for the server provider to improve mock assertion accuracy and better reflect actual server behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/voltagent/pull/1284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->