### PR TITLE
feat(core): add agent tool authorization guard

### DIFF
--- a/.changeset/tool-authorization-guard.md
+++ b/.changeset/tool-authorization-guard.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": minor
+---
+
+Add an agent tool authorization guard that can allow or deny local, async-generator, and provider tool execution before tools run.

--- a/packages/core/src/agent/agent.spec-d.ts
+++ b/packages/core/src/agent/agent.spec-d.ts
@@ -628,6 +628,32 @@ describe("Agent Type System", () => {
       expectTypeOf(hooks).toMatchTypeOf<AgentHooks>();
     });
 
+    it("should validate agent toolGuard option", () => {
+      const agentOptions: AgentOptions = {
+        name: "GuardedAgent",
+        instructions: "Test",
+        model: "openai/gpt-4o-mini",
+        toolGuard: async ({ agent, tool, args, context }) => {
+          expectTypeOf(agent).toMatchTypeOf<Agent>();
+          expectTypeOf(tool.name).toEqualTypeOf<string>();
+          expectTypeOf(args).toBeAny();
+          expectTypeOf(context).toMatchTypeOf<OperationContext>();
+          return { denied: true, reason: "read-only" };
+        },
+      };
+
+      expectTypeOf(agentOptions).toMatchTypeOf<AgentOptions>();
+
+      const booleanGuardOptions: AgentOptions = {
+        name: "BooleanGuardAgent",
+        instructions: "Test",
+        model: "openai/gpt-4o-mini",
+        toolGuard: () => true,
+      };
+
+      expectTypeOf(booleanGuardOptions).toMatchTypeOf<AgentOptions>();
+    });
+
     it("should allow sync and async hooks", () => {
       const syncHooks: AgentHooks = {
         onStart: () => {

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -1497,6 +1497,7 @@ Use pandas and summarize findings.`.split("\n"),
       });
       const onToolError = vi.fn();
       const onToolEnd = vi.fn();
+      const toolOnEnd = vi.fn();
       const agent = new Agent({
         name: "TestAgent",
         instructions: "Test",
@@ -1510,6 +1511,9 @@ Use pandas and summarize findings.`.split("\n"),
         description: "Deletes a note",
         parameters: z.object({ id: z.string() }),
         execute,
+        hooks: {
+          onEnd: toolOnEnd,
+        },
       });
 
       const operationContext = (agent as any).createOperationContext("input");
@@ -1549,6 +1553,7 @@ Use pandas and summarize findings.`.split("\n"),
       });
 
       expect(onToolEnd).toHaveBeenCalledTimes(1);
+      expect(toolOnEnd).toHaveBeenCalledTimes(1);
       const toolEndArgs = onToolEnd.mock.calls[0][0];
       expect(toolEndArgs.tool).toBe(protectedTool);
       expect(toolEndArgs.output).toBeUndefined();
@@ -1558,6 +1563,88 @@ Use pandas and summarize findings.`.split("\n"),
       });
 
       operationContext.traceContext.end("completed");
+    });
+
+    it("blocks routed provider tool execution before invoking the provider", async () => {
+      const toolGuard = vi.fn().mockResolvedValue({
+        denied: true,
+        reason: "read-only agent",
+      });
+      const onToolError = vi.fn();
+      const onToolEnd = vi.fn();
+      const agent = new Agent({
+        name: "TestAgent",
+        instructions: "Test",
+        model: mockModel as any,
+        toolGuard,
+        hooks: createHooks({ onToolError, onToolEnd }),
+      });
+
+      const providerTool = {
+        type: "provider",
+        id: "provider.deleteNote",
+        name: "provider-delete-note",
+        description: "Deletes a note through a provider tool",
+        args: { id: { type: "string" } },
+      } as any;
+      const operationContext = (agent as any).createOperationContext("input");
+      const executionOptions = {
+        ...operationContext,
+        hooks: agent.hooks,
+        toolContext: {
+          name: providerTool.name,
+          callId: "provider-call-1",
+          messages: [],
+          abortSignal: operationContext.abortController.signal,
+        },
+      };
+      const runInternalGenerateText = vi
+        .spyOn(agent as any, "runInternalGenerateText")
+        .mockRejectedValue(new Error("provider should not run"));
+
+      const result = await (agent as any).executeProviderToolViaCallTool({
+        tool: providerTool,
+        args: { id: "note-1" },
+        oc: operationContext,
+        hooks: agent.hooks,
+        executionOptions,
+      });
+
+      expect(runInternalGenerateText).not.toHaveBeenCalled();
+      expect(toolGuard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent,
+          tool: providerTool,
+          args: { id: "note-1" },
+          context: operationContext,
+        }),
+      );
+      expect(result).toMatchObject({
+        error: true,
+        toolName: "provider-delete-note",
+        code: "TOOL_FORBIDDEN",
+      });
+      expect(onToolError).toHaveBeenCalledTimes(1);
+      expect(onToolError.mock.calls[0][0]).toMatchObject({
+        tool: providerTool,
+        args: { id: "note-1" },
+        error: expect.objectContaining({
+          message: "read-only agent",
+          stage: "tool_execution",
+        }),
+      });
+      expect(onToolEnd).toHaveBeenCalledTimes(1);
+      expect(onToolEnd.mock.calls[0][0]).toMatchObject({
+        tool: providerTool,
+        output: undefined,
+        error: expect.objectContaining({
+          message: "read-only agent",
+          stage: "tool_execution",
+        }),
+      });
+
+      operationContext.traceContext.end("completed");
+      runInternalGenerateText.mockRestore();
     });
 
     it("calls onToolError when a tool throws", async () => {

--- a/packages/core/src/agent/agent.spec.ts
+++ b/packages/core/src/agent/agent.spec.ts
@@ -1489,6 +1489,77 @@ Use pandas and summarize findings.`.split("\n"),
       operationContext.traceContext.end("completed");
     });
 
+    it("blocks tool execution when toolGuard denies the tool", async () => {
+      const execute = vi.fn().mockResolvedValue("should-not-run");
+      const toolGuard = vi.fn().mockResolvedValue({
+        denied: true,
+        reason: "read-only agent",
+      });
+      const onToolError = vi.fn();
+      const onToolEnd = vi.fn();
+      const agent = new Agent({
+        name: "TestAgent",
+        instructions: "Test",
+        model: mockModel as any,
+        toolGuard,
+        hooks: createHooks({ onToolError, onToolEnd }),
+      });
+
+      const protectedTool = new Tool({
+        name: "delete-note",
+        description: "Deletes a note",
+        parameters: z.object({ id: z.string() }),
+        execute,
+      });
+
+      const operationContext = (agent as any).createOperationContext("input");
+      const executeFactory = (agent as any).createToolExecutionFactory(
+        operationContext,
+        agent.hooks,
+      );
+
+      const result = await executeFactory(protectedTool)({ id: "note-1" });
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(toolGuard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent,
+          tool: protectedTool,
+          args: { id: "note-1" },
+          context: operationContext,
+        }),
+      );
+      expect(result).toMatchObject({
+        error: true,
+        toolName: "delete-note",
+        code: "TOOL_FORBIDDEN",
+      });
+      expect(result.message).toContain("read-only agent");
+      expect(onToolError).toHaveBeenCalledTimes(1);
+      const toolErrorArgs = onToolError.mock.calls[0][0];
+      expect(toolErrorArgs.tool).toBe(protectedTool);
+      expect(toolErrorArgs.args).toEqual({ id: "note-1" });
+      expect(toolErrorArgs.originalError).toMatchObject({
+        code: "TOOL_FORBIDDEN",
+        message: "read-only agent",
+      });
+      expect(toolErrorArgs.error).toMatchObject({
+        message: "read-only agent",
+        stage: "tool_execution",
+      });
+
+      expect(onToolEnd).toHaveBeenCalledTimes(1);
+      const toolEndArgs = onToolEnd.mock.calls[0][0];
+      expect(toolEndArgs.tool).toBe(protectedTool);
+      expect(toolEndArgs.output).toBeUndefined();
+      expect(toolEndArgs.error).toMatchObject({
+        message: "read-only agent",
+        stage: "tool_execution",
+      });
+
+      operationContext.traceContext.end("completed");
+    });
+
     it("calls onToolError when a tool throws", async () => {
       const onToolError = vi.fn();
       const onToolEnd = vi.fn();

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6440,7 +6440,7 @@ export class Agent {
 
     const result = await this.toolGuard({
       agent: this,
-      tool: tool as any,
+      tool,
       context: oc,
       args,
       options,
@@ -6613,14 +6613,6 @@ export class Agent {
         let hasErrorOutputOverride = false;
 
         spanOutcome = { status: "error", error: voltAgentError };
-
-        await tool.hooks?.onEnd?.({
-          tool,
-          args,
-          output: undefined,
-          error: voltAgentError,
-          options: executionOptions,
-        });
 
         await tool.hooks?.onEnd?.({
           tool,
@@ -7252,6 +7244,62 @@ export class Agent {
       executionOptions.toolContext?.callId ?? randomUUID(),
     );
 
+    const hasOutputOverride = (
+      value: unknown,
+    ): value is {
+      output?: unknown;
+    } => {
+      if (!value || typeof value !== "object") {
+        return false;
+      }
+      return Object.prototype.hasOwnProperty.call(value, "output");
+    };
+
+    try {
+      await this.assertToolGuardAllows(tool, args, oc, executionOptions);
+    } catch (errorValue) {
+      const error = errorValue instanceof Error ? errorValue : new Error(String(errorValue));
+      const toolCallId = executionOptions.toolContext?.callId ?? randomUUID();
+      const voltAgentError = createVoltAgentError(error, {
+        stage: "tool_execution",
+        toolError: {
+          toolCallId,
+          toolName: tool.name,
+          toolExecutionError: error,
+          toolArguments: args,
+        },
+      });
+
+      const onToolErrorResult = await hooks.onToolError?.({
+        agent: this,
+        tool,
+        args,
+        error: voltAgentError,
+        originalError: error,
+        context: oc,
+        options: executionOptions,
+      });
+
+      await hooks.onToolEnd?.({
+        agent: this,
+        tool,
+        output: undefined,
+        error: voltAgentError,
+        context: oc,
+        options: executionOptions,
+      });
+
+      if (isToolDeniedError(errorValue)) {
+        oc.abortController.abort(errorValue);
+      }
+
+      if (hasOutputOverride(onToolErrorResult)) {
+        return onToolErrorResult.output;
+      }
+
+      return buildToolErrorResult(error, toolCallId, tool.name);
+    }
+
     const tools: Record<string, any> = {
       [tool.name]: tool,
     };
@@ -7291,10 +7339,9 @@ export class Agent {
           `Provider tool "${tool.name}" received arguments that do not match callTool input.`,
         );
       }
-      await this.assertToolGuardAllows(tool, callInput, oc, executionOptions);
       await hooks.onToolStart?.({
         agent: this,
-        tool: tool as any,
+        tool,
         args: callInput,
         context: oc,
         options: executionOptions,
@@ -7304,17 +7351,6 @@ export class Agent {
     if (!toolResult) {
       throw new Error("Provider tool did not return a result.");
     }
-
-    const hasOutputOverride = (
-      value: unknown,
-    ): value is {
-      output?: unknown;
-    } => {
-      if (!value || typeof value !== "object") {
-        return false;
-      }
-      return Object.prototype.hasOwnProperty.call(value, "output");
-    };
 
     const toolError =
       toolResult.output && typeof toolResult.output === "object" && "error" in toolResult.output
@@ -7329,7 +7365,7 @@ export class Agent {
     if (toolError && hookError) {
       const onToolErrorResult = await hooks.onToolError?.({
         agent: this,
-        tool: tool as any,
+        tool,
         args,
         error: hookError,
         originalError: new Error(toolError),
@@ -7344,7 +7380,7 @@ export class Agent {
 
     await hooks.onToolEnd?.({
       agent: this,
-      tool: tool as any,
+      tool,
       output: toolError ? undefined : toolResult.output,
       error: hookError,
       context: oc,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -106,7 +106,12 @@ import {
   type EnqueueEvalScoringArgs,
   enqueueEvalScoring as enqueueEvalScoringHelper,
 } from "./eval";
-import type { AgentHooks, OnToolEndHookResult, OnToolErrorHookResult } from "./hooks";
+import type {
+  AgentHooks,
+  AgentToolGuard,
+  OnToolEndHookResult,
+  OnToolErrorHookResult,
+} from "./hooks";
 import { stripDanglingOpenAIReasoningFromModelMessages } from "./model-message-normalizer";
 import { AgentTraceContext, addModelAttributesToSpan } from "./open-telemetry/trace-context";
 import {
@@ -1044,6 +1049,7 @@ export class Agent {
   private readonly workspaceToolkitOptions: AgentOptions["workspaceToolkits"];
   private readonly workspaceSkillsPromptOption: AgentOptions["workspaceSkillsPrompt"];
   private readonly configuredHooks?: AgentHooks;
+  private readonly toolGuard?: AgentToolGuard;
   private readonly maxStepsConfigured: boolean;
   private defaultObservability?: VoltAgentObservability;
   private readonly toolManager: ToolManager;
@@ -1078,6 +1084,7 @@ export class Agent {
     this.workspaceToolkitOptions = options.workspaceToolkits;
     this.workspaceSkillsPromptOption = options.workspaceSkillsPrompt;
     this.configuredHooks = options.hooks;
+    this.toolGuard = options.toolGuard;
     this.maxStepsConfigured = options.maxSteps !== undefined;
     const globalWorkspace = AgentRegistry.getInstance().getGlobalWorkspace();
     const workspaceOption = options.workspace === undefined ? globalWorkspace : options.workspace;
@@ -6421,6 +6428,46 @@ export class Agent {
     return parseResult.data;
   }
 
+  private async assertToolGuardAllows(
+    tool: BaseTool | ProviderTool,
+    args: any,
+    oc: OperationContext,
+    options?: ToolExecuteOptions,
+  ): Promise<void> {
+    if (!this.toolGuard) {
+      return;
+    }
+
+    const result = await this.toolGuard({
+      agent: this,
+      tool: tool as any,
+      context: oc,
+      args,
+      options,
+    });
+
+    const denied =
+      result === false ||
+      (typeof result === "object" &&
+        result !== null &&
+        (result.denied === true || result.allowed === false));
+    if (!denied) {
+      return;
+    }
+
+    const reason =
+      typeof result === "object" && result !== null && typeof result.reason === "string"
+        ? result.reason
+        : "Tool execution denied by toolGuard.";
+
+    throw new ToolDeniedError({
+      toolName: tool.name,
+      message: reason,
+      code: "TOOL_FORBIDDEN",
+      httpStatus: 403,
+    });
+  }
+
   private createToolExecutionFactory(
     oc: OperationContext,
     hooks: AgentHooks,
@@ -6623,6 +6670,7 @@ export class Agent {
           try {
             await this.waitForSpeculativeInputGuardrail(oc);
             await oc.traceContext.withSpan(toolSpan, async () => {
+              await this.assertToolGuardAllows(tool, args, oc, executionOptions);
               await runToolStartHooks();
             });
 
@@ -6683,7 +6731,8 @@ export class Agent {
       return oc.traceContext.withSpan(toolSpan, async () => {
         try {
           await this.waitForSpeculativeInputGuardrail(oc);
-          // Call tool start hook - can throw ToolDeniedError
+          // Call tool guard and start hook - both can throw ToolDeniedError
+          await this.assertToolGuardAllows(tool, args, oc, executionOptions);
           await runToolStartHooks();
 
           // Execute tool with merged options
@@ -7242,6 +7291,7 @@ export class Agent {
           `Provider tool "${tool.name}" received arguments that do not match callTool input.`,
         );
       }
+      await this.assertToolGuardAllows(tool, callInput, oc, executionOptions);
       await hooks.onToolStart?.({
         agent: this,
         tool: tool as any,

--- a/packages/core/src/agent/hooks/index.spec.ts
+++ b/packages/core/src/agent/hooks/index.spec.ts
@@ -1,4 +1,4 @@
-import { type AgentHooks, createHooks } from ".";
+import { type AgentHooks, type ToolGuardResult, createHooks } from ".";
 import type { Tool } from "../../tool";
 import { createVoltAgentError } from "../errors";
 import { createMockLanguageModel, createMockTool, createTestAgent } from "../test-utils";
@@ -8,6 +8,20 @@ describe("Agent Hooks Functionality", () => {
   let hooks: AgentHooks;
   let agent: ReturnType<typeof createTestAgent>;
   let tool: Tool<any, any>;
+
+  it("models object toolGuard results as mutually exclusive outcomes", () => {
+    const allowed = { allowed: true } satisfies ToolGuardResult;
+    const denied = { denied: true, reason: "read-only" } satisfies ToolGuardResult;
+    const deniedByAllowedFalse = { allowed: false, reason: "read-only" } satisfies ToolGuardResult;
+
+    // @ts-expect-error allowed and denied are mutually exclusive outcomes.
+    const conflicting = { allowed: true, denied: true } satisfies ToolGuardResult;
+
+    expect(allowed.allowed).toBe(true);
+    expect(denied.denied).toBe(true);
+    expect(deniedByAllowedFalse.allowed).toBe(false);
+    expect(conflicting).toEqual({ allowed: true, denied: true });
+  });
 
   beforeEach(() => {
     hooks = createHooks();

--- a/packages/core/src/agent/hooks/index.ts
+++ b/packages/core/src/agent/hooks/index.ts
@@ -59,6 +59,19 @@ export interface OnToolStartHookArgs {
   options?: ToolExecuteOptions;
 }
 
+export interface ToolGuardArgs extends OnToolStartHookArgs {}
+
+export type ToolGuardResult =
+  | boolean
+  | {
+      allowed?: boolean;
+      denied?: boolean;
+      reason?: string;
+    }
+  | undefined;
+
+export type AgentToolGuard = (args: ToolGuardArgs) => Promise<ToolGuardResult> | ToolGuardResult;
+
 export interface OnToolEndHookArgs {
   agent: Agent;
   tool: AgentTool;

--- a/packages/core/src/agent/hooks/index.ts
+++ b/packages/core/src/agent/hooks/index.ts
@@ -1,6 +1,6 @@
 import type { ModelMessage } from "@ai-sdk/provider-utils";
 import type { UIMessage } from "ai";
-import type { AgentTool } from "../../tool";
+import type { AgentTool, ProviderTool } from "../../tool";
 import type { Agent } from "../agent";
 import type { AbortError, CancellationError, VoltAgentError } from "../errors";
 import type { ToolExecuteOptions, UsageInfo } from "../providers/base/types";
@@ -51,9 +51,11 @@ export interface OnHandoffCompleteHookArgs {
   bail: (transformedResult?: string) => void;
 }
 
+export type AgentHookTool = AgentTool | ProviderTool;
+
 export interface OnToolStartHookArgs {
   agent: Agent;
-  tool: AgentTool;
+  tool: AgentHookTool;
   context: OperationContext;
   args: any;
   options?: ToolExecuteOptions;
@@ -61,20 +63,30 @@ export interface OnToolStartHookArgs {
 
 export interface ToolGuardArgs extends OnToolStartHookArgs {}
 
-export type ToolGuardResult =
-  | boolean
+export type ToolGuardObjectResult =
   | {
-      allowed?: boolean;
-      denied?: boolean;
+      allowed: true;
+      denied?: never;
       reason?: string;
     }
-  | undefined;
+  | {
+      allowed: false;
+      denied?: never;
+      reason?: string;
+    }
+  | {
+      denied: true;
+      allowed?: never;
+      reason?: string;
+    };
+
+export type ToolGuardResult = boolean | ToolGuardObjectResult | undefined;
 
 export type AgentToolGuard = (args: ToolGuardArgs) => Promise<ToolGuardResult> | ToolGuardResult;
 
 export interface OnToolEndHookArgs {
   agent: Agent;
-  tool: AgentTool;
+  tool: AgentHookTool;
   /** The successful output from the tool. Undefined on error. */
   output: unknown | undefined;
   /** The error if the tool execution failed. */
@@ -89,7 +101,7 @@ export interface OnToolEndHookResult {
 
 export interface OnToolErrorHookArgs {
   agent: Agent;
-  tool: AgentTool;
+  tool: AgentHookTool;
   args: any;
   /** Structured VoltAgentError for this failure. */
   error: VoltAgentError | AbortError;

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -55,7 +55,7 @@ import type {
   WorkspaceSkillsToolkitOptions,
 } from "../workspace";
 import type { ContextInput } from "./agent";
-import type { AgentHooks } from "./hooks";
+import type { AgentHooks, AgentToolGuard } from "./hooks";
 import type { AgentTraceContext } from "./open-telemetry/trace-context";
 
 // Re-export for backward compatibility
@@ -717,6 +717,11 @@ export type AgentOptions = {
 
   // Hooks
   hooks?: AgentHooks;
+  /**
+   * Optional per-tool authorization guard.
+   * Return `false`, `{ allowed: false }`, or `{ denied: true }` to block execution.
+   */
+  toolGuard?: AgentToolGuard;
 
   // Guardrails
   inputGuardrails?: InputGuardrail[];


### PR DESCRIPTION
## Summary
- Adds an Agent-level `toolGuard` hook for per-tool authorization before local tool execution.
- Supports deny responses via `false`, `{ allowed: false }`, or `{ denied: true, reason }`.
- Reuses the existing `ToolDeniedError` path so denied tool calls still reach `onToolError` / `onToolEnd` hooks for audit logging.
- Adds behavior and type coverage for the public API.

## Test Plan
- `vitest run packages/core/src/agent/agent.spec.ts packages/core/src/agent/hooks/index.spec.ts --config vitest.config.mts -t "Tool Execution|toolGuard|Hook Type Tests"`
- `pnpm --filter @voltagent/core typecheck`
- `pnpm --filter @voltagent/core build`
- `biome check packages/core/src/agent/agent.ts packages/core/src/agent/types.ts packages/core/src/agent/hooks/index.ts packages/core/src/agent/agent.spec.ts packages/core/src/agent/agent.spec-d.ts`

Related to #1177

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an agent-level `toolGuard` to allow or deny tool calls before they run across local, streaming, and provider tools. Denials use `ToolDeniedError` so `onToolError`/`onToolEnd` include audit context. Addresses #1177.

- **New Features**
  - `AgentOptions.toolGuard`: sync/async guard returning `boolean` or `{ allowed | denied | reason }` (mutually exclusive).
  - Guard runs before `onToolStart` for local, async-generator, and provider tools; denied calls return `TOOL_FORBIDDEN` (403).

- **Bug Fixes**
  - Enforces guard before routed provider tool calls, blocking provider invocation and preserving error/end hooks.
  - Expands hook types to accept provider tools; adds tests for provider guard denial and mutual exclusivity.

<sup>Written for commit 0fb458490703f5a89f6bb0e196c0c4f79bf95cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional tool authorization controls that can allow or deny tool execution.
  * Supports boolean or structured authorization decisions with customizable denial reasons.
  * Authorization applies consistently across regular, streaming, and provider tools.

* **Bug Fixes**
  * Prevented unauthorized tools from executing.
  * Denied tools return a `TOOL_FORBIDDEN` error with relevant context while preserving lifecycle and error callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->