### PR TITLE
docs: fix broken README links to recipes-and-guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ You can test the pre-built `expenseApprovalWorkflow` directly from the VoltOps c
 
 For more examples, visit our [examples repository](https://github.com/VoltAgent/voltagent/tree/main/examples).
 
-- **[Airtable Agent](https://voltagent.dev/examples/guides/airtable-agent)** - React to new records and write updates back into Airtable with VoltOps actions.
-- **[Slack Agent](https://voltagent.dev/examples/guides/slack-agent)** - Respond to channel messages and reply via VoltOps Slack actions.
+- **[Airtable Agent](https://voltagent.dev/recipes-and-guides/airtable-agent)** - React to new records and write updates back into Airtable with VoltOps actions.
+- **[Slack Agent](https://voltagent.dev/recipes-and-guides/slack-agent)** - Respond to channel messages and reply via VoltOps Slack actions.
 - **[ChatGPT App With VoltAgent](https://voltagent.dev/examples/agents/chatgpt-app)** - Deploy VoltAgent over MCP and connect to ChatGPT Apps.
 - **[WhatsApp Order Agent](https://voltagent.dev/examples/agents/whatsapp-ai-agent)** - Build a WhatsApp chatbot that handles food orders through natural conversation. ([Source](https://github.com/VoltAgent/voltagent/tree/main/examples/with-whatsapp))
 - **[YouTube to Blog Agent](https://voltagent.dev/examples/agents/youtube-blog-agent)** - Convert YouTube videos into Markdown blog posts using a supervisor agent with MCP tools. ([Source](https://github.com/VoltAgent/voltagent/tree/main/examples/with-youtube-to-blog))

--- a/i18n/README-cn-bsc.md
+++ b/i18n/README-cn-bsc.md
@@ -250,8 +250,8 @@ export const expenseApprovalWorkflow = createWorkflowChain({
 
 有关更多示例，请访问我们的[示例仓库](https://github.com/VoltAgent/voltagent/tree/main/examples)。
 
-- **[Airtable 代理](https://voltagent.dev/examples/guides/airtable-agent)** - 响应新记录并通过 VoltOps 操作将更新写回 Airtable。
-- **[Slack 代理](https://voltagent.dev/examples/guides/slack-agent)** - 响应频道消息并通过 VoltOps Slack 操作进行回复。
+- **[Airtable 代理](https://voltagent.dev/recipes-and-guides/airtable-agent)** - 响应新记录并通过 VoltOps 操作将更新写回 Airtable。
+- **[Slack 代理](https://voltagent.dev/recipes-and-guides/slack-agent)** - 响应频道消息并通过 VoltOps Slack 操作进行回复。
 - **[ChatGPT 应用与 VoltAgent](https://voltagent.dev/examples/agents/chatgpt-app)** - 通过 MCP 部署 VoltAgent 并连接到 ChatGPT 应用。
 - **[WhatsApp 订单代理](https://voltagent.dev/examples/agents/whatsapp-ai-agent)** - 构建一个 WhatsApp 聊天机器人，通过自然对话处理食品订单。([源代码](https://github.com/VoltAgent/voltagent/tree/main/examples/with-whatsapp))
 - **[YouTube 转博客代理](https://voltagent.dev/examples/agents/youtube-blog-agent)** - 使用主管代理与 MCP 工具将 YouTube 视频转换为 Markdown 博客文章。([源代码](https://github.com/VoltAgent/voltagent/tree/main/examples/with-youtube-to-blog))

--- a/i18n/README-cn-traditional.md
+++ b/i18n/README-cn-traditional.md
@@ -250,8 +250,8 @@ export const expenseApprovalWorkflow = createWorkflowChain({
 
 有關更多範例，請訪問我們的[範例存儲庫](https://github.com/VoltAgent/voltagent/tree/main/examples)。
 
-- **[Airtable 代理](https://voltagent.dev/examples/guides/airtable-agent)** - 響應新記錄並通過 VoltOps 操作將更新寫回 Airtable。
-- **[Slack 代理](https://voltagent.dev/examples/guides/slack-agent)** - 響應頻道訊息並通過 VoltOps Slack 操作進行回覆。
+- **[Airtable 代理](https://voltagent.dev/recipes-and-guides/airtable-agent)** - 響應新記錄並通過 VoltOps 操作將更新寫回 Airtable。
+- **[Slack 代理](https://voltagent.dev/recipes-and-guides/slack-agent)** - 響應頻道訊息並通過 VoltOps Slack 操作進行回覆。
 - **[ChatGPT 應用與 VoltAgent](https://voltagent.dev/examples/agents/chatgpt-app)** - 通過 MCP 部署 VoltAgent 並連接到 ChatGPT 應用。
 - **[WhatsApp 訂單代理](https://voltagent.dev/examples/agents/whatsapp-ai-agent)** - 構建一個 WhatsApp 聊天機器人，通過自然對話處理食品訂單。([原始碼](https://github.com/VoltAgent/voltagent/tree/main/examples/with-whatsapp))
 - **[YouTube 轉部落格代理](https://voltagent.dev/examples/agents/youtube-blog-agent)** - 使用監督者代理與 MCP 工具將 YouTube 視訊轉換為 Markdown 部落格文章。([原始碼](https://github.com/VoltAgent/voltagent/tree/main/examples/with-youtube-to-blog))

--- a/i18n/README-jp.md
+++ b/i18n/README-jp.md
@@ -250,8 +250,8 @@ VoltOpsコンソールから直接、事前構築された`expenseApprovalWorkfl
 
 より多くのサンプルについては、[サンプルリポジトリ](https://github.com/VoltAgent/voltagent/tree/main/examples)をご覧ください。
 
-- **[Airtableエージェント](https://voltagent.dev/examples/guides/airtable-agent)** - 新しいレコードに反応し、VoltOpsアクションでAirtableに更新を書き戻します。
-- **[Slackエージェント](https://voltagent.dev/examples/guides/slack-agent)** - チャンネルメッセージに応答し、VoltOps Slackアクションで返信します。
+- **[Airtableエージェント](https://voltagent.dev/recipes-and-guides/airtable-agent)** - 新しいレコードに反応し、VoltOpsアクションでAirtableに更新を書き戻します。
+- **[Slackエージェント](https://voltagent.dev/recipes-and-guides/slack-agent)** - チャンネルメッセージに応答し、VoltOps Slackアクションで返信します。
 - **[ChatGPTアプリとVoltAgent](https://voltagent.dev/examples/agents/chatgpt-app)** - VoltAgentをMCP経由でデプロイし、ChatGPTアプリに接続します。
 - **[WhatsApp注文エージェント](https://voltagent.dev/examples/agents/whatsapp-ai-agent)** - 自然な会話で食品注文を処理するWhatsAppチャットボットを構築します。（[ソースコード](https://github.com/VoltAgent/voltagent/tree/main/examples/with-whatsapp)）
 - **[YouTubeからブログエージェント](https://voltagent.dev/examples/agents/youtube-blog-agent)** - MCPツールを使用したスーパーバイザーエージェントでYouTube動画をMarkdownブログ投稿に変換します。（[ソースコード](https://github.com/VoltAgent/voltagent/tree/main/examples/with-youtube-to-blog)）

--- a/i18n/README-kr.md
+++ b/i18n/README-kr.md
@@ -250,8 +250,8 @@ VoltOps 콘솔에서 직접 사전 구축된 `expenseApprovalWorkflow`를 테스
 
 더 많은 예제는 [예제 리포지토리](https://github.com/VoltAgent/voltagent/tree/main/examples)를 방문하세요.
 
-- **[Airtable 에이전트](https://voltagent.dev/examples/guides/airtable-agent)** - 새 레코드에 반응하고 VoltOps 액션으로 Airtable에 업데이트를 작성합니다.
-- **[Slack 에이전트](https://voltagent.dev/examples/guides/slack-agent)** - 채널 메시지에 응답하고 VoltOps Slack 액션으로 답장합니다.
+- **[Airtable 에이전트](https://voltagent.dev/recipes-and-guides/airtable-agent)** - 새 레코드에 반응하고 VoltOps 액션으로 Airtable에 업데이트를 작성합니다.
+- **[Slack 에이전트](https://voltagent.dev/recipes-and-guides/slack-agent)** - 채널 메시지에 응답하고 VoltOps Slack 액션으로 답장합니다.
 - **[ChatGPT 앱과 VoltAgent](https://voltagent.dev/examples/agents/chatgpt-app)** - VoltAgent를 MCP를 통해 배포하고 ChatGPT 앱에 연결합니다.
 - **[WhatsApp 주문 에이전트](https://voltagent.dev/examples/agents/whatsapp-ai-agent)** - 자연스러운 대화로 음식 주문을 처리하는 WhatsApp 챗봇을 구축합니다. ([소스 코드](https://github.com/VoltAgent/voltagent/tree/main/examples/with-whatsapp))
 - **[YouTube to 블로그 에이전트](https://voltagent.dev/examples/agents/youtube-blog-agent)** - MCP 도구를 사용한 감독자 에이전트로 YouTube 비디오를 Markdown 블로그 게시물로 변환합니다. ([소스 코드](https://github.com/VoltAgent/voltagent/tree/main/examples/with-youtube-to-blog))


### PR DESCRIPTION
## What is the current behavior?

The README and its translated copies link to two recipe pages under the old `/examples/guides/` path:

- `https://voltagent.dev/examples/guides/airtable-agent` → 404
- `https://voltagent.dev/examples/guides/slack-agent` → 404

The recipes plugin in `website/docusaurus.config.ts` exposes these pages under `routeBasePath: "recipes-and-guides"`, and the file `website/docusaurus.config.ts` already maps `/recipes/slack-agent/` → `/recipes-and-guides/slack-agent/`, but there is no redirect from the `/examples/guides/...` paths used by the README, so the links land on a 404.

## What is the new behavior?

Updates the README links (English + 5 i18n copies) to the canonical `/recipes-and-guides/<slug>` URLs:

- `https://voltagent.dev/recipes-and-guides/airtable-agent`
- `https://voltagent.dev/recipes-and-guides/slack-agent`

Pages confirmed at `website/recipes/airtable-agent.md` and `website/recipes/slack-agent.md`, and registered in `website/sidebarsRecipes.ts`.

## Notes for reviewers

- Docs-only change, no source / build / test impact (precedent: #923 README+i18n update merged without a changeset).
- Diff is +10/-10 across `README.md` + the four `i18n/README-*.md` translations.
- Did not add a redirect because the `/examples/guides/...` paths weren't in the existing `from:` lists; happy to add one if preferred over the README edit.

## PR Checklist

- [x] The commit message follows our guidelines
- [x] Docs have been added / updated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken Airtable Agent and Slack Agent links in the README and all i18n copies. Updated URLs to https://voltagent.dev/recipes-and-guides/airtable-agent and https://voltagent.dev/recipes-and-guides/slack-agent so they no longer 404.

<sup>Written for commit 6d1fe2de4108a2db9d913ff1578387bfece253b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1325?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Airtable and Slack agent documentation links across multiple language versions of the README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/voltagent/pull/1325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->