### PR TITLE
fix(core): preserve workflow input after finish

### DIFF
--- a/.changeset/workflow-input-preserved-after-finish.md
+++ b/.changeset/workflow-input-preserved-after-finish.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Fixed workflow `state.input` being overwritten with the final output once a workflow finished. `finish()` reassigned the stored input to the current data, so reading `state.input` after completion returned the final result instead of the initial input it documents. The initial input is now preserved through completion; `state.data` still reflects the final value.

--- a/packages/core/src/workflow/internal/state.spec.ts
+++ b/packages/core/src/workflow/internal/state.spec.ts
@@ -128,6 +128,17 @@ describe("WorkflowStateManager", () => {
       expect(result.status).toBe("completed");
     });
 
+    it("should preserve the original input after the workflow finishes", () => {
+      stateManager.start({ value: "original" });
+      stateManager.update({ data: { value: "final" } });
+      stateManager.finish();
+
+      // `input` is documented as the initial input and must survive completion;
+      // only `data` should reflect the final value.
+      expect(stateManager.state.input).toEqual({ value: "original" });
+      expect(stateManager.state.data).toEqual({ value: "final" });
+    });
+
     it("should transition from suspended to failed", () => {
       stateManager.start({ data: "test" });
       stateManager.suspend("Pause");

--- a/packages/core/src/workflow/internal/state.ts
+++ b/packages/core/src/workflow/internal/state.ts
@@ -167,7 +167,6 @@ class WorkflowStateManagerInternal<DATA, RESULT> implements WorkflowStateManager
 
   finish() {
     assertCanMutate(this.#state);
-    this.#input = this.#state.data as DATA;
     this.#internalUpdate({
       endAt: new Date(),
       status: "completed",


### PR DESCRIPTION
## What this fixes

`WorkflowStateManager.finish()` reassigned the stored input to the current data:

```ts
finish() {
  assertCanMutate(this.#state);
  this.#input = this.#state.data as DATA;   // removed
  ...
}
```

`WorkflowState.input` is documented as the initial input to the workflow, and `update()` deliberately preserves it across the run. But `finish()` overwrote it with the final `data`, so reading `state.input` after a workflow completed returned the final output instead of the original input.

## Repro

```ts
const sm = createWorkflowStateManager();
sm.start({ value: "original" });
sm.update({ data: { value: "final" } });
sm.finish();
sm.state.input; // { value: "final" }  — expected { value: "original" }
```

## Fix

Remove the reassignment in `finish()`. The input is set once in `start()` and now stays put through completion; `state.data` still reflects the final value. Added a regression test, and the full workflow suite (164 tests) stays green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
In `@voltagent/core`, fix `WorkflowStateManager.finish()` overwriting `state.input` with the final `data`, so completed workflows now preserve their original input. Removed the reassignment and added a regression test; `state.data` still reflects the final value.

<sup>Written for commit 79496a11b5455c7340038a39dd6a8a1ab19e4af7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow completion so the original input remains preserved after a run finishes.
  * Ensured the final workflow state still reflects the completed output separately from the initial input.
* **Tests**
  * Added coverage verifying that completed workflows keep the starting input unchanged while updating the final data value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->