### PR TITLE
test(elysia): mock node http server in provider spec

### DIFF
--- a/packages/server-elysia/src/elysia-server-provider.spec.ts
+++ b/packages/server-elysia/src/elysia-server-provider.spec.ts
@@ -1,7 +1,12 @@
+import { createServer } from "node:http";
 import { portManager } from "@voltagent/server-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as appFactory from "./app-factory";
 import { ElysiaServerProvider } from "./elysia-server-provider";
+
+vi.mock("node:http", () => ({
+  createServer: vi.fn(),
+}));
 
 // Mock dependencies
 vi.mock("@voltagent/server-core", async () => {
@@ -21,11 +26,11 @@ vi.mock("@voltagent/server-core", async () => {
 
 describe("ElysiaServerProvider", () => {
   let provider: ElysiaServerProvider;
+  let mockServer: any;
   const mockApp = {
-    listen: vi.fn().mockReturnValue({}),
     stop: vi.fn(),
-    routes: [], // For extractCustomEndpoints
-    get: vi.fn(), // For configureApp test
+    routes: [],
+    get: vi.fn(),
   };
 
   const mockDeps = {
@@ -43,6 +48,14 @@ describe("ElysiaServerProvider", () => {
   } as any;
 
   beforeEach(() => {
+    mockServer = {
+      listen: vi.fn((_port, _host, cb) => cb()),
+      close: vi.fn((cb) => cb?.()),
+      once: vi.fn(),
+      listening: true,
+    };
+
+    vi.mocked(createServer).mockReturnValue(mockServer);
     vi.spyOn(appFactory, "createApp").mockResolvedValue({ app: mockApp } as any);
     provider = new ElysiaServerProvider(mockDeps, { port: 3000 });
   });
@@ -55,16 +68,15 @@ describe("ElysiaServerProvider", () => {
   it("should start the server", async () => {
     await provider.start();
     expect(appFactory.createApp).toHaveBeenCalled();
-    expect(mockApp.listen).toHaveBeenCalledWith({
-      port: 3000,
-      hostname: "0.0.0.0",
-    });
+    expect(createServer).toHaveBeenCalled();
+    expect(mockServer.listen).toHaveBeenCalledWith(3000, "0.0.0.0", expect.any(Function));
   });
 
   it("should stop the server", async () => {
     await provider.start();
     await provider.stop();
     expect(mockApp.stop).toHaveBeenCalled();
+    expect(mockServer.close).toHaveBeenCalled();
   });
 
   it("should throw if already running", async () => {
@@ -82,9 +94,7 @@ describe("ElysiaServerProvider", () => {
   it("should extract and display custom endpoints from configureApp", async () => {
     const { printServerStartup } = await import("@voltagent/server-core");
 
-    // Create a fresh mock app for this test to avoid pollution
     const localMockApp = {
-      listen: vi.fn().mockReturnValue({}),
       stop: vi.fn(),
       routes: [{ method: "GET", path: "/custom-test" }],
       get: vi.fn(),
@@ -112,8 +122,7 @@ describe("ElysiaServerProvider", () => {
   });
 
   it("should handle startup errors and release port", async () => {
-    // Mock app.listen to throw
-    mockApp.listen.mockImplementationOnce(() => {
+    mockServer.listen.mockImplementationOnce(() => {
       throw new Error("Startup failed");
     });
 


### PR DESCRIPTION
## Summary
- update the Elysia provider tests to mock `node:http.createServer()` instead of the old `app.listen()` path
- assert against the mocked Node server's `listen()` / `close()` lifecycle
- keep the startup-error test aligned with the current implementation by throwing from the mocked HTTP server

## Problem
`startServer()` now creates a Node HTTP server directly, but the spec file still mocked and asserted on `app.listen()`. That leaves the real HTTP server path unmocked during tests and causes the suite to hit `EADDRINUSE` instead of exercising the provider logic.

## Notes
This PR only updates the test suite to match the current Node-based startup flow.

Fixes #1204


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Elysia provider tests to mock `node:http.createServer()` and assert the Node server `listen`/`close` lifecycle, aligning with the current startup path and preventing EADDRINUSE. Fixes #1204.

<sup>Written for commit d9a42dbc1b15d6ed4f83080964f0c0d0f362c980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated server lifecycle tests to verify startup and shutdown behavior through the underlying server instance.
  * Improved coverage for startup errors and port release handling.
  * Adjusted custom endpoint test setup to match the new server mocking approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->