### PR TITLE
Refresh MiniMax M3 model params

### DIFF
--- a/packages/core/src/registries/model-provider-registry-minimax.spec.ts
+++ b/packages/core/src/registries/model-provider-registry-minimax.spec.ts
@@ -149,6 +149,7 @@ describe("MiniMax provider registry", () => {
     const registry = ModelProviderRegistry.getInstance();
 
     const modelIds = [
+      "MiniMax-M3",
       "MiniMax-M2.7",
       "MiniMax-M2.7-highspeed",
       "MiniMax-M2.5",

--- a/packages/core/src/registries/model-provider-registry.generated.ts
+++ b/packages/core/src/registries/model-provider-registry.generated.ts
@@ -317,7 +317,7 @@ export const MODEL_PROVIDER_REGISTRY: Record<string, ModelProviderRegistryEntry>
     npm: "@ai-sdk/anthropic",
     api: "https://api.minimax.io/anthropic/v1",
     env: ["MINIMAX_API_KEY"],
-    doc: "https://platform.minimax.io/docs/guides/quickstart",
+    doc: "https://platform.minimax.io/docs/api-reference/api-overview",
   },
   "minimax-cn": {
     id: "minimax-cn",
@@ -325,7 +325,7 @@ export const MODEL_PROVIDER_REGISTRY: Record<string, ModelProviderRegistryEntry>
     npm: "@ai-sdk/anthropic",
     api: "https://api.minimaxi.com/anthropic/v1",
     env: ["MINIMAX_API_KEY"],
-    doc: "https://platform.minimaxi.com/docs/guides/quickstart",
+    doc: "https://platform.minimaxi.com/docs/api-reference/api-overview",
   },
   mistral: {
     id: "mistral",

--- a/packages/core/src/registries/model-provider-registry.ts
+++ b/packages/core/src/registries/model-provider-registry.ts
@@ -150,7 +150,7 @@ const EXTRA_PROVIDER_REGISTRY: ModelProviderRegistryEntry[] = [
     npm: "@ai-sdk/openai-compatible",
     api: "https://api.minimax.io/v1",
     env: ["MINIMAX_API_KEY"],
-    doc: "https://platform.minimax.io/docs/guides/quickstart",
+    doc: "https://platform.minimax.io/docs/api-reference/api-overview",
   },
   {
     id: "minimax-cn",
@@ -158,7 +158,7 @@ const EXTRA_PROVIDER_REGISTRY: ModelProviderRegistryEntry[] = [
     npm: "@ai-sdk/openai-compatible",
     api: "https://api.minimaxi.com/v1",
     env: ["MINIMAX_API_KEY"],
-    doc: "https://platform.minimaxi.com/docs/guides/quickstart",
+    doc: "https://platform.minimaxi.com/docs/api-reference/api-overview",
   },
 ];
 

--- a/packages/core/src/registries/model-provider-types.generated.ts
+++ b/packages/core/src/registries/model-provider-types.generated.ts
@@ -1103,8 +1103,8 @@ export type ProviderModelsMap = {
     "qwen/qwen3-coder-30b",
   ];
   readonly lucidquery: readonly ["lucidnova-rf1-100b", "lucidquery-nexus-coder"];
-  readonly minimax: readonly ["MiniMax-M2", "MiniMax-M2.1"];
-  readonly "minimax-cn": readonly ["MiniMax-M2", "MiniMax-M2.1"];
+  readonly minimax: readonly ["MiniMax-M2", "MiniMax-M2.1", "MiniMax-M3"];
+  readonly "minimax-cn": readonly ["MiniMax-M2", "MiniMax-M2.1", "MiniMax-M3"];
   readonly mistral: readonly [
     "codestral-latest",
     "devstral-2512",

--- a/website/models-docs/providers/minimax-cn.md
+++ b/website/models-docs/providers/minimax-cn.md
@@ -14,7 +14,7 @@ import { Agent } from "@voltagent/core";
 const agent = new Agent({
   name: "minimax-cn-agent",
   instructions: "You are a helpful assistant",
-  model: "minimax-cn/MiniMax-M2.7",
+  model: "minimax-cn/MiniMax-M3",
 });
 ```
 
@@ -34,13 +34,20 @@ You can override the base URL by setting `MINIMAX_CN_BASE_URL`.
 
 ## Provider docs
 
-- https://platform.minimaxi.com/docs/guides/quickstart
+- https://platform.minimaxi.com/docs/api-reference/api-overview
+
+## Pricing
+
+| Model | Input | Output | Cache read | Cache write |
+|---|---:|---:|---:|---:|
+| MiniMax-M3 | $0.60 / 1M tokens | $2.40 / 1M tokens | $0.12 / 1M tokens | Not listed |
 
 ## Models
 
 | Model | Context | Description |
 |---|---|---|
-| MiniMax-M2.7 | 1M tokens | Latest flagship model |
+| MiniMax-M3 | 1M tokens | Latest flagship model |
+| MiniMax-M2.7 | 1M tokens | Previous generation |
 | MiniMax-M2.7-highspeed | 1M tokens | Optimized for speed |
 | MiniMax-M2.5 | 1M tokens | Previous generation |
 | MiniMax-M2.5-highspeed | 204K tokens | Fast inference |

--- a/website/models-docs/providers/minimax.md
+++ b/website/models-docs/providers/minimax.md
@@ -16,7 +16,7 @@ import { Agent } from "@voltagent/core";
 const agent = new Agent({
   name: "minimax-agent",
   instructions: "You are a helpful assistant",
-  model: "minimax/MiniMax-M2.7",
+  model: "minimax/MiniMax-M3",
 });
 ```
 
@@ -36,13 +36,20 @@ You can override the base URL by setting `MINIMAX_BASE_URL`.
 
 ## Provider docs
 
-- https://platform.minimax.io/docs/guides/quickstart
+- https://platform.minimax.io/docs/api-reference/api-overview
+
+## Pricing
+
+| Model | Input | Output | Cache read | Cache write |
+|---|---:|---:|---:|---:|
+| MiniMax-M3 | $0.60 / 1M tokens | $2.40 / 1M tokens | $0.12 / 1M tokens | Not listed |
 
 ## Models
 
 | Model | Context | Description |
 |---|---|---|
-| MiniMax-M2.7 | 1M tokens | Latest flagship model |
+| MiniMax-M3 | 1M tokens | Latest flagship model |
+| MiniMax-M2.7 | 1M tokens | Previous generation |
 | MiniMax-M2.7-highspeed | 1M tokens | Optimized for speed |
 | MiniMax-M2.5 | 1M tokens | Previous generation |
 | MiniMax-M2.5-highspeed | 204K tokens | Fast inference |


### PR DESCRIPTION
Reason: MiniMax provider docs and generated registry stop at M2.x/M2.7; add M3 and refresh pricing/context/base URL.

## Summary
- Add MiniMax-M3 to the MiniMax model router type registry and provider tests.
- Refresh MiniMax docs to use MiniMax-M3, the current docs entrypoint, and the current M3 pricing/context details.

## Test plan
- Secret scan: `git add -A -N && git diff HEAD | grep -E "$SECRET_RE"`
- Attempted: `pnpm --dir /root/octopatch-4/work/repos/VoltAgent_voltagent install --frozen-lockfile` (failed because the default pnpm required Node 22.13 while the runner has Node 20.20.2)
- Attempted: `corepack prepare pnpm@8.10.5 --activate && pnpm --dir /root/octopatch-4/work/repos/VoltAgent_voltagent install --frozen-lockfile --registry=https://registry.npmjs.org --reporter=append-only` (failed with ENOSPC during dependency linking)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MiniMax-M3 to the MiniMax model registry for `minimax` and `minimax-cn`, updates tests, and makes M3 the default in docs. Refreshes provider doc links to the current API reference and updates pricing/context details.

<sup>Written for commit 8703987b3c870ca40b61bfbfeadcf38af3a15d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support and examples for the latest MiniMax model in both provider listings and quick start snippets.
  * Expanded model availability details to show the newer model alongside existing options.

* **Documentation**
  * Updated provider links to point to the API reference.
  * Added pricing tables and refreshed model descriptions for MiniMax providers.

* **Tests**
  * Extended coverage to confirm the newer MiniMax model resolves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->