### PR TITLE
fix(core): use aggregate usage consistently across providers

### DIFF
--- a/.changeset/consistent-usage-totals.md
+++ b/.changeset/consistent-usage-totals.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Use aggregate finish usage consistently across providers.

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -1161,7 +1161,7 @@ Use pandas and summarize findings.`.split("\n"),
       expect(parts[1]).toEqual(expect.objectContaining({ type: "text-delta", id: "text-1" }));
     });
 
-    it("uses last-step usage for finish events when provider is anthropic", async () => {
+    it("keeps aggregate total usage for finish events when provider is anthropic", async () => {
       const agent = new Agent({
         name: "TestAgent",
         instructions: "You are a helpful assistant",
@@ -1223,7 +1223,7 @@ Use pandas and summarize findings.`.split("\n"),
       }
 
       const finishPart = parts.find((part) => part.type === "finish");
-      expect(finishPart?.totalUsage).toEqual(lastStepUsage);
+      expect(finishPart?.totalUsage).toEqual(summedUsage);
     });
 
     it("keeps fullStream intact after probe for ReadableStream-based providers", async () => {

--- a/packages/core/src/utils/usage-normalizer.spec.ts
+++ b/packages/core/src/utils/usage-normalizer.spec.ts
@@ -17,7 +17,7 @@ const toAsync = async function* <T>(items: T[]): AsyncIterable<T> {
 };
 
 describe("resolveFinishUsage", () => {
-  it("prefers last-step usage when provider metadata indicates anthropic", () => {
+  it("prefers total usage when provider metadata indicates anthropic", () => {
     const lastStepUsage: LanguageModelUsage = {
       inputTokens: 5,
       outputTokens: 6,
@@ -35,10 +35,10 @@ describe("resolveFinishUsage", () => {
       totalUsage,
     });
 
-    expect(resolved).toBe(lastStepUsage);
+    expect(resolved).toBe(totalUsage);
   });
 
-  it("prefers last-step usage when usage includes cache fields", () => {
+  it("prefers total usage when usage includes cache fields", () => {
     const lastStepUsage = {
       inputTokens: 5,
       outputTokens: 6,
@@ -56,7 +56,7 @@ describe("resolveFinishUsage", () => {
       totalUsage,
     });
 
-    expect(resolved).toBe(lastStepUsage);
+    expect(resolved).toBe(totalUsage);
   });
 
   it("prefers total usage when provider is not anthropic", () => {
@@ -98,7 +98,7 @@ describe("resolveFinishUsage", () => {
 });
 
 describe("normalizeFinishUsageStream", () => {
-  it("overrides finish totalUsage with last-step usage for anthropic streams", async () => {
+  it("keeps finish totalUsage unchanged for anthropic streams", async () => {
     const lastStepUsage: LanguageModelUsage = {
       inputTokens: 10,
       outputTokens: 5,
@@ -121,10 +121,10 @@ describe("normalizeFinishUsageStream", () => {
 
     const normalized = await collectStream(normalizeFinishUsageStream(toAsync(parts)));
 
-    expect(normalized[2].totalUsage).toEqual(lastStepUsage);
+    expect(normalized[2].totalUsage).toEqual(totalUsage);
   });
 
-  it("uses finish metadata to override totalUsage when finish-step metadata is missing", async () => {
+  it("keeps finish totalUsage unchanged when finish-step metadata is missing", async () => {
     const lastStepUsage: LanguageModelUsage = {
       inputTokens: 9,
       outputTokens: 4,
@@ -147,10 +147,10 @@ describe("normalizeFinishUsageStream", () => {
 
     const normalized = await collectStream(normalizeFinishUsageStream(toAsync(parts)));
 
-    expect(normalized[1].totalUsage).toEqual(lastStepUsage);
+    expect(normalized[1].totalUsage).toEqual(totalUsage);
   });
 
-  it("overrides totalUsage when cache fields indicate anthropic usage", async () => {
+  it("keeps finish totalUsage unchanged when cache fields are present", async () => {
     const lastStepUsage = {
       inputTokens: 8,
       outputTokens: 4,
@@ -169,7 +169,7 @@ describe("normalizeFinishUsageStream", () => {
 
     const normalized = await collectStream(normalizeFinishUsageStream(toAsync(parts)));
 
-    expect(normalized[1].totalUsage).toEqual(lastStepUsage);
+    expect(normalized[1].totalUsage).toEqual(totalUsage);
   });
 
   it("keeps finish totalUsage unchanged for non-anthropic streams", async () => {

--- a/packages/core/src/utils/usage-normalizer.ts
+++ b/packages/core/src/utils/usage-normalizer.ts
@@ -13,34 +13,10 @@ type StreamPartWithUsage = {
   providerMetadata?: unknown;
 };
 
-const shouldUseLastStepUsage = (providerMetadata: unknown, usage?: LanguageModelUsage): boolean => {
-  if (providerMetadata && typeof providerMetadata === "object") {
-    if (Object.prototype.hasOwnProperty.call(providerMetadata, "anthropic")) {
-      return true;
-    }
-  }
-
-  const raw = (usage as { raw?: Record<string, unknown> } | undefined)?.raw;
-  if (raw && typeof raw === "object") {
-    if (
-      Object.prototype.hasOwnProperty.call(raw, "cache_creation_input_tokens") ||
-      Object.prototype.hasOwnProperty.call(raw, "cache_read_input_tokens")
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
 export const resolveFinishUsage = (input: FinishUsageInput): LanguageModelUsage | undefined => {
-  const { providerMetadata, usage, totalUsage } = input;
+  const { usage, totalUsage } = input;
   if (!usage && !totalUsage) {
     return undefined;
-  }
-
-  if (shouldUseLastStepUsage(providerMetadata, usage ?? totalUsage)) {
-    return usage ?? totalUsage;
   }
 
   return totalUsage ?? usage;
@@ -49,33 +25,7 @@ export const resolveFinishUsage = (input: FinishUsageInput): LanguageModelUsage 
 export async function* normalizeFinishUsageStream<T extends StreamPartWithUsage>(
   baseStream: AsyncIterable<T>,
 ): AsyncIterable<T> {
-  let lastStepUsage: LanguageModelUsage | undefined;
-  let useLastStepUsage = false;
-
   for await (const part of baseStream) {
-    if (part.type === "finish-step") {
-      lastStepUsage = part.usage;
-      if (!useLastStepUsage) {
-        useLastStepUsage = shouldUseLastStepUsage(part.providerMetadata, lastStepUsage);
-      }
-    }
-
-    if (part.type === "finish" && !useLastStepUsage) {
-      if (shouldUseLastStepUsage(part.providerMetadata, lastStepUsage)) {
-        useLastStepUsage = true;
-        if (part.usage) {
-          lastStepUsage = part.usage;
-        }
-      }
-    }
-
-    if (part.type === "finish" && useLastStepUsage && lastStepUsage) {
-      if (part.totalUsage !== undefined) {
-        yield { ...part, totalUsage: lastStepUsage };
-        continue;
-      }
-    }
-
     yield part;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

Finish usage resolution prefers aggregate `totalUsage` for most providers, but switches to last-step `usage` for Anthropic/cache cases. That makes root span usage and `onEnd.output.usage` provider-dependent during tool-call runs.

The stream normalizer also rewrites finish `totalUsage` to the last step for Anthropic/cache streams.

## What is the new behavior?

`resolveFinishUsage` now consistently prefers aggregate `totalUsage` whenever AI SDK provides it, falling back to `usage` only when no aggregate is available.

`normalizeFinishUsageStream` now preserves finish `totalUsage` instead of rewriting it by provider/cache metadata. Updated tests cover Anthropic/cache cases and assert aggregate usage is preserved.

fixes #1360

Related to #1359. The dashboard/export total fallback that double-counted cached/reasoning breakdowns is handled in companion PR: https://github.com/VoltAgent/console/pull/44

## Notes for reviewers

Docs were not updated because this restores consistent bug-fix behavior rather than introducing a new public API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage totals shown for streaming events, keeping the aggregate finish usage consistent across providers.
  * Anthropic-related finish events now preserve the correct total usage instead of replacing it with step-level values.
  * Streamed finish usage is no longer adjusted unexpectedly when cache-related or metadata fields are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->