### PR TITLE
docs: add TokenLab base URL example for model router

### DIFF
--- a/website/docs/getting-started/model-router.md
+++ b/website/docs/getting-started/model-router.md
@@ -80,6 +80,14 @@ OpenAI-compatible providers may also require a base URL. You can override it wit
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 ```
 
+Registry entries can define their own API key and base URL variables. For example, an OpenAI-compatible TokenLab entry
+would be configured with:
+
+```bash
+TOKENLAB_API_KEY=your-tokenlab-api-key
+TOKENLAB_BASE_URL=https://api.tokenlab.sh/v1
+```
+
 ## When to Use ai-sdk Providers Directly
 
 Use model strings for quick setup and dynamic routing. If you need provider-specific configuration or advanced options, pass a `LanguageModel` from an ai-sdk provider instead:


### PR DESCRIPTION
## Summary
- Add TokenLab as an OpenAI-compatible base URL example for registry-defined provider env vars.
- Keep the change docs-only and scoped to the project's existing OpenAI-compatible configuration surface.

## Validation
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TokenLab OpenAI-compatible example to the model router docs, showing how to set `TOKENLAB_API_KEY` and `TOKENLAB_BASE_URL` for registry-defined providers. This clarifies how to configure TokenLab with the router without code changes.

<sup>Written for commit 52caa1fd55de3f9ce688255b7a62f2127436f555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified environment variable configuration for registry entries.
  * Added an example showing how to set custom API key and base URL variables for an OpenAI-compatible provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->