### PR TITLE
fix(core): clear the queue task timeout timer on every attempt

### DIFF
--- a/.changeset/lucky-timers-rest.md
+++ b/.changeset/lucky-timers-rest.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Clear a `BackgroundQueue` task's timeout timer when the attempt fails, not just when it succeeds. A failing memory operation left one pending timer per attempt, each keeping the Node event loop alive for the full timeout (30s by default in `MemoryManager`), so a short-lived process could not exit.

--- a/packages/core/src/utils/queue/queue.spec.ts
+++ b/packages/core/src/utils/queue/queue.spec.ts
@@ -239,6 +239,105 @@ describe("BackgroundQueue", () => {
     }, 5000);
   });
 
+  describe("Timeout timers", () => {
+    it("should clear the timeout timer when a task fails", async () => {
+      vi.useFakeTimers();
+      try {
+        const timerQueue = new BackgroundQueue({
+          maxConcurrency: 1,
+          defaultTimeout: 30000,
+          defaultRetries: 0,
+        });
+
+        timerQueue.enqueue({
+          id: "failing-task",
+          operation: async () => {
+            throw new Error("Task failed");
+          },
+        });
+
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should clear the timeout timer of every retried attempt", async () => {
+      vi.useFakeTimers();
+      try {
+        const timerQueue = new BackgroundQueue({
+          maxConcurrency: 1,
+          defaultTimeout: 30000,
+          defaultRetries: 2,
+        });
+
+        timerQueue.enqueue({
+          id: "always-failing-task",
+          operation: async () => {
+            throw new Error("Task failed");
+          },
+        });
+
+        // Long enough to cover the 50ms and 100ms waits between the three attempts.
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should clear the timeout timer when a task succeeds", async () => {
+      vi.useFakeTimers();
+      try {
+        const timerQueue = new BackgroundQueue({
+          maxConcurrency: 1,
+          defaultTimeout: 30000,
+          defaultRetries: 0,
+        });
+
+        timerQueue.enqueue({ id: "succeeding-task", operation: async () => "result" });
+
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should still time out a task that never settles", async () => {
+      vi.useFakeTimers();
+      try {
+        const timerQueue = new BackgroundQueue({
+          maxConcurrency: 1,
+          defaultTimeout: 1000,
+          defaultRetries: 0,
+        });
+        let settled = false;
+
+        timerQueue.enqueue({
+          id: "hanging-task",
+          operation: () =>
+            new Promise<string>((resolve) => {
+              setTimeout(() => {
+                settled = true;
+                resolve("too late");
+              }, 60000);
+            }),
+        });
+
+        await vi.advanceTimersByTimeAsync(1500);
+
+        expect(settled).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("Configuration options", () => {
     it("should use custom configuration", () => {
       const customQueue = new BackgroundQueue({

--- a/packages/core/src/utils/queue/queue.spec.ts
+++ b/packages/core/src/utils/queue/queue.spec.ts
@@ -314,23 +314,30 @@ describe("BackgroundQueue", () => {
         const timerQueue = new BackgroundQueue({
           maxConcurrency: 1,
           defaultTimeout: 1000,
-          defaultRetries: 0,
+          defaultRetries: 1,
         });
         let settled = false;
+        let attempts = 0;
 
         timerQueue.enqueue({
           id: "hanging-task",
-          operation: () =>
-            new Promise<string>((resolve) => {
+          operation: () => {
+            attempts += 1;
+            return new Promise<string>((resolve) => {
               setTimeout(() => {
                 settled = true;
                 resolve("too late");
               }, 60000);
-            }),
+            });
+          },
         });
 
+        // Past the 1000ms timeout of the first attempt and the 50ms wait before
+        // the retry, but well short of the 60000ms the operation needs.
         await vi.advanceTimersByTimeAsync(1500);
 
+        // A second attempt only starts if the first one was timed out.
+        expect(attempts).toBe(2);
         expect(settled).toBe(false);
       } finally {
         vi.useRealTimers();

--- a/packages/core/src/utils/queue/queue.ts
+++ b/packages/core/src/utils/queue/queue.ts
@@ -88,15 +88,16 @@ export class BackgroundQueue {
           }, task.timeout);
         });
 
-        const result = await Promise.race([task.operation(), timeoutPromise]);
+        try {
+          const result = await Promise.race([task.operation(), timeoutPromise]);
 
-        // Clear timeout if task completed
-        if (timeoutId) {
+          this.logger.trace(`Task ${task.id} completed (attempt ${attempt}/${maxAttempts}`);
+          return result;
+        } finally {
+          // The timer outlives the attempt it belongs to unless cleared, and an
+          // uncleared one keeps the event loop alive for its full duration.
           clearTimeout(timeoutId);
         }
-
-        this.logger.trace(`Task ${task.id} completed (attempt ${attempt}/${maxAttempts}`);
-        return result;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [x] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated — no public API change
- [x] Changesets have been added

## What is the current behavior?

`BackgroundQueue.executeTask` clears an attempt's timeout timer only after `Promise.race` resolves, so a rejected attempt jumps to the `catch` block and leaves the timer pending. The timer keeps the Node event loop alive for its full duration, blocking process exit, and with retries one timer is left per attempt.

`MemoryManager` builds its queue with `defaultTimeout: 30000` and `defaultRetries: 5`, so a memory operation that keeps failing leaves six 30-second timers pending.

## What is the new behavior?

The `Promise.race` is wrapped in a `try`/`finally` that clears the timer, so the timer is released whether the attempt resolves, rejects, or times out — and before the retry backoff rather than after it. The timeout itself is unchanged: a task that never settles is still rejected at `task.timeout`.

Measured with the `MemoryManager` options and a task that throws, using the reproduction from #1394:

| | before | after |
| --- | --- | --- |
| `defaultRetries: 0`, task throws | exits after 30017ms | exits after 1ms |
| `defaultRetries: 5`, task throws | exits after 30807ms | exits after 813ms |
| `defaultRetries: 0`, task succeeds | exits after 14ms | exits after 14ms |

The 813ms is the sum of the retry backoffs (50 + 100 + 150 + 200 + 250ms), which the fix does not change.

fixes #1394

## Notes for reviewers

Four tests were added to `queue.spec.ts` under `Timeout timers`, asserting `vi.getTimerCount() === 0` after a task fails, after every attempt of a retried task fails, and after a task succeeds, plus one that a task which never settles is still timed out.

Two of the four fail on `main` at `9aedd49` — `expected 1 to be +0` and `expected 3 to be +0`. The other two pass before and after and are there as guards.

`npx vitest run src/utils/queue/queue.spec.ts` → 13 passed.

Full `@voltagent/core` suite before and after: the set of failing tests is byte-identical (79 lines), 12 failed both ways, and passed goes 353 → 357, matching the 4 added tests. The pre-existing failures are all `Cannot find package '@voltagent/internal/utils'` in my checkout (the workspace package is not built) plus one `spawn C:Program ENOENT` in `workspace/sandbox/local.spec.ts` from a space in a Windows path; none of them touch the queue.

One note on `biome check`: it reports formatting diffs for these files, but it reports the same for files I did not touch (e.g. `packages/core/src/utils/id.ts`) because my checkout has `core.autocrlf=true`. The committed diff contains zero CR bytes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a timer leak in BackgroundQueue by clearing each attempt’s timeout in a finally block around Promise.race. Prevents pending timers from keeping the Node event loop alive and blocking process exit, especially with retries (fixes #1394).

- **Bug Fixes**
  - Clear the attempt’s timeout whether it succeeds, fails, or times out, and do it before any retry backoff.
  - Keep timeout behavior unchanged: tasks that never settle still reject at the configured timeout and start the next attempt when retries are enabled.
  - With `MemoryManager` defaults (30s timeout, 5 retries), failing operations no longer leave multiple 30s timers that delay exit.

<sup>Written for commit 17a3fa11adb2b43da018fd31fb1e55dcabca61c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background task timeout cleanup after failed attempts and retries.
  * Prevented completed or failed tasks from leaving pending timers that could keep short-lived processes running.
  * Ensured timeout handling remains reliable for successful, failed, retried, and never-completing tasks.

* **Tests**
  * Added coverage for timeout cleanup across task execution outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->