### PR TITLE
fix(server-hono): type HonoServerProvider.app field as OpenAPIHonoType instead of any

### DIFF
--- a/.changeset/server-hono-type-app-field.md
+++ b/.changeset/server-hono-type-app-field.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/server-hono": patch
+---
+
+fix(server-hono): type HonoServerProvider.app field as OpenAPIHonoType instead of any

--- a/packages/server-hono/src/hono-server-provider.ts
+++ b/packages/server-hono/src/hono-server-provider.ts
@@ -17,13 +17,14 @@ import {
 import { createApp } from "./app-factory";
 import type { HonoServerConfig } from "./types";
 import { extractCustomEndpoints } from "./utils/custom-endpoints";
+import type { OpenAPIHonoType } from "./zod-openapi-compat";
 
 /**
  * Hono server provider class
  */
 export class HonoServerProvider extends BaseServerProvider {
   private honoConfig: HonoServerConfig;
-  private app?: any; // Store app instance to extract custom endpoints
+  private app?: OpenAPIHonoType;
 
   constructor(deps: ServerProviderDeps, config: HonoServerConfig = {}) {
     super(deps, config);


### PR DESCRIPTION
## What is current behavior?

`HonoServerProvider.app` is typed as `any`, losing type safety:

```ts
private app?: any; // Store app instance to extract custom endpoints
```

## What is new behavior?

The field is typed as `OpenAPIHonoType`, which is exactly the type returned by `createApp` and already accepted by `extractCustomEndpoints`:

```ts
private app?: OpenAPIHonoType;
```

This removes the `any` from the stored app reference without requiring any cast, since both the assignment (`this.app = app` from `createApp`) and the consumption (`extractCustomEndpoints(this.app)`) already use `OpenAPIHonoType`.

## Notes for reviewers

- `extractCustomEndpoints(app: OpenAPIHonoType)` already uses this type — no change needed there.
- No behavior change, purely a type improvement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Change `HonoServerProvider.app` type from `any` to `OpenAPIHonoType` to match `createApp` and `extractCustomEndpoints`. Improves type safety and IDE autocomplete with no runtime changes.

<sup>Written for commit e94a82d76b463364d45ba11ba1431fa01de06f8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type safety for the Hono server application instance, replacing a generic type with a more specific type definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->