### PR TITLE
fix(server-core): validate workflow ownership on control endpoints

### DIFF
--- a/.changeset/workflow-control-ownership.md
+++ b/.changeset/workflow-control-ownership.md
@@ -1,0 +1,10 @@
+---
+"@voltagent/server-core": patch
+"@voltagent/server-hono": patch
+"@voltagent/serverless-hono": patch
+"@voltagent/server-elysia": patch
+---
+
+Validate workflow ownership before suspend and cancel control routes act on an execution.
+
+Fixes #1316.

--- a/packages/server-core/src/handlers/workflow.handlers.spec.ts
+++ b/packages/server-core/src/handlers/workflow.handlers.spec.ts
@@ -1,6 +1,6 @@
 import type { ServerProviderDeps, WorkflowStateEntry } from "@voltagent/core";
 import { describe, expect, it, vi } from "vitest";
-import { handleListWorkflowRuns } from "./workflow.handlers";
+import { createWorkflowControlRequestBody, handleListWorkflowRuns } from "./workflow.handlers";
 
 function createWorkflowState(
   id: string,
@@ -188,5 +188,17 @@ describe("handleListWorkflowRuns", () => {
         metadata: undefined,
       }),
     );
+  });
+});
+
+describe("createWorkflowControlRequestBody", () => {
+  it("rejects primitive JSON bodies and annotates object bodies with the route workflow id", () => {
+    expect(createWorkflowControlRequestBody("invalid", "wf-1")).toBeUndefined();
+    expect(createWorkflowControlRequestBody(1, "wf-1")).toBeUndefined();
+    expect(createWorkflowControlRequestBody(["invalid"], "wf-1")).toBeUndefined();
+    expect(createWorkflowControlRequestBody({ reason: "pause" }, "wf-1")).toEqual({
+      __workflowId: "wf-1",
+      reason: "pause",
+    });
   });
 });

--- a/packages/server-core/src/handlers/workflow.handlers.ts
+++ b/packages/server-core/src/handlers/workflow.handlers.ts
@@ -631,13 +631,16 @@ export async function handleAttachWorkflowStream(
 }
 
 async function isWorkflowExecutionOwnedByRoute(
-  body: any,
+  body: WorkflowControlRequestBody | undefined,
   executionId: string,
   deps: ServerProviderDeps,
 ) {
   const workflowId = body?.__workflowId;
+  if (typeof workflowId !== "string" || workflowId.trim().length === 0) {
+    return false;
+  }
+
   return (
-    typeof workflowId !== "string" ||
     (
       await deps.workflowRegistry
         .getWorkflow(workflowId)
@@ -646,13 +649,32 @@ async function isWorkflowExecutionOwnedByRoute(
   );
 }
 
+export type WorkflowControlRequestBody = Record<string, unknown> & {
+  __workflowId: string;
+  reason?: string;
+};
+
+export function createWorkflowControlRequestBody(
+  body: unknown,
+  workflowId: string,
+): WorkflowControlRequestBody | undefined {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return undefined;
+  }
+
+  return {
+    ...(body as Record<string, unknown>),
+    __workflowId: workflowId,
+  };
+}
+
 /**
  * Handler for suspending a workflow
  * Returns suspension result
  */
 export async function handleSuspendWorkflow(
   executionId: string,
-  body: any,
+  body: WorkflowControlRequestBody | undefined,
   deps: ServerProviderDeps,
   logger: Logger,
 ): Promise<ApiResponse> {
@@ -717,7 +739,7 @@ export async function handleSuspendWorkflow(
  */
 export async function handleCancelWorkflow(
   executionId: string,
-  body: any,
+  body: WorkflowControlRequestBody | undefined,
   deps: ServerProviderDeps,
   logger: Logger,
 ): Promise<ApiResponse> {

--- a/packages/server-core/src/handlers/workflow.handlers.ts
+++ b/packages/server-core/src/handlers/workflow.handlers.ts
@@ -630,6 +630,22 @@ export async function handleAttachWorkflowStream(
   }
 }
 
+async function isWorkflowExecutionOwnedByRoute(
+  body: any,
+  executionId: string,
+  deps: ServerProviderDeps,
+) {
+  const workflowId = body?.__workflowId;
+  return (
+    typeof workflowId !== "string" ||
+    (
+      await deps.workflowRegistry
+        .getWorkflow(workflowId)
+        ?.workflow.memory.getWorkflowState(executionId)
+    )?.workflowId === workflowId
+  );
+}
+
 /**
  * Handler for suspending a workflow
  * Returns suspension result
@@ -647,6 +663,13 @@ export async function handleSuspendWorkflow(
       return {
         success: false,
         error: "Workflow suspension not supported",
+      };
+    }
+
+    if (!(await isWorkflowExecutionOwnedByRoute(body, executionId, deps))) {
+      return {
+        success: false,
+        error: "Workflow execution not found or already completed",
       };
     }
 
@@ -705,6 +728,13 @@ export async function handleCancelWorkflow(
       return {
         success: false,
         error: "Workflow cancellation not supported",
+      };
+    }
+
+    if (!(await isWorkflowExecutionOwnedByRoute(body, executionId, deps))) {
+      return {
+        success: false,
+        error: "No active execution found or workflow already completed",
       };
     }
 

--- a/packages/server-core/src/handlers/workflow.stream-attach.handlers.spec.ts
+++ b/packages/server-core/src/handlers/workflow.stream-attach.handlers.spec.ts
@@ -356,6 +356,18 @@ describe("workflow stream attach handler", () => {
       expect(controller[method]).not.toHaveBeenCalled();
       expect(deps.workflowRegistry.activeExecutions?.has(executionId)).toBe(true);
 
+      const missingRouteResponse = await handler(
+        executionId,
+        { reason: "missing route id" } as any,
+        deps,
+        logger,
+      );
+
+      expect(missingRouteResponse.success).toBe(false);
+      expect((missingRouteResponse as ErrorResponse).error).toContain(error);
+      expect(controller[method]).not.toHaveBeenCalled();
+      expect(deps.workflowRegistry.activeExecutions?.has(executionId)).toBe(true);
+
       const correctRouteResponse = await handler(
         executionId,
         { __workflowId: "wf-1", reason: "correct route" },

--- a/packages/server-core/src/handlers/workflow.stream-attach.handlers.spec.ts
+++ b/packages/server-core/src/handlers/workflow.stream-attach.handlers.spec.ts
@@ -3,7 +3,12 @@ import type { Logger } from "@voltagent/internal";
 import { describe, expect, it, vi } from "vitest";
 import type { ErrorResponse } from "../types/responses";
 import { isErrorResponse } from "../types/responses";
-import { handleAttachWorkflowStream, handleStreamWorkflow } from "./workflow.handlers";
+import {
+  handleAttachWorkflowStream,
+  handleCancelWorkflow,
+  handleStreamWorkflow,
+  handleSuspendWorkflow,
+} from "./workflow.handlers";
 
 type ParsedSSEEvent = {
   id?: string;
@@ -48,7 +53,7 @@ function createDeps(options?: {
   const stream = options?.streamFactory ? options.streamFactory : vi.fn();
 
   const workflow = {
-    createSuspendController: vi.fn().mockReturnValue(createSuspendController()),
+    createSuspendController: vi.fn().mockImplementation(createSuspendController),
     stream,
     memory: {
       getWorkflowState,
@@ -118,6 +123,65 @@ function assertErrorResponse(
   value: ReadableStream | ErrorResponse,
 ): asserts value is ErrorResponse {
   expect(isErrorResponse(value)).toBe(true);
+}
+
+async function startBlockingWorkflowExecution(action: string) {
+  const logger = createLogger();
+  let releaseStream = () => {};
+  const streamBlocked = new Promise<void>((resolve) => {
+    releaseStream = resolve;
+  });
+  const executionId = `exec-${action}-1`;
+  const { deps } = createDeps({
+    workflowState: {
+      id: executionId,
+      workflowId: "wf-1",
+      workflowName: "Workflow 1",
+      status: "running",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    streamFactory: () => ({
+      executionId,
+      [Symbol.asyncIterator]: async function* () {
+        yield {
+          type: "workflow-start",
+          executionId,
+          from: "Workflow 1",
+          status: "running",
+          timestamp: new Date().toISOString(),
+        };
+        await streamBlocked;
+      },
+      result: Promise.resolve({ ok: true }),
+      status: Promise.resolve("completed"),
+      endAt: Promise.resolve(new Date("2026-01-01T00:00:00.000Z")),
+    }),
+  });
+
+  const streamResponse = await handleStreamWorkflow("wf-1", { input: {} }, deps, logger);
+  expect(isErrorResponse(streamResponse)).toBe(false);
+
+  if (isErrorResponse(streamResponse)) {
+    throw new Error("Expected active workflow stream");
+  }
+
+  const streamReader = streamResponse.getReader();
+  await readSSEEvent(streamReader);
+
+  const controller = deps.workflowRegistry.activeExecutions?.get(executionId) as ReturnType<
+    typeof createSuspendController
+  >;
+  expect(controller).toBeDefined();
+
+  return {
+    controller,
+    deps,
+    executionId,
+    logger,
+    releaseStream,
+    streamReader,
+  };
 }
 
 describe("workflow stream attach handler", () => {
@@ -260,4 +324,51 @@ describe("workflow stream attach handler", () => {
     const attachedFinal = await readSSEEvent(attachedReader);
     expect(attachedFinal.data.type).toBe("workflow-result");
   });
+
+  it.each([
+    {
+      action: "suspend",
+      error: "not found",
+      handler: handleSuspendWorkflow,
+      method: "suspend",
+    },
+    {
+      action: "cancel",
+      error: "No active execution found",
+      handler: handleCancelWorkflow,
+      method: "cancel",
+    },
+  ])(
+    "rejects $action requests on the wrong workflow route",
+    async ({ action, error, handler, method }) => {
+      const { controller, deps, executionId, logger, releaseStream, streamReader } =
+        await startBlockingWorkflowExecution(action);
+
+      const wrongRouteResponse = await handler(
+        executionId,
+        { __workflowId: "wf-2", reason: "wrong route" },
+        deps,
+        logger,
+      );
+
+      expect(wrongRouteResponse.success).toBe(false);
+      expect((wrongRouteResponse as ErrorResponse).error).toContain(error);
+      expect(controller[method]).not.toHaveBeenCalled();
+      expect(deps.workflowRegistry.activeExecutions?.has(executionId)).toBe(true);
+
+      const correctRouteResponse = await handler(
+        executionId,
+        { __workflowId: "wf-1", reason: "correct route" },
+        deps,
+        logger,
+      );
+
+      expect(correctRouteResponse.success).toBe(true);
+      expect(controller[method]).toHaveBeenCalledWith("correct route");
+      expect(deps.workflowRegistry.activeExecutions?.has(executionId)).toBe(false);
+
+      releaseStream();
+      await streamReader.cancel();
+    },
+  );
 });

--- a/packages/server-elysia/src/routes/workflow.routes.ts
+++ b/packages/server-elysia/src/routes/workflow.routes.ts
@@ -1,6 +1,7 @@
 import type { ServerProviderDeps } from "@voltagent/core";
 import type { Logger } from "@voltagent/internal";
 import {
+  createWorkflowControlRequestBody,
   handleAttachWorkflowStream,
   handleCancelWorkflow,
   handleExecuteWorkflow,
@@ -287,8 +288,12 @@ export function registerWorkflowRoutes(
   app.post(
     "/workflows/:id/executions/:executionId/suspend",
     async ({ params, body, set }) => {
-      (body as Record<string, unknown>).__workflowId = params.id;
-      const response = await handleSuspendWorkflow(params.executionId, body, deps, logger);
+      const response = await handleSuspendWorkflow(
+        params.executionId,
+        createWorkflowControlRequestBody(body, params.id),
+        deps,
+        logger,
+      );
       if (!response.success) {
         const errorMessage = response.error || "";
         set.status = errorMessage.includes("not found")
@@ -321,8 +326,12 @@ export function registerWorkflowRoutes(
   app.post(
     "/workflows/:id/executions/:executionId/cancel",
     async ({ params, body, set }) => {
-      (body as Record<string, unknown>).__workflowId = params.id;
-      const response = await handleCancelWorkflow(params.executionId, body, deps, logger);
+      const response = await handleCancelWorkflow(
+        params.executionId,
+        createWorkflowControlRequestBody(body, params.id),
+        deps,
+        logger,
+      );
       if (!response.success) {
         const errorMessage = response.error || "";
         set.status = errorMessage.includes("not found")

--- a/packages/server-elysia/src/routes/workflow.routes.ts
+++ b/packages/server-elysia/src/routes/workflow.routes.ts
@@ -287,6 +287,7 @@ export function registerWorkflowRoutes(
   app.post(
     "/workflows/:id/executions/:executionId/suspend",
     async ({ params, body, set }) => {
+      (body as Record<string, unknown>).__workflowId = params.id;
       const response = await handleSuspendWorkflow(params.executionId, body, deps, logger);
       if (!response.success) {
         const errorMessage = response.error || "";
@@ -320,6 +321,7 @@ export function registerWorkflowRoutes(
   app.post(
     "/workflows/:id/executions/:executionId/cancel",
     async ({ params, body, set }) => {
+      (body as Record<string, unknown>).__workflowId = params.id;
       const response = await handleCancelWorkflow(params.executionId, body, deps, logger);
       if (!response.success) {
         const errorMessage = response.error || "";

--- a/packages/server-hono/src/routes/index.ts
+++ b/packages/server-hono/src/routes/index.ts
@@ -2,6 +2,7 @@ import type { ServerProviderDeps } from "@voltagent/core";
 import type { Logger } from "@voltagent/internal";
 import {
   UPDATE_ROUTES,
+  createWorkflowControlRequestBody,
   handleAttachWorkflowStream,
   handleCancelWorkflow,
   handleChatStream,
@@ -412,8 +413,7 @@ export function registerWorkflowRoutes(
     if (!executionId) {
       throw new Error("Missing execution id parameter");
     }
-    const body = await c.req.json();
-    body.__workflowId = c.req.param("id");
+    const body = createWorkflowControlRequestBody(await c.req.json(), c.req.param("id"));
     const response = await handleSuspendWorkflow(executionId, body, deps, logger);
     if (!response.success) {
       return c.json(response, 500);
@@ -427,8 +427,7 @@ export function registerWorkflowRoutes(
     if (!executionId) {
       throw new Error("Missing execution id parameter");
     }
-    const body = await c.req.json();
-    body.__workflowId = c.req.param("id");
+    const body = createWorkflowControlRequestBody(await c.req.json(), c.req.param("id"));
     const response = await handleCancelWorkflow(executionId, body, deps, logger);
     if (!response.success) {
       const errorMessage = response.error || "";

--- a/packages/server-hono/src/routes/index.ts
+++ b/packages/server-hono/src/routes/index.ts
@@ -413,6 +413,7 @@ export function registerWorkflowRoutes(
       throw new Error("Missing execution id parameter");
     }
     const body = await c.req.json();
+    body.__workflowId = c.req.param("id");
     const response = await handleSuspendWorkflow(executionId, body, deps, logger);
     if (!response.success) {
       return c.json(response, 500);
@@ -427,6 +428,7 @@ export function registerWorkflowRoutes(
       throw new Error("Missing execution id parameter");
     }
     const body = await c.req.json();
+    body.__workflowId = c.req.param("id");
     const response = await handleCancelWorkflow(executionId, body, deps, logger);
     if (!response.success) {
       const errorMessage = response.error || "";

--- a/packages/serverless-hono/src/routes.ts
+++ b/packages/serverless-hono/src/routes.ts
@@ -532,6 +532,7 @@ export function registerWorkflowRoutes(app: Hono, deps: ServerProviderDeps, logg
     if (!body) {
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    (body as Record<string, unknown>).__workflowId = c.req.param("id");
     const response = await handleSuspendWorkflow(executionId, body, deps, logger);
     if (response.success) {
       return c.json(response, 200);
@@ -551,6 +552,7 @@ export function registerWorkflowRoutes(app: Hono, deps: ServerProviderDeps, logg
     if (!body) {
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
+    (body as Record<string, unknown>).__workflowId = c.req.param("id");
     const response = await handleCancelWorkflow(executionId, body, deps, logger);
     if (response.success) {
       return c.json(response, 200);

--- a/packages/serverless-hono/src/routes.ts
+++ b/packages/serverless-hono/src/routes.ts
@@ -33,6 +33,7 @@ import {
   type TriggerHttpRequestContext,
   UPDATE_ROUTES,
   WORKFLOW_ROUTES,
+  createWorkflowControlRequestBody,
   executeA2ARequest,
   executeTriggerHandler,
   getConversationMessagesHandler,
@@ -528,11 +529,10 @@ export function registerWorkflowRoutes(app: Hono, deps: ServerProviderDeps, logg
 
   app.post(WORKFLOW_ROUTES.suspendWorkflow.path, async (c) => {
     const executionId = c.req.param("executionId");
-    const body = await readJsonBody(c, logger);
+    const body = createWorkflowControlRequestBody(await readJsonBody(c, logger), c.req.param("id"));
     if (!body) {
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
-    (body as Record<string, unknown>).__workflowId = c.req.param("id");
     const response = await handleSuspendWorkflow(executionId, body, deps, logger);
     if (response.success) {
       return c.json(response, 200);
@@ -548,11 +548,10 @@ export function registerWorkflowRoutes(app: Hono, deps: ServerProviderDeps, logg
 
   app.post(WORKFLOW_ROUTES.cancelWorkflow.path, async (c) => {
     const executionId = c.req.param("executionId");
-    const body = await readJsonBody(c, logger);
+    const body = createWorkflowControlRequestBody(await readJsonBody(c, logger), c.req.param("id"));
     if (!body) {
       return c.json({ success: false, error: "Invalid JSON body" }, 400);
     }
-    (body as Record<string, unknown>).__workflowId = c.req.param("id");
     const response = await handleCancelWorkflow(executionId, body, deps, logger);
     if (response.success) {
       return c.json(response, 200);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`POST /workflows/:id/executions/:executionId/suspend` and `POST /workflows/:id/executions/:executionId/cancel` ignore the workflow ID path parameter and act on the active execution by `executionId` alone.

That allows a wrong-route request to suspend or cancel a live execution that belongs to another workflow.

## What is the new behavior?

The shared control handlers now verify that the route workflow owns the execution before acting on it.

The adapters pass the route workflow ID into the shared handler body, and wrong-route suspend/cancel requests are rejected instead of mutating the real execution.

Fixes #1316

## Notes for reviewers

- The shared handler signatures are unchanged.
- The fix is localized to workflow control routing and `server-core` ownership validation.
- Regression coverage was added to the existing `workflow.stream-attach.handlers.spec.ts` file.
- I reran the full `@voltagent/server-core` test suite locally after the final patch, and manually rechecked the reported wrong-route repro behavior earlier in the investigation.
- I also noticed an unrelated `packages/server-elysia/src/elysia-server-provider.spec.ts` issue during earlier local validation ( #1204 ) and intentionally left it out to keep this PR minimal and scoped to #1316.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate workflow ownership on suspend and cancel, and harden request validation so wrong-route or malformed requests can’t control executions. Adapters tag control requests with the route workflow ID, and `@voltagent/server-core` verifies ownership before acting. Fixes #1316.

- **Bug Fixes**
  - `@voltagent/server-core`: enforce ownership in suspend/cancel; added `createWorkflowControlRequestBody` to validate JSON bodies and attach `__workflowId`.
  - `@voltagent/server-elysia`, `@voltagent/server-hono`, `@voltagent/serverless-hono`: use `createWorkflowControlRequestBody` to inject `__workflowId`; `serverless-hono` returns 400 for invalid JSON.
  - Added regression tests for wrong-route suspend/cancel, correct-route success, and request-body validation.

<sup>Written for commit dbd40e84e44aac88dc88c002ca0bf8c6a5bb4a20. Summary will update on new commits. <a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1318?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suspend and cancel workflow actions now verify the workflow ownership before operating; requests targeting a wrong or missing workflow will return an error, while correct-route requests proceed and respect provided reasons.

* **Tests**
  * Added coverage validating failure for incorrect/missing workflow routing and success paths that invoke the control actions and clean up active executions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/voltagent/pull/1318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->