### PR TITLE
fix(server-core): return workflow execute status

### DIFF
--- a/.changeset/bright-penguins-bow.md
+++ b/.changeset/bright-penguins-bow.md
@@ -1,0 +1,7 @@
+---
+"@voltagent/server-core": patch
+---
+
+fix(server-core): return workflow execute result status
+
+Fixes #1300

--- a/packages/server-core/src/handlers/workflow.handlers.ts
+++ b/packages/server-core/src/handlers/workflow.handlers.ts
@@ -468,7 +468,7 @@ export async function handleExecuteWorkflow(
           executionId: result.executionId,
           startAt: result.startAt instanceof Date ? result.startAt.toISOString() : result.startAt,
           endAt: result.endAt instanceof Date ? result.endAt.toISOString() : result.endAt,
-          status: "completed",
+          status: result.status,
           result: result.result,
         },
       };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`POST /workflows/:id/execute` hardcodes `status: "completed"` in `handleExecuteWorkflow()`, so self-suspended workflow executions are reported as completed in the synchronous API response.

## What is the new behavior?

`handleExecuteWorkflow()` now returns `result.status` from `workflow.run()` instead of the hardcoded literal.

fixes #1300

## Notes for reviewers

- This intentionally keeps the code change to a single handler line, plus the required changeset.
- Tests were not added in this PR. `handleExecuteWorkflow()` currently has no direct unit coverage; suggested follow-up tests are captured in #1300.
- Docs were not updated because this PR is limited to the server handler fix.
- Validation status:
  - The repository `PR Checks` workflow was triggered for this PR but is currently `action_required` before jobs start: https://github.com/VoltAgent/voltagent/actions/runs/26419520383
  - Current PR checks visible on GitHub: `CodeRabbit` passed, `cubic · AI code reviewer` passed, `Joggr` is neutral/skipped.
  - Once maintainers approve the forked workflow run if needed, the standard lint/build/test matrix from `.github/workflows/pull-request.yml` should run automatically.
