### PR TITLE
docs: add MiniMax-M3 and update minimax default model

### DIFF
--- a/.changeset/MiniMax-m3-update.md
+++ b/.changeset/MiniMax-m3-update.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+docs: add MiniMax-M3 model and update default to M3 for minimax providers

--- a/packages/core/src/registries/model-provider-registry-minimax.spec.ts
+++ b/packages/core/src/registries/model-provider-registry-minimax.spec.ts
@@ -74,7 +74,7 @@ describe("MiniMax provider registry", () => {
 
     const { ModelProviderRegistry } = await import("./model-provider-registry");
     const registry = ModelProviderRegistry.getInstance();
-    const model = await registry.resolveLanguageModel("minimax/MiniMax-M2.7");
+    const model = await registry.resolveLanguageModel("minimax/MiniMax-M3");
 
     expect(model).toBeDefined();
     expect(createOpenAICompatibleCalls.length).toBeGreaterThan(0);
@@ -91,7 +91,7 @@ describe("MiniMax provider registry", () => {
 
     const { ModelProviderRegistry } = await import("./model-provider-registry");
     const registry = ModelProviderRegistry.getInstance();
-    const model = await registry.resolveLanguageModel("minimax-cn/MiniMax-M2.7");
+    const model = await registry.resolveLanguageModel("minimax-cn/MiniMax-M3");
 
     expect(model).toBeDefined();
 
@@ -115,7 +115,7 @@ describe("MiniMax provider registry", () => {
 
     const { ModelProviderRegistry } = await import("./model-provider-registry");
     const registry = ModelProviderRegistry.getInstance();
-    await registry.resolveLanguageModel("minimax/MiniMax-M2.7");
+    await registry.resolveLanguageModel("minimax/MiniMax-M3");
 
     const minimaxCall = createOpenAICompatibleCalls.find((call) => {
       const config = call[0] as Record<string, unknown>;
@@ -137,7 +137,7 @@ describe("MiniMax provider registry", () => {
     const { ModelProviderRegistry } = await import("./model-provider-registry");
     const registry = ModelProviderRegistry.getInstance();
 
-    await expect(registry.resolveLanguageModel("minimax/MiniMax-M2.7")).rejects.toThrow(
+    await expect(registry.resolveLanguageModel("minimax/MiniMax-M3")).rejects.toThrow(
       /MINIMAX_API_KEY/,
     );
   });
@@ -148,12 +148,7 @@ describe("MiniMax provider registry", () => {
     const { ModelProviderRegistry } = await import("./model-provider-registry");
     const registry = ModelProviderRegistry.getInstance();
 
-    const modelIds = [
-      "MiniMax-M2.7",
-      "MiniMax-M2.7-highspeed",
-      "MiniMax-M2.5",
-      "MiniMax-M2.5-highspeed",
-    ];
+    const modelIds = ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"];
 
     for (const modelId of modelIds) {
       const model = await registry.resolveLanguageModel(`minimax/${modelId}`);
@@ -168,7 +163,7 @@ describe("MiniMax provider registry", () => {
 
     const { ModelProviderRegistry } = await import("./model-provider-registry");
     const registry = ModelProviderRegistry.getInstance();
-    await registry.resolveLanguageModel("minimax/MiniMax-M2.7");
+    await registry.resolveLanguageModel("minimax/MiniMax-M3");
 
     // Anthropic adapter should NOT have been called for MiniMax
     expect(createAnthropicCalls.length).toBe(anthropicCallsBefore);

--- a/website/models-docs/providers/minimax-cn.md
+++ b/website/models-docs/providers/minimax-cn.md
@@ -14,7 +14,7 @@ import { Agent } from "@voltagent/core";
 const agent = new Agent({
   name: "minimax-cn-agent",
   instructions: "You are a helpful assistant",
-  model: "minimax-cn/MiniMax-M2.7",
+  model: "minimax-cn/MiniMax-M3",
 });
 ```
 
@@ -38,11 +38,8 @@ You can override the base URL by setting `MINIMAX_CN_BASE_URL`.
 
 ## Models
 
-| Model | Context | Description |
-|---|---|---|
-| MiniMax-M2.7 | 1M tokens | Latest flagship model |
-| MiniMax-M2.7-highspeed | 1M tokens | Optimized for speed |
-| MiniMax-M2.5 | 1M tokens | Previous generation |
-| MiniMax-M2.5-highspeed | 204K tokens | Fast inference |
-| MiniMax-M2.1 | 1M tokens | Legacy |
-| MiniMax-M2 | 1M tokens | Legacy |
+| Model                  | Context   | Description           |
+| ---------------------- | --------- | --------------------- |
+| MiniMax-M3             | 1M tokens | Latest flagship model |
+| MiniMax-M2.7           | 1M tokens | Previous generation   |
+| MiniMax-M2.7-highspeed | 1M tokens | Optimized for speed   |

--- a/website/models-docs/providers/minimax-cn.md
+++ b/website/models-docs/providers/minimax-cn.md
@@ -40,6 +40,6 @@ You can override the base URL by setting `MINIMAX_CN_BASE_URL`.
 
 | Model                  | Context   | Description           |
 | ---------------------- | --------- | --------------------- |
-| MiniMax-M3             | 1M tokens | Latest flagship model |
-| MiniMax-M2.7           | 1M tokens | Previous generation   |
-| MiniMax-M2.7-highspeed | 1M tokens | Optimized for speed   |
+| MiniMax-M3             | 512K context | Latest flagship model |
+| MiniMax-M2.7           | 192K context | Previous generation   |
+| MiniMax-M2.7-highspeed | 192K context | Optimized for speed   |

--- a/website/models-docs/providers/minimax.md
+++ b/website/models-docs/providers/minimax.md
@@ -42,6 +42,6 @@ You can override the base URL by setting `MINIMAX_BASE_URL`.
 
 | Model                  | Context   | Description           |
 | ---------------------- | --------- | --------------------- |
-| MiniMax-M3             | 1M tokens | Latest flagship model |
-| MiniMax-M2.7           | 1M tokens | Previous generation   |
-| MiniMax-M2.7-highspeed | 1M tokens | Optimized for speed   |
+| MiniMax-M3             | 512K context | Latest flagship model |
+| MiniMax-M2.7           | 192K context | Previous generation   |
+| MiniMax-M2.7-highspeed | 192K context | Optimized for speed   |

--- a/website/models-docs/providers/minimax.md
+++ b/website/models-docs/providers/minimax.md
@@ -16,7 +16,7 @@ import { Agent } from "@voltagent/core";
 const agent = new Agent({
   name: "minimax-agent",
   instructions: "You are a helpful assistant",
-  model: "minimax/MiniMax-M2.7",
+  model: "minimax/MiniMax-M3",
 });
 ```
 
@@ -40,11 +40,8 @@ You can override the base URL by setting `MINIMAX_BASE_URL`.
 
 ## Models
 
-| Model | Context | Description |
-|---|---|---|
-| MiniMax-M2.7 | 1M tokens | Latest flagship model |
-| MiniMax-M2.7-highspeed | 1M tokens | Optimized for speed |
-| MiniMax-M2.5 | 1M tokens | Previous generation |
-| MiniMax-M2.5-highspeed | 204K tokens | Fast inference |
-| MiniMax-M2.1 | 1M tokens | Legacy |
-| MiniMax-M2 | 1M tokens | Legacy |
+| Model                  | Context   | Description           |
+| ---------------------- | --------- | --------------------- |
+| MiniMax-M3             | 1M tokens | Latest flagship model |
+| MiniMax-M2.7           | 1M tokens | Previous generation   |
+| MiniMax-M2.7-highspeed | 1M tokens | Optimized for speed   |


### PR DESCRIPTION
## Summary

- Add `MiniMax-M3` (latest flagship) to the `minimax` and `minimax-cn` provider docs and use it as the default in the quickstart code samples.
- Drop the older `MiniMax-M2.5` / `M2.5-highspeed` / `M2.1` / `M2` rows from the model tables since they are no longer recommended for new integrations.
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as previous-generation options.
- Update the provider unit tests to use `MiniMax-M3` as the default model and assert that `M3`, `M2.7`, and `M2.7-highspeed` all resolve through `@ai-sdk/openai-compatible`.

The auto-generated `model-provider-registry.generated.ts` and `model-provider-types.generated.ts` are intentionally left alone — the existing `EXTRA_PROVIDER_REGISTRY` overrides take care of the runtime registration regardless of which models models.dev currently lists, so this PR only touches the user-facing docs and tests.

## Test plan

- [x] `pnpm vitest run src/registries/model-provider-registry-minimax.spec.ts` passes (8/8) inside `packages/core`.
- [x] `npx biome check` clean on the modified spec file.
- [x] `npx prettier --check` clean on the modified markdown after applying `prettier --write`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `MiniMax-M3` the default model for `minimax` and `minimax-cn`, update quickstart samples and provider tests, and remove M2.5/M2.1/M2 from docs while keeping M2.7 and M2.7-highspeed as previous-gen options. Tests confirm M3, M2.7, and M2.7-highspeed resolve via `@ai-sdk/openai-compatible`; no runtime registry changes.

- Bug Fixes
  - Corrected MiniMax context windows in docs: M3 = 512K, M2.7/M2.7-highspeed = 192K.

<sup>Written for commit 3b11827650803cf2ce5e06ba49decd5b6296d7be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the MiniMax-M3 model and made M3 the default MiniMax model.

* **Documentation**
  * Updated MiniMax and MiniMax (China) docs and examples to show MiniMax-M3 as default and refreshed the supported models table; older variants (M2.5, M2.1, M2) removed from public docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->