### PR TITLE
fix(scorers): detect AI SDK v5 tool parts in toolCallAccuracy

### DIFF
--- a/.changeset/tool-call-accuracy-v5-parts.md
+++ b/.changeset/tool-call-accuracy-v5-parts.md
@@ -1,0 +1,7 @@
+---
+"@voltagent/scorers": patch
+---
+
+Fix the code-based `toolCallAccuracy` scorer missing tool calls in AI SDK v5 message parts
+
+The scorer read tool calls from message `parts` only when a part's `type` was exactly `"tool_call"`. AI SDK v5 encodes a tool call in message parts as `type: "tool-<toolName>"`, so those calls were skipped and the scorer reported the expected tool as not called even when it was. It now recognizes `tool-<name>` parts too, matching how it already reads them from tool-call lists.

--- a/packages/scorers/src/tool-call-accuracy.spec.ts
+++ b/packages/scorers/src/tool-call-accuracy.spec.ts
@@ -129,6 +129,36 @@ describe("createToolCallAccuracyScorerCode", () => {
     expect(result.score).toBe(1);
   });
 
+  it("extracts tool names from AI SDK v5 message parts (type: tool-<name>)", async () => {
+    const scorer = createToolCallAccuracyScorerCode({
+      expectedTool: "searchProducts",
+    });
+
+    const result = await scorer.scorer({
+      payload: {
+        messages: [
+          {
+            id: "msg-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-searchProducts",
+                toolCallId: "call-1",
+                state: "output-available",
+                input: {},
+                output: {},
+              },
+            ],
+          },
+        ],
+      } satisfies ToolCallAccuracyPayload,
+      params: {} as ToolCallAccuracyParams,
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.score).toBe(1);
+  });
+
   it("supports custom buildPayload mappings", async () => {
     const scorer = createToolCallAccuracyScorerCode<{ events: Array<{ name: string }> }>({
       expectedTool: "searchProducts",

--- a/packages/scorers/src/tool-call-accuracy.ts
+++ b/packages/scorers/src/tool-call-accuracy.ts
@@ -276,7 +276,11 @@ function extractToolNamesFromParts(parts: unknown[]): string[] {
     }
 
     const partType = normalizeMessageType(part.type);
-    if (partType !== "tool_call") {
+    // AI SDK v5 encodes a tool call in message parts as `type: "tool-<name>"`,
+    // not `"tool_call"`. Accept those too (extractToolName reads the name from
+    // the type); tool results and streaming events are still excluded because
+    // shouldExtractToolNameFromType returns false for them.
+    if (partType !== "tool_call" && !shouldExtractToolNameFromType(partType)) {
       continue;
     }
 


### PR DESCRIPTION
While using the code-based `toolCallAccuracy` scorer on agent outputs, I hit a case where it reported the expected tool as never called even though it was. The cause is in how tool calls are read from message `parts`.

## What was wrong

`extractToolNamesFromParts` only accepted a part when its `type` was exactly `"tool_call"`:

```ts
const partType = normalizeMessageType(part.type);
if (partType !== "tool_call") {
  continue;
}
```

AI SDK v5 encodes a tool call in message parts as `type: "tool-<toolName>"` (for example `"tool-getWeather"`), which normalizes to `"tool_getweather"` and never equals `"tool_call"`. So tool calls living in `message.parts` were skipped, and the scorer scored `0` for a tool that was actually called.

This is inconsistent with the tool-call **list** path, which already extracts `tool-<name>` / `tool_<name>` via `extractToolName` (covered by the existing "keeps extracting from tool_<name> type in tool call lists" test).

## Fix

Accept tool-typed parts as well, reusing the existing `shouldExtractToolNameFromType` guard so tool results and streaming events stay excluded:

```ts
if (partType !== "tool_call" && !shouldExtractToolNameFromType(partType)) {
  continue;
}
```

`extractToolName` then reads the name from the `type`, exactly as it already does for lists.

## Test

Added a regression test that feeds an AI SDK v5 assistant message with a `type: "tool-searchProducts"` part. It fails on `main` (score `0`) and passes with this change (score `1`). Full `@voltagent/scorers` suite stays green (77 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `toolCallAccuracy` in `@voltagent/scorers` to detect tool calls encoded as `type: "tool-<name>"` in message parts, so expected tools aren’t reported as missing.

- **Bug Fixes**
  - Accepts `tool-<name>` part types when extracting tool names; still excludes tool results and streaming events via `shouldExtractToolNameFromType`.
  - Adds a regression test for `type: "tool-searchProducts"`; full suite remains green.

<sup>Written for commit ce5afd5f4b82c0999b8c3189af1ead2cd7cc8aed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call scoring so tool calls are recognized when message parts use the newer `tool-<name>` format.
  * Prevents valid tool calls from being missed, which makes scorer results more accurate.
  * Added test coverage for the newer message-part format to confirm the scorer returns a full score when expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->