### PR TITLE
docs(sandbox-daytona): add README with usage and configuration reference

### DIFF
--- a/.changeset/sandbox-daytona-readme.md
+++ b/.changeset/sandbox-daytona-readme.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/sandbox-daytona": patch
+---
+
+Add README documentation

--- a/packages/sandbox-daytona/README.md
+++ b/packages/sandbox-daytona/README.md
@@ -1,0 +1,92 @@
+<div align="center">
+<a href="https://voltagent.dev/">
+<img width="1500" height="276" alt="voltagent" src="https://github.com/user-attachments/assets/d9ad69bd-b905-42a3-81af-99a0581348c0" />
+</a>
+
+<h3 align="center">
+AI Agent Engineering Platform
+</h3>
+
+<div align="center">
+    <a href="https://voltagent.dev">Home Page</a> |
+    <a href="https://voltagent.dev/docs/">Documentation</a> |
+    <a href="https://github.com/voltagent/voltagent/tree/main/examples">Examples</a>
+</div>
+</div>
+
+<br/>
+
+<div align="center">
+
+[![GitHub issues](https://img.shields.io/github/issues/voltagent/voltagent)](https://github.com/voltagent/voltagent/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/voltagent/voltagent)](https://github.com/voltagent/voltagent/pulls)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![npm version](https://img.shields.io/npm/v/@voltagent/sandbox-daytona.svg)](https://www.npmjs.com/package/@voltagent/sandbox-daytona)
+[![npm downloads](https://img.shields.io/npm/dm/@voltagent/sandbox-daytona.svg)](https://www.npmjs.com/package/@voltagent/sandbox-daytona)
+[![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
+
+</div>
+
+## @voltagent/sandbox-daytona
+
+A [Daytona](https://www.daytona.io/) sandbox provider for VoltAgent's Workspace sandbox feature. `DaytonaSandbox` implements VoltAgent's `WorkspaceSandbox` contract, letting agents execute shell commands inside an isolated Daytona sandbox instead of the local machine.
+
+---
+
+## Install
+
+```bash
+npm install @voltagent/sandbox-daytona
+# or
+yarn add @voltagent/sandbox-daytona
+# or
+pnpm add @voltagent/sandbox-daytona
+```
+
+## Usage
+
+```typescript
+import { Agent, Workspace } from "@voltagent/core";
+import { DaytonaSandbox } from "@voltagent/sandbox-daytona";
+import { openai } from "@ai-sdk/openai";
+
+const sandbox = new DaytonaSandbox({
+  apiKey: process.env.DAYTONA_API_KEY,
+});
+
+const agent = new Agent({
+  name: "my-agent",
+  instructions: "A helpful assistant with sandboxed shell access",
+  model: openai("gpt-4o-mini"),
+  workspace: new Workspace({ sandbox }),
+});
+```
+
+## Configuration
+
+`DaytonaSandboxOptions`:
+
+| Option                 | Type                      | Default                   | Description                                                                          |
+| ---------------------- | ------------------------- | ------------------------- | ------------------------------------------------------------------------------------ |
+| `apiKey`               | `string`                  | —                         | Daytona API key                                                                      |
+| `apiUrl`               | `string`                  | —                         | Daytona API URL (for self-hosted/custom deployments)                                 |
+| `target`               | `string`                  | —                         | Daytona target region/runner                                                         |
+| `clientOptions`        | `Record<string, unknown>` | —                         | Extra options passed to the underlying `Daytona` SDK client constructor              |
+| `createParams`         | `Record<string, unknown>` | —                         | Params passed to the Daytona SDK's `client.create()` when provisioning a sandbox     |
+| `createTimeoutSeconds` | `number`                  | —                         | Timeout (seconds) for sandbox creation                                               |
+| `env`                  | `Record<string, string>`  | —                         | Default environment variables merged into every `execute()` call                     |
+| `cwd`                  | `string`                  | —                         | Default working directory for `execute()`; per-call `cwd` overrides it               |
+| `defaultTimeoutMs`     | `number`                  | `60000`                   | Default command timeout; per-call `timeoutMs` overrides it                           |
+| `maxOutputBytes`       | `number`                  | `5 * 1024 * 1024` (5 MiB) | Max stdout/stderr bytes kept per stream before truncation                            |
+| `sandbox`              | `DaytonaSandboxInstance`  | —                         | Pre-resolved Daytona SDK sandbox instance to reuse instead of provisioning a new one |
+
+Use `getSandbox()` to access the underlying Daytona SDK sandbox instance directly for Daytona-specific APIs beyond `execute()`.
+
+## Documentation
+
+- [VoltAgent Documentation](https://voltagent.dev/docs/)
+- [Daytona Documentation](https://www.daytona.io/docs/)
+
+## License
+
+Licensed under the MIT License, Copyright © 2026-present VoltAgent.


### PR DESCRIPTION
## PR Checklist
- [x] Commit message follows guidelines (conventional commits: `<type>(<scope>): <description>`)

## Bugs / Features
- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added (`pnpm changeset`)

## What is the current behavior?
`@voltagent/sandbox-daytona` has no README, so users have no documentation for wiring `DaytonaSandbox` into a VoltAgent `Workspace`.

## What is the new behavior?
Adds a README covering installation, basic usage with `Workspace`, and the `DaytonaSandboxOptions` configuration reference.

## Notes for reviewers
Mirrors the style/structure of the recently added `@voltagent/server-core` README (#1331).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a README for `@voltagent/sandbox-daytona` with install, basic `Workspace` usage, and a `DaytonaSandboxOptions` reference. This gives clear docs for running agents in a Daytona-backed sandbox.

<sup>Written for commit 76e76e4fa38699feb5a9b0d69343173dad681709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README documentation for the sandbox-daytona package, including installation instructions, TypeScript usage examples, configuration options, and resource links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->