### PR TITLE
fix(core): prevent streamText abort unhandled rejections

### DIFF
--- a/.changeset/quiet-stream-abort.md
+++ b/.changeset/quiet-stream-abort.md
@@ -1,0 +1,21 @@
+---
+"@voltagent/core": patch
+---
+
+fix: prevent unhandled rejections when aborting `Agent.streamText()` streams
+
+## The Problem
+
+`Agent.streamText()` eagerly read the AI SDK result getters for `text`, `usage`, and `finishReason` while constructing VoltAgent's wrapped result. In AI SDK v6 these fields are lazy promises, so reading them early could materialize promises that the caller never consumes.
+
+When a caller only consumed the UI/full stream and aborted the run, those unconsumed promises could reject globally as `unhandledRejection` events.
+
+## The Solution
+
+VoltAgent now preserves the lazy getter behavior for `text`, `usage`, and `finishReason`. The sanitized text promise is also created only when `result.text` is accessed.
+
+## Impact
+
+- Aborting a consumed `streamText()` stream no longer emits unhandled rejections for unconsumed result fields
+- Callers using only `toUIMessageStream()`, `toUIMessageStreamResponse()`, `fullStream`, or `textStream` do not need to attach defensive `.catch()` handlers to `text`, `usage`, or `finishReason`
+- Matches AI SDK v6's lazy stream result contract more closely

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -1008,6 +1008,82 @@ Use pandas and summarize findings.`.split("\n"),
       expect(text).toBe("Streamed response");
     });
 
+    it("does not eagerly materialize lazy stream result promises", async () => {
+      const agent = new Agent({
+        name: "TestAgent",
+        instructions: "You are a helpful assistant",
+        model: mockModel as any,
+      });
+
+      const getterAccesses = {
+        text: 0,
+        usage: 0,
+        finishReason: 0,
+      };
+
+      const mockStream = {
+        get text() {
+          getterAccesses.text += 1;
+          return Promise.resolve("Streamed response");
+        },
+        textStream: (async function* () {
+          yield "Streamed response";
+        })(),
+        fullStream: toAsyncIterableStream(
+          convertArrayToReadableStream([
+            {
+              type: "text-delta" as const,
+              id: "text-1",
+              delta: "Streamed response",
+              text: "Streamed response",
+            },
+          ]),
+        ),
+        get usage() {
+          getterAccesses.usage += 1;
+          return Promise.resolve({
+            inputTokens: 10,
+            outputTokens: 5,
+            totalTokens: 15,
+          });
+        },
+        get finishReason() {
+          getterAccesses.finishReason += 1;
+          return Promise.resolve("stop");
+        },
+        warnings: [],
+        toUIMessageStream: vi.fn(),
+        toUIMessageStreamResponse: vi.fn(),
+        pipeUIMessageStreamToResponse: vi.fn(),
+        pipeTextStreamToResponse: vi.fn(),
+        toTextStreamResponse: vi.fn(),
+        partialOutputStream: undefined,
+      };
+
+      vi.mocked(ai.streamText).mockReturnValue(mockStream as any);
+
+      const result = await agent.streamText("Stream this");
+
+      expect(getterAccesses).toEqual({
+        text: 0,
+        usage: 0,
+        finishReason: 0,
+      });
+
+      await expect(result.text).resolves.toBe("Streamed response");
+      await expect(result.usage).resolves.toEqual({
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      });
+      await expect(result.finishReason).resolves.toBe("stop");
+      expect(getterAccesses).toEqual({
+        text: 1,
+        usage: 1,
+        finishReason: 1,
+      });
+    });
+
     it("pre-creates streaming message ids and forwards them to UI streams", async () => {
       const agent = new Agent({
         name: "TestAgent",

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1961,7 +1961,7 @@ export class Agent {
         const guardrailStreamingEnabled = guardrailSet.output.length > 0;
 
         let guardrailPipeline: GuardrailPipeline | null = null;
-        let sanitizedTextPromise!: PromiseLike<string>;
+        let sanitizedTextPromise: Promise<string> | undefined;
         const { result, modelName: effectiveModelName } = await this.executeWithModelFallback({
           oc,
           operation: "streamText",
@@ -2190,7 +2190,7 @@ export class Agent {
                     finalText = bailedResult.response;
                   }
                 } else if (guardrailPipeline) {
-                  finalText = await sanitizedTextPromise;
+                  finalText = await getSanitizedTextPromise();
                 } else if (guardrailSet.output.length > 0) {
                   finalText = await executeOutputGuardrails({
                     output: finalResult.text,
@@ -2512,31 +2512,28 @@ export class Agent {
           ? createBaseFullStream()
           : undefined;
 
-        if (guardrailStreamingEnabled) {
-          guardrailPipeline = createGuardrailPipeline(
-            baseFullStreamForPipeline as AsyncIterable<VoltAgentTextStreamPart>,
-            result.textStream,
-            guardrailContext,
-          );
-          sanitizedTextPromise = guardrailPipeline.finalizePromise.then(async () => {
-            const sanitized = guardrailPipeline?.runner?.getSanitizedText();
-            if (typeof sanitized === "string" && sanitized.length > 0) {
-              return sanitized;
-            }
-            // Wait for AI SDK text first (stream must complete)
-            const aiSdkText = await result.text;
+        const createSanitizedTextPromise = (): Promise<string> => {
+          if (guardrailPipeline) {
+            return guardrailPipeline.finalizePromise.then(async () => {
+              const sanitized = guardrailPipeline?.runner?.getSanitizedText();
+              if (typeof sanitized === "string" && sanitized.length > 0) {
+                return sanitized;
+              }
+              // Wait for AI SDK text first (stream must complete)
+              const aiSdkText = await result.text;
 
-            // NOW check for bailed result (set during stream processing)
-            const bailedResult = oc.systemContext.get("bailedResult") as
-              | { agentName: string; response: string }
-              | undefined;
-            return bailedResult?.response || aiSdkText;
-          });
-        } else {
+              // NOW check for bailed result (set during stream processing)
+              const bailedResult = oc.systemContext.get("bailedResult") as
+                | { agentName: string; response: string }
+                | undefined;
+              return bailedResult?.response || aiSdkText;
+            });
+          }
+
           // Wrap result.text with a bail check
           // IMPORTANT: Wait for AI SDK text first (stream must complete/abort)
           // This ensures createStepHandler has processed tool results and set bailedResult
-          sanitizedTextPromise = result.text.then((aiSdkText) => {
+          return Promise.resolve(result.text).then((aiSdkText) => {
             // NOW check if bailed (set by createStepHandler during stream processing)
             const bailedResult = oc.systemContext.get("bailedResult") as
               | { agentName: string; response: string }
@@ -2544,6 +2541,23 @@ export class Agent {
 
             // Return bailed subagent's result instead of supervisor's (if bailed)
             return bailedResult?.response || aiSdkText;
+          });
+        };
+
+        const getSanitizedTextPromise = (): Promise<string> => {
+          sanitizedTextPromise ??= createSanitizedTextPromise();
+          return sanitizedTextPromise;
+        };
+
+        if (guardrailStreamingEnabled) {
+          guardrailPipeline = createGuardrailPipeline(
+            baseFullStreamForPipeline as AsyncIterable<VoltAgentTextStreamPart>,
+            result.textStream,
+            guardrailContext,
+          );
+          void guardrailPipeline.finalizePromise.catch(() => {
+            // The guarded streams surface this error to their consumers. Keep the
+            // internal finalizer promise from leaking when text is never requested.
           });
         }
 
@@ -2676,15 +2690,21 @@ export class Agent {
 
         // Create a wrapper that includes context and delegates to the original result
         const resultWithContext: StreamTextResultWithContext = {
-          text: sanitizedTextPromise,
+          get text() {
+            return getSanitizedTextPromise();
+          },
           get textStream() {
             return getGuardrailAwareTextStream();
           },
           get fullStream() {
             return getGuardrailAwareFullStream();
           },
-          usage: result.usage,
-          finishReason: result.finishReason,
+          get usage() {
+            return result.usage;
+          },
+          get finishReason() {
+            return result.finishReason;
+          },
           get partialOutputStream() {
             return result.partialOutputStream;
           },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked (no issue number provided)
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not applicable; internal bug fix)
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

`Agent.streamText()` eagerly materializes the AI SDK `text`, `usage`, and `finishReason` lazy result promises while constructing VoltAgent's wrapped stream result.

When a caller only consumes the stream, for example through `toUIMessageStream()`, and then aborts the run, those unconsumed promises can reject without handlers and emit global `unhandledRejection` events.

## What is the new behavior?

VoltAgent preserves lazy access for `text`, `usage`, and `finishReason` on `streamText()` results. The sanitized text promise is now created only when `result.text` is accessed.

This keeps stream-only consumers from needing defensive `.catch()` handlers for fields they never read and aligns the wrapper more closely with AI SDK v6's lazy stream result contract.

fixes (issue): N/A

## Notes for reviewers

Validation run locally:

- `pnpm --filter @voltagent/core build`
- `pnpm --filter @voltagent/core test:single src/agent/agent.spec.ts -t "does not eagerly materialize lazy stream result promises"`
- `pnpm exec biome check packages/core/src/agent/agent.ts packages/core/src/agent/agent.spec.ts .changeset/quiet-stream-abort.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unhandled promise rejections when aborting `Agent.streamText()` by keeping `text`, `usage`, and `finishReason` lazy. Stream-only consumers (e.g., `toUIMessageStream()`) can abort safely, matching AI SDK v6’s lazy stream contract.

- **Bug Fixes**
  - Do not eagerly create result promises; expose `text`, `usage`, and `finishReason` as getters on the wrapper.
  - Build sanitized text lazily only when `result.text` is accessed; contain guardrail finalizer errors so they don’t leak if text isn’t read.
  - Keep guardrail-aware `textStream`/`fullStream` behavior without forcing promise creation.

<sup>Written for commit 18c2b1133056a9c596def0a5e7a926909e1dbd7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Resolved unhandled rejection errors when aborting stream operations. Agent.streamText() now uses lazy evaluation for stream result fields, creating promises only when explicitly accessed by callers. This prevents errors that previously occurred when aborting mid-stream after consuming partial results or specific stream derivatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->