### PR TITLE
examples: add Tuning Engines OpenAI-compatible endpoint

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -98,6 +98,7 @@ Create a multi-agent research workflow where different AI agents collaborate to 
 - [Amazon Bedrock](./with-amazon-bedrock) — Run AWS Bedrock models by configuring credentials and model IDs in VoltAgent.
 - [Anthropic](./with-anthropic) — Use Claude models as your agent’s LLM via the AI SDK.
 - [OpenRouter](./with-openrouter) — Use OpenRouter through VoltAgent's built-in `openrouter/<model>` routing.
+- [Tuning Engines](./with-tuning-engines) — Route VoltAgent model calls through a governed OpenAI-compatible endpoint for policy, traces, and usage/cost reporting.
 - [Chroma](./with-chroma) — RAG with Chroma vectors showing automatic vs tool‑driven retrieval patterns.
 - [Client‑side Tools](./with-client-side-tools) — Next.js UI triggers typed client‑side tools safely, VoltAgent on the server.
 - [Cloudflare Workers](./with-cloudflare-workers) — Deploy your agent on Workers using the Hono server adapter.

--- a/examples/with-tuning-engines/.env.example
+++ b/examples/with-tuning-engines/.env.example
@@ -1,0 +1,2 @@
+TUNING_ENGINES_API_KEY=sk-te-your-inference-key
+TUNING_ENGINES_MODEL=gpt-4o

--- a/examples/with-tuning-engines/README.md
+++ b/examples/with-tuning-engines/README.md
@@ -1,0 +1,75 @@
+# with-tuning-engines
+
+A [VoltAgent](https://github.com/VoltAgent/voltagent) application using Tuning Engines as a governed OpenAI-compatible endpoint.
+
+Tuning Engines can sit between VoltAgent and the underlying model providers so that VoltAgent owns the agent runtime, tools, and memory, while Tuning Engines centralizes model access, policy checks, audit logs, traces, and usage/cost reporting.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js (v20 or newer)
+- npm, yarn, or pnpm
+- A Tuning Engines inference key with access to the model alias you want to use
+
+### Installation
+
+1. Clone this repository
+2. Install dependencies
+3. Copy `.env.example` to `.env`
+4. Set `TUNING_ENGINES_API_KEY`
+5. Optionally set `TUNING_ENGINES_MODEL`
+
+```bash
+npm install
+# or
+yarn
+# or
+pnpm install
+```
+
+### Development
+
+Run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+```
+
+The example starts a VoltAgent server on port `3141`.
+
+The dev script uses `tsx watch --env-file=.env ./src`, matching the example's `package.json` setup.
+
+## What This Example Shows
+
+- `Agent` configured with `@ai-sdk/openai` and a custom `baseURL`
+- Tuning Engines inference key usage via `TUNING_ENGINES_API_KEY`
+- Optional model alias selection via `TUNING_ENGINES_MODEL`
+- Local memory storage with LibSQL
+- Hono server integration through `@voltagent/server-hono`
+
+## Notes
+
+Use `pnpm build && pnpm start` for the compiled output, or `pnpm dev` during development.
+
+## Project Structure
+
+```text
+.
+├── src/
+│   └── index.ts
+├── .env.example
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## Try Example
+
+```bash
+npm create voltagent-app@latest -- --example with-tuning-engines
+```

--- a/examples/with-tuning-engines/package.json
+++ b/examples/with-tuning-engines/package.json
@@ -1,6 +1,9 @@
 {
   "name": "voltagent-example-with-tuning-engines",
   "author": "",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.0",
     "@voltagent/cli": "^0.1.21",

--- a/examples/with-tuning-engines/package.json
+++ b/examples/with-tuning-engines/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "voltagent-example-with-tuning-engines",
+  "author": "",
+  "dependencies": {
+    "@ai-sdk/openai": "^3.0.0",
+    "@voltagent/cli": "^0.1.21",
+    "@voltagent/core": "^2.7.5",
+    "@voltagent/libsql": "^2.1.2",
+    "@voltagent/logger": "^2.0.2",
+    "@voltagent/server-hono": "^2.0.13",
+    "ai": "^6.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.2.1",
+    "tsx": "^4.21.0",
+    "typescript": "^5.8.2"
+  },
+  "keywords": [
+    "agent",
+    "ai",
+    "openai-compatible",
+    "tuning-engines",
+    "voltagent"
+  ],
+  "license": "MIT",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VoltAgent/voltagent.git",
+    "directory": "examples/with-tuning-engines"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch --env-file=.env ./src",
+    "start": "node dist/index.js",
+    "volt": "volt"
+  },
+  "type": "module"
+}

--- a/examples/with-tuning-engines/src/index.ts
+++ b/examples/with-tuning-engines/src/index.ts
@@ -1,0 +1,48 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { Agent, Memory, VoltAgent } from "@voltagent/core";
+import { LibSQLMemoryAdapter } from "@voltagent/libsql";
+import { createPinoLogger } from "@voltagent/logger";
+import { honoServer } from "@voltagent/server-hono";
+
+if (!process.env.TUNING_ENGINES_API_KEY) {
+  throw new Error("TUNING_ENGINES_API_KEY is required");
+}
+
+const tuningEngines = createOpenAI({
+  apiKey: process.env.TUNING_ENGINES_API_KEY,
+  baseURL: "https://api.tuningengines.com/v1",
+});
+
+const logger = createPinoLogger({
+  name: "with-tuning-engines",
+  level: "info",
+});
+
+const agent = new Agent({
+  name: "Tuning Engines Assistant",
+  instructions:
+    "You are a helpful assistant running through a governed OpenAI-compatible endpoint.",
+  model: tuningEngines(process.env.TUNING_ENGINES_MODEL ?? "gpt-4o"),
+  memory: new Memory({
+    storage: new LibSQLMemoryAdapter(),
+  }),
+});
+
+new VoltAgent({
+  agents: {
+    agent,
+  },
+  logger,
+  server: honoServer(),
+});
+
+(async () => {
+  const result = await agent.generateText(
+    "Explain how policy, traces, and usage reporting help production AI agents.",
+  );
+
+  logger.info("Tuning Engines example request completed", {
+    text: result.text,
+    usage: result.usage,
+  });
+})();

--- a/examples/with-tuning-engines/src/index.ts
+++ b/examples/with-tuning-engines/src/index.ts
@@ -37,12 +37,17 @@ new VoltAgent({
 });
 
 (async () => {
-  const result = await agent.generateText(
-    "Explain how policy, traces, and usage reporting help production AI agents.",
-  );
+  try {
+    const result = await agent.generateText(
+      "Explain how policy, traces, and usage reporting help production AI agents.",
+    );
 
-  logger.info("Tuning Engines example request completed", {
-    text: result.text,
-    usage: result.usage,
-  });
+    logger.info("Tuning Engines example request completed", {
+      text: result.text,
+      usage: result.usage,
+    });
+  } catch (error) {
+    logger.error("Tuning Engines example request failed", { error });
+    process.exitCode = 1;
+  }
 })();

--- a/examples/with-tuning-engines/tsconfig.json
+++ b/examples/with-tuning-engines/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a runnable with-tuning-engines example alongside the existing provider examples
- configure @ai-sdk/openai with a custom baseURL and TUNING_ENGINES_API_KEY
- update the examples index to include the new example

## Why
We are an AI infrastructure team using VoltAgent with Tuning Engines. VoltAgent remains the agent runtime for tools, memory, and server behavior; Tuning Engines provides a governed OpenAI-compatible endpoint for model access, policy checks, audit logs, traces, and usage/cost reporting. Since the examples already include provider/gateway setups such as OpenRouter, this gives teams using Tuning Engines a starter that matches the existing examples structure. It would mean a lot to us if this is useful, and I am happy to adjust the example to fit your conventions.

## Validation
- git diff --check
- attempted dependency install for the example; the repo-wide pnpm workspace install failed locally because the machine ran out of disk while fetching workspace dependencies, so I did not complete a TypeScript build in this environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable `with-tuning-engines` example that routes VoltAgent model calls through a governed OpenAI-compatible endpoint, with startup validation and logging. This enables policy checks, traces, and usage/cost reporting without changing agent code.

- **New Features**
  - New example at `examples/with-tuning-engines` using `@ai-sdk/openai` with custom `baseURL` and `TUNING_ENGINES_API_KEY`; optional `TUNING_ENGINES_MODEL` (default `gpt-4o`); `.env.example` added; linked in the examples index.
  - Runs a VoltAgent server via `@voltagent/server-hono` with LibSQL memory (`@voltagent/libsql`) and structured logging via `@voltagent/logger`.
  - Startup hardening: throws if `TUNING_ENGINES_API_KEY` is missing; dev script uses `tsx` with `.env`.
  - Demo performs one text generation on boot and logs response text and usage.

<sup>Written for commit 38f7ffffacfdd21cfe4ee9b11af9c8fcaca1a40e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Tuning Engines" example showing VoltAgent integration with a governed OpenAI-compatible endpoint, selectable model, local memory, logging, and a runnable dev/start workflow.

* **Documentation**
  * Included full example docs, environment variable placeholders, installation and dev/start instructions, usage notes, and project structure guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->