### PR TITLE
fix(internal): cancel source stream when AsyncIterableStream stops early

### DIFF
--- a/.changeset/async-iterable-stream-cancel.md
+++ b/.changeset/async-iterable-stream-cancel.md
@@ -1,0 +1,7 @@
+---
+"@voltagent/internal": patch
+---
+
+Cancel the source stream when an `AsyncIterableStream` is iterated and stopped early
+
+`createAsyncIterableStream` returned an async iterator with no `return` method, so breaking out of a `for await...of` loop early left the reader lock held and never cancelled the underlying stream. It now implements `return` to cancel the reader, matching the built-in `ReadableStream` async iterator and tearing down the upstream when iteration stops early.

--- a/packages/internal/src/utils/async-iterable-stream.spec.ts
+++ b/packages/internal/src/utils/async-iterable-stream.spec.ts
@@ -31,4 +31,26 @@ describe("createAsyncIterableStream()", () => {
 
     expect(await convertReadableStreamToArray(asyncIterableStream)).toEqual(testData);
   });
+
+  it("should cancel the source stream when async iteration stops early", async () => {
+    let cancelled = false;
+    const source = new ReadableStream<number>({
+      start(controller) {
+        controller.enqueue(1);
+        controller.enqueue(2);
+        controller.enqueue(3);
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    const asyncIterableStream = createAsyncIterableStream(source);
+
+    for await (const _chunk of asyncIterableStream) {
+      break; // stop after the first chunk
+    }
+
+    expect(cancelled).toBe(true);
+  });
 });

--- a/packages/internal/src/utils/async-iterable-stream.ts
+++ b/packages/internal/src/utils/async-iterable-stream.ts
@@ -39,6 +39,13 @@ export function createAsyncIterableStream<T>(source: ReadableStream<T>): AsyncIt
         const { done, value } = await reader.read();
         return done ? { done: true, value: undefined } : { done: false, value };
       },
+      // Called when the consumer stops early (break/throw/return). Mirror the
+      // built-in ReadableStream async iterator and cancel the source so the
+      // upstream is torn down instead of leaking the reader lock.
+      async return(): Promise<IteratorResult<T>> {
+        await reader.cancel();
+        return { done: true, value: undefined };
+      },
     };
   };
 


### PR DESCRIPTION
While consuming an `AsyncIterableStream` from `@voltagent/internal` with a `for await...of` loop that breaks early, I noticed the upstream stream was never torn down.

## What was wrong

`createAsyncIterableStream` overrides `[Symbol.asyncIterator]` with an iterator that only implements `next`:

```ts
(stream as AsyncIterableStream<T>)[Symbol.asyncIterator] = () => {
  const reader = stream.getReader();
  return {
    async next(): Promise<IteratorResult<T>> {
      const { done, value } = await reader.read();
      return done ? { done: true, value: undefined } : { done: false, value };
    },
  };
};
```

When a `for await...of` loop is exited early (`break`, `throw`, or `return`), the runtime calls the iterator’s `return()` for cleanup. The built-in `ReadableStream` async iterator implements this and cancels the stream. This custom iterator has no `return()`, so on early exit the reader lock is kept and the source is never cancelled. For agent/LLM streams that means the upstream request is not aborted when a consumer stops reading.

## Fix

Implement `return()` to cancel the reader, matching the built-in behavior:

```ts
async return(): Promise<IteratorResult<T>> {
  await reader.cancel();
  return { done: true, value: undefined };
},
```

## Test

Added a regression test: a source `ReadableStream` with a `cancel` spy, iterated with `for await...of` and broken after the first chunk. It fails on `main` (source never cancelled) and passes with this change. Full `@voltagent/internal` suite stays green (129 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `AsyncIterableStream` in `@voltagent/internal` cancels the underlying `ReadableStream` when a `for await...of` loop stops early. This prevents reader-lock leaks and tears down upstream requests.

- **Bug Fixes**
  - Implemented iterator `return()` to call `reader.cancel()`, matching built-in `ReadableStream` behavior.
  - Added a regression test that breaks after the first chunk and asserts the source `cancel` is called.

<sup>Written for commit e38bb4e0cf51f749e00d957f172519af857be250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped streamed results from staying open when iteration ends early.
  * Breaking out of a `for await...of` loop now cleanly closes the stream and releases resources.
  * Added test coverage for early stream cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->