### PR TITLE
Add MiniMax target model to router types

### DIFF
--- a/packages/core/scripts/generate-model-provider-registry.js
+++ b/packages/core/scripts/generate-model-provider-registry.js
@@ -33,6 +33,11 @@ const isEmbeddingModel = (modelId, modelInfo) => {
 const formatStringLiteral = (value) =>
   `'${String(value).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
 
+const PROVIDER_MODEL_OVERRIDES = {
+  minimax: ["MiniMax-M2.7"],
+  "minimax-cn": ["MiniMax-M2.7"],
+};
+
 async function fetchProviders() {
   const response = await fetch(API_URL);
   if (!response.ok) {
@@ -81,6 +86,12 @@ async function run() {
     if (embeddingModels.length) {
       providerEmbeddingModels[normalizedId] = embeddingModels;
     }
+  }
+
+  for (const [providerId, models] of Object.entries(PROVIDER_MODEL_OVERRIDES)) {
+    providerModels[providerId] = Array.from(
+      new Set([...(providerModels[providerId] || []), ...models].map(normalizeModelId)),
+    ).sort();
   }
 
   const registryContent = `${HEADER}

--- a/packages/core/src/registries/model-provider-types.generated.ts
+++ b/packages/core/src/registries/model-provider-types.generated.ts
@@ -1103,8 +1103,8 @@ export type ProviderModelsMap = {
     "qwen/qwen3-coder-30b",
   ];
   readonly lucidquery: readonly ["lucidnova-rf1-100b", "lucidquery-nexus-coder"];
-  readonly minimax: readonly ["MiniMax-M2", "MiniMax-M2.1", "MiniMax-M3"];
-  readonly "minimax-cn": readonly ["MiniMax-M2", "MiniMax-M2.1", "MiniMax-M3"];
+  readonly minimax: readonly ["MiniMax-M2", "MiniMax-M2.1", "MiniMax-M2.7", "MiniMax-M3"];
+  readonly "minimax-cn": readonly ["MiniMax-M2", "MiniMax-M2.1", "MiniMax-M2.7", "MiniMax-M3"];
   readonly mistral: readonly [
     "codestral-latest",
     "devstral-2512",


### PR DESCRIPTION
Reason: Add the current MiniMax model to the model router type map.

Changes:
- Adds a generator-level model override so regenerated router types retain the MiniMax target model.
- Updates the generated provider model type map for both MiniMax regional provider IDs.

Checks:
- node --check packages/core/scripts/generate-model-provider-registry.js
- git diff --check

Note: The focused package test could not be run because this clone's PNPM install did not create workspace links for test binaries.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `MiniMax-M2.7` to the model router types and generation so `minimax` and `minimax-cn` include the current target model. Ensures routing and types stay in sync across regenerations.

- **Bug Fixes**
  - Added a generator-level override to always include `MiniMax-M2.7` for `minimax` and `minimax-cn`.
  - Updated the generated `ProviderModelsMap` to list `MiniMax-M2.7` for both providers.

<sup>Written for commit f4802dfedeb04c8d8203b401fa36e4be5ccd4e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for the MiniMax-M2.7 model in MiniMax provider model lists.
  * Ensured model lists are consistently merged, deduplicated, and sorted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->