### PR TITLE
fix(update): validate package names in updateAllPackages

### DIFF
--- a/packages/core/src/utils/update/index.ts
+++ b/packages/core/src/utils/update/index.ts
@@ -32,6 +32,12 @@ export type PackageUpdateInfo = {
  */
 type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
+const NPM_PACKAGE_NAME_REGEX =
+  /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+const isValidPackageName = (packageName: string): boolean =>
+  NPM_PACKAGE_NAME_REGEX.test(packageName);
+
 /**
  * Detects the package manager being used in the project
  */
@@ -334,7 +340,15 @@ export const updateAllPackages = async (
     // 3. Prepare the package list for updating
     const packagesToUpdate = updateCheckResult.updates
       .filter((pkg) => pkg.type !== "latest")
+      .filter((pkg) => isValidPackageName(pkg.name))
       .map((pkg) => `${pkg.name}@latest`);
+
+    if (packagesToUpdate.length === 0) {
+      return {
+        success: false,
+        message: "No valid packages available for updating",
+      };
+    }
 
     const logger = new LoggerProxy({ component: "update-checker" });
     logger.info(`Updating ${packagesToUpdate.length} packages in ${rootDir}`);
@@ -410,10 +424,8 @@ export const updateSinglePackage = async (
     }
 
     // Command injection protection - only allow valid NPM package names
-    const isValidPackageName = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(
-      packageName,
-    );
-    if (!isValidPackageName) {
+    const isPackageNameValid = isValidPackageName(packageName);
+    if (!isPackageNameValid) {
       return {
         success: false,
         message: `Invalid package name: ${packageName}`,


### PR DESCRIPTION
## Summary
- reuse the existing npm package-name validation logic via a shared helper
- filter invalid package names out of `updateAllPackages()` before building shell commands
- bail out early when no valid packages remain, avoiding an empty package-manager invocation

## Problem
`updateAllPackages()` was interpolating package names from `checkForUpdates()` directly into `execSync()` commands, while `updateSinglePackage()` already validated names first. That left a command-injection gap between the two code paths.

## Notes
This keeps the fix intentionally small and follows the validation pattern already used in `updateSinglePackage()`.

Fixes #1205


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate package names in `updateAllPackages()` to close a command-injection gap and avoid empty package-manager runs. Reuses a shared regex helper and returns early when no valid packages remain.

- **Bug Fixes**
  - Add shared `isValidPackageName` helper and use it in `updateAllPackages()`.
  - Filter invalid names before building shell commands; skip updates if none are valid.
  - Update `updateSinglePackage()` to use the shared helper for consistency.

<sup>Written for commit d5e39d72cfa078271b11cb545a9335264561d9c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package update validation to skip invalid package names.
  * When no valid packages are available for an update, the update flow now fails clearly instead of proceeding.
  * Single-package updates continue to reject invalid names with the same early-return behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->