### PR TITLE
fix(core): strip tool output provider metadata from direct UI stream

### DIFF
--- a/.changeset/cold-socks-listen.md
+++ b/.changeset/cold-socks-listen.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Strip provider metadata from direct UI stream tool output chunks before they reach console clients.

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -1160,6 +1160,111 @@ Use pandas and summarize findings.`.split("\n"),
       expect(parts[1]).toEqual(expect.objectContaining({ type: "text-delta", id: "text-1" }));
     });
 
+    it("strips providerMetadata from direct UI stream tool output chunks", async () => {
+      const agent = new Agent({
+        name: "TestAgent",
+        instructions: "You are a helpful assistant",
+        model: mockModel as any,
+      });
+
+      const providerMetadata = {
+        anthropic: {
+          caller: {
+            type: "direct",
+          },
+        },
+      };
+
+      const mockStream = {
+        text: Promise.resolve("Streamed response"),
+        textStream: (async function* () {
+          yield "Streamed response";
+        })(),
+        fullStream: (async function* () {
+          yield {
+            type: "text-delta" as const,
+            id: "text-1",
+            delta: "Streamed response",
+            text: "Streamed response",
+          };
+        })(),
+        usage: Promise.resolve({
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        }),
+        finishReason: Promise.resolve("stop"),
+        warnings: [],
+        toUIMessageStream: vi.fn().mockReturnValue(
+          toAsyncIterableStream(
+            convertArrayToReadableStream([
+              {
+                type: "tool-input-available",
+                toolCallId: "tool-1",
+                toolName: "lookup",
+                input: { query: "weather" },
+                providerMetadata,
+              },
+              {
+                type: "tool-output-available",
+                toolCallId: "tool-1",
+                output: { ok: true },
+                providerMetadata,
+              },
+              {
+                type: "tool-output-error",
+                toolCallId: "tool-2",
+                errorText: "failed",
+                providerMetadata,
+              },
+              {
+                type: "text-delta",
+                id: "text-1",
+                delta: "Done",
+                providerMetadata,
+              },
+            ]),
+          ),
+        ),
+        toUIMessageStreamResponse: vi.fn(),
+        pipeUIMessageStreamToResponse: vi.fn(),
+        pipeTextStreamToResponse: vi.fn(),
+        toTextStreamResponse: vi.fn(),
+        partialOutputStream: undefined,
+      };
+
+      vi.mocked(ai.streamText).mockReturnValue(mockStream as any);
+
+      const result = await agent.streamText("Stream this");
+      const uiChunks: any[] = [];
+      for await (const chunk of result.toUIMessageStream() as AsyncIterable<any>) {
+        uiChunks.push(chunk);
+      }
+
+      expect(uiChunks[0]).toEqual(
+        expect.objectContaining({
+          type: "tool-input-available",
+          providerMetadata,
+        }),
+      );
+      expect(uiChunks[1]).toEqual({
+        type: "tool-output-available",
+        toolCallId: "tool-1",
+        output: { ok: true },
+      });
+      expect(uiChunks[2]).toEqual({
+        type: "tool-output-error",
+        toolCallId: "tool-2",
+        errorText: "failed",
+      });
+      expect(uiChunks[3]).toEqual(
+        expect.objectContaining({
+          type: "text-delta",
+          providerMetadata,
+        }),
+      );
+    });
+
     it("uses last-step usage for finish events when provider is anthropic", async () => {
       const agent = new Agent({
         name: "TestAgent",

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -1265,6 +1265,73 @@ Use pandas and summarize findings.`.split("\n"),
       );
     });
 
+    it("propagates cancellation when stripping providerMetadata from direct UI stream chunks", async () => {
+      const agent = new Agent({
+        name: "TestAgent",
+        instructions: "You are a helpful assistant",
+        model: mockModel as any,
+      });
+
+      const cancelSpy = vi.fn();
+      const baseStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            type: "tool-output-available",
+            toolCallId: "tool-1",
+            output: { ok: true },
+            providerMetadata: { anthropic: { caller: { type: "direct" } } },
+          });
+        },
+        cancel: cancelSpy,
+      });
+
+      const mockStream = {
+        text: Promise.resolve("Streamed response"),
+        textStream: (async function* () {
+          yield "Streamed response";
+        })(),
+        fullStream: (async function* () {
+          yield {
+            type: "text-delta" as const,
+            id: "text-1",
+            delta: "Streamed response",
+            text: "Streamed response",
+          };
+        })(),
+        usage: Promise.resolve({
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        }),
+        finishReason: Promise.resolve("stop"),
+        warnings: [],
+        toUIMessageStream: vi.fn().mockReturnValue(toAsyncIterableStream(baseStream)),
+        toUIMessageStreamResponse: vi.fn(),
+        pipeUIMessageStreamToResponse: vi.fn(),
+        pipeTextStreamToResponse: vi.fn(),
+        toTextStreamResponse: vi.fn(),
+        partialOutputStream: undefined,
+      };
+
+      vi.mocked(ai.streamText).mockReturnValue(mockStream as any);
+
+      const result = await agent.streamText("Stream this");
+      const reader = (result.toUIMessageStream() as ReadableStream<any>).getReader();
+
+      await expect(reader.read()).resolves.toEqual({
+        done: false,
+        value: {
+          type: "tool-output-available",
+          toolCallId: "tool-1",
+          output: { ok: true },
+        },
+      });
+
+      await reader.cancel("client disconnected");
+
+      expect(cancelSpy).toHaveBeenCalledWith("client disconnected");
+    });
+
     it("uses last-step usage for finish events when provider is anthropic", async () => {
       const agent = new Agent({
         name: "TestAgent",

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2599,23 +2599,13 @@ export class Agent {
         const stripProviderMetadataFromDirectUIStream = (
           baseStream: ToUIMessageStreamReturn,
         ): ToUIMessageStreamReturn => {
-          return createAsyncIterableReadable<UIStreamChunk>(async (controller) => {
-            const reader = (baseStream as ReadableStream<UIStreamChunk>).getReader();
-            try {
-              while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                if (value !== undefined) {
-                  controller.enqueue(stripProviderMetadataFromToolOutputChunk(value));
-                }
-              }
-              controller.close();
-            } catch (error) {
-              controller.error(error);
-            } finally {
-              reader.releaseLock();
-            }
-          });
+          return (baseStream as ReadableStream<UIStreamChunk>).pipeThrough(
+            new TransformStream<UIStreamChunk, UIStreamChunk>({
+              transform(chunk, controller) {
+                controller.enqueue(stripProviderMetadataFromToolOutputChunk(chunk));
+              },
+            }),
+          ) as ToUIMessageStreamReturn;
         };
 
         const getGuardrailAwareUIStream = (

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2575,11 +2575,54 @@ export class Agent {
           return result.textStream;
         };
 
+        const stripProviderMetadataFromToolOutputChunk = (chunk: UIStreamChunk): UIStreamChunk => {
+          if (chunk === null || typeof chunk !== "object") {
+            return chunk;
+          }
+
+          const type = (chunk as { type?: unknown }).type;
+          if (type !== "tool-output-available" && type !== "tool-output-error") {
+            return chunk;
+          }
+
+          if (!("providerMetadata" in chunk)) {
+            return chunk;
+          }
+
+          const { providerMetadata: _providerMetadata, ...sanitizedChunk } = chunk as Record<
+            string,
+            unknown
+          >;
+          return sanitizedChunk as UIStreamChunk;
+        };
+
+        const stripProviderMetadataFromDirectUIStream = (
+          baseStream: ToUIMessageStreamReturn,
+        ): ToUIMessageStreamReturn => {
+          return createAsyncIterableReadable<UIStreamChunk>(async (controller) => {
+            const reader = (baseStream as ReadableStream<UIStreamChunk>).getReader();
+            try {
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value !== undefined) {
+                  controller.enqueue(stripProviderMetadataFromToolOutputChunk(value));
+                }
+              }
+              controller.close();
+            } catch (error) {
+              controller.error(error);
+            } finally {
+              reader.releaseLock();
+            }
+          });
+        };
+
         const getGuardrailAwareUIStream = (
           streamOptions?: ToUIMessageStreamOptions,
         ): ToUIMessageStreamReturn => {
           if (!guardrailPipeline) {
-            return result.toUIMessageStream(streamOptions);
+            return stripProviderMetadataFromDirectUIStream(result.toUIMessageStream(streamOptions));
           }
           return guardrailPipeline.createUIStream(streamOptions) as ToUIMessageStreamReturn;
         };


### PR DESCRIPTION
## Summary
- strip `providerMetadata` from direct `result.toUIMessageStream()` tool output chunks for `tool-output-available` and `tool-output-error`
- leave guardrail/full-stream UI conversion unchanged so provider metadata forwarding for #1195 remains intact
- add regression coverage for the direct UI stream path

Closes #1290

## Tests
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --dir packages/internal build`
- `pnpm --dir packages/core test:single src/agent/agent.spec.ts src/agent/streaming/guardrail-stream.spec.ts`
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/core lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking provider metadata to console clients by stripping it from direct UI stream tool output chunks in `@voltagent/core`. Guardrail and full-stream paths are unchanged for #1195. Closes #1290.

- **Bug Fixes**
  - Strip `providerMetadata` from `tool-output-available` and `tool-output-error` in direct `result.toUIMessageStream()`.
  - Preserve UI stream cancellation while transforming the direct stream.
  - Add regression tests, including cancellation coverage, for the direct UI stream path.

<sup>Written for commit 8e02def4059809800e38c7a5f10b04d1356566ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider metadata is no longer included in direct UI stream tool-output and error chunks sent to console clients.

* **Tests**
  * Added unit tests verifying metadata is stripped from tool output chunks and that stream cancellation still propagates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->