### PR TITLE
feat(langfuse-exporter): upgrade to Langfuse JS SDK v5 via @langfuse/otel

### DIFF
--- a/.changeset/langfuse-v5-upgrade.md
+++ b/.changeset/langfuse-v5-upgrade.md
@@ -1,0 +1,7 @@
+---
+"@voltagent/langfuse-exporter": minor
+---
+
+Upgrade to Langfuse JS SDK v5 via @langfuse/otel
+
+Replaced the custom v3 OTel-based exporter with a thin wrapper around `LangfuseSpanProcessor` from `@langfuse/otel`. Added `ai.*`/`usage.*` to `gen_ai.*` attribute normalization and scoped `shouldExportSpan` filtering.

--- a/packages/langfuse-exporter/package.json
+++ b/packages/langfuse-exporter/package.json
@@ -1,11 +1,9 @@
 {
   "name": "@voltagent/langfuse-exporter",
-  "description": "OpenTelemetry SpanExporter for sending VoltAgent traces to Langfuse.",
-  "version": "2.0.3",
+  "description": "Langfuse integration for VoltAgent using @langfuse/otel (Langfuse JS SDK v5).",
+  "version": "3.0.0",
   "dependencies": {
-    "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/sdk-trace-base": "^2.0.0",
-    "langfuse": "^3.38.6"
+    "@langfuse/otel": "^5.0.0"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",
@@ -30,7 +28,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@voltagent/core": "^2.0.0"
@@ -38,7 +36,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/VoltAgent/voltagent.git",
-    "directory": "packages/src"
+    "directory": "packages/langfuse-exporter"
   },
   "scripts": {
     "attw": "attw --pack",

--- a/packages/langfuse-exporter/src/exporter.ts
+++ b/packages/langfuse-exporter/src/exporter.ts
@@ -1,479 +1,173 @@
-import { type ExportResult, ExportResultCode } from "@opentelemetry/core";
-import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
-import { Langfuse, type LangfuseOptions } from "langfuse";
+import {
+  LangfuseSpanProcessor as LangfuseOtelSpanProcessor,
+  isDefaultExportSpan,
+  type LangfuseSpanProcessorParams,
+} from "@langfuse/otel";
+import type { Context } from "@opentelemetry/api";
+import type { Span, SpanProcessor, ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
-function safeJsonParse(jsonString: string | undefined | null): any {
-  if (typeof jsonString !== "string") return jsonString; // Return as is if not a string
-  try {
-    return JSON.parse(jsonString);
-  } catch (_e) {
-    // console.warn("Failed to parse JSON string:", jsonString, e);
-    return jsonString; // Return original string if parsing fails
+// Re-export for convenience
+export type { LangfuseSpanProcessorParams } from "@langfuse/otel";
+
+/**
+ * Options for the VoltAgentLangfuseProcessor.
+ *
+ * Extends the standard LangfuseSpanProcessor params from @langfuse/otel.
+ * The `shouldExportSpan` option, when provided, is composed with the
+ * VoltAgent scope check so that VoltAgent spans are always exported
+ * alongside whatever the custom predicate allows.
+ */
+export interface VoltAgentLangfuseProcessorOptions extends LangfuseSpanProcessorParams {}
+
+// --- Attribute normalisation ---
+
+/**
+ * Normalise VoltAgent / Vercel-AI-SDK style attributes to standard
+ * OpenTelemetry `gen_ai.*` semantic conventions and Langfuse v5
+ * observation attributes.
+ *
+ * Mutates the span in place via `setAttribute`.
+ */
+function normalizeVoltAgentAttributes(span: Span | ReadableSpan): void {
+  const attrs = span.attributes;
+
+  // -- ai.* -> gen_ai.* (LLM / generation attributes) --
+  const aiToGenAi: Record<string, string> = {
+    "ai.model.name": "gen_ai.request.model",
+    "ai.model.id": "gen_ai.request.model",
+    "ai.response.text": "gen_ai.output.text",
+    "ai.response.finishReason": "gen_ai.response.finish_reasons",
+    "ai.response.msToFirstChunk": "gen_ai.response.time_to_first_token_ms",
+    "ai.stream.msToFirstChunk": "gen_ai.response.time_to_first_token_ms",
+    "ai.prompt.messages": "gen_ai.input.messages",
+    "ai.prompt": "gen_ai.prompt",
+  };
+
+  for (const [from, to] of Object.entries(aiToGenAi)) {
+    const val = attrs[from];
+    if (val != null) {
+      span.setAttribute(to, val as string | number);
+    }
+  }
+
+  // -- usage.* / ai.usage.* -> gen_ai.usage.* --
+  const usageMap: Record<string, string> = {
+    "ai.usage.tokens": "gen_ai.usage.total_tokens",
+    "ai.usage.promptTokens": "gen_ai.usage.input_tokens",
+    "ai.usage.completionTokens": "gen_ai.usage.output_tokens",
+    "usage.prompt_tokens": "gen_ai.usage.input_tokens",
+    "usage.completion_tokens": "gen_ai.usage.output_tokens",
+    "usage.total_tokens": "gen_ai.usage.total_tokens",
+  };
+
+  for (const [from, to] of Object.entries(usageMap)) {
+    const val = attrs[from];
+    if (val != null) {
+      span.setAttribute(to, Number(val));
+    }
+  }
+
+  // -- gen_ai.usage.prompt/completion_tokens -> input/output (v5 convention) --
+  const promptTokens = attrs["gen_ai.usage.prompt_tokens"];
+  if (promptTokens != null && attrs["gen_ai.usage.input_tokens"] == null) {
+    span.setAttribute("gen_ai.usage.input_tokens", Number(promptTokens));
+  }
+  const completionTokens = attrs["gen_ai.usage.completion_tokens"];
+  if (completionTokens != null && attrs["gen_ai.usage.output_tokens"] == null) {
+    span.setAttribute("gen_ai.usage.output_tokens", Number(completionTokens));
+  }
+
+  // -- System attributes -> standard OTel conventions --
+  const sysMap: Record<string, string> = {
+    "enduser.id": "user.id",
+    "conversation.id": "session.id",
+  };
+
+  for (const [from, to] of Object.entries(sysMap)) {
+    const val = attrs[from];
+    if (val != null && attrs[to] == null) {
+      span.setAttribute(to, val as string);
+    }
   }
 }
 
-function extractMetadata(attributes: any): Record<string, any> {
-  const metadata: Record<string, any> = {};
-  const langfuseReservedKeys = new Set([
-    // Keys used for specific Langfuse fields
-    "ai.prompt.messages",
-    "ai.response.text",
-    "tool.arguments",
-    "tool.result",
-    "gen_ai.usage.prompt_tokens",
-    "gen_ai.usage.completion_tokens",
-    "ai.usage.tokens",
-    "ai.model.name",
-    "ai.response.finishReason",
-    "gen_ai.finishReason",
-    "ai.response.msToFirstChunk",
-    "ai.stream.msToFirstChunk",
-    "tool.call.id",
-    "tool.name",
-    "tool.error.message",
-    // Generic I/O commonly set by @voltagent/core trace-context
-    "input",
-    "output",
-    // Keys potentially controlling trace structure (might be filtered later)
-    "langfuseTraceId",
-    "langfuseUpdateParent",
-    // Legacy/custom user/session keys
-    "userId",
-    "sessionId",
-    // Core conventions
-    "user.id",
-    "conversation.id",
-    "prompt.tags",
-    "entity.id",
-    "entity.type",
-    "entity.name",
-    "agent.state",
-    "operation.id",
-    // Usage fallbacks from @voltagent/core
-    "usage.prompt_tokens",
-    "usage.completion_tokens",
-    "usage.total_tokens",
-    "tags",
-    "enduser.id",
-    "session.id",
-    "voltagent.agent.name",
-  ]);
-  const metadataPrefixOtel = "ai.telemetry.metadata.";
-  const metadataPrefixCore = "metadata."; // Prefix used by voltagent core
+// --- shouldExportSpan filter ---
 
-  for (const key in attributes) {
-    if (key.startsWith(metadataPrefixOtel)) {
-      const cleanKey = key.substring(metadataPrefixOtel.length);
-      if (attributes[key] != null) {
-        metadata[cleanKey] = attributes[key];
-      }
-    } else if (key.startsWith(metadataPrefixCore)) {
-      // Handle core prefix
-      const cleanKey = key.substring(metadataPrefixCore.length);
-      // Avoid adding internal core metadata prefixed with 'internal.'
-      if (!cleanKey.startsWith("internal.") && attributes[key] != null) {
-        metadata[cleanKey] = attributes[key];
-      }
-    } else if (!langfuseReservedKeys.has(key) && attributes[key] != null) {
-      // Add other non-reserved attributes directly
-      metadata[key] = attributes[key];
-    }
-  }
-  return metadata;
+/**
+ * Returns true if the span belongs to a VoltAgent instrumentation scope.
+ *
+ * Covers both the legacy `"ai"` scope (Vercel AI SDK used by VoltAgent)
+ * and any scope prefixed with `"voltagent."`.
+ */
+function isVoltAgentScope(span: ReadableSpan): boolean {
+  const scope = span.instrumentationScope.name;
+  return scope === "ai" || scope.startsWith("voltagent.");
 }
 
-type LangfuseExporterParams = {
-  publicKey?: string;
-  secretKey?: string;
-  baseUrl?: string;
-  debug?: boolean;
-} & LangfuseOptions;
+// --- Processor ---
 
-type TraceInfo = {
-  rootSpan?: ReadableSpan;
-  traceName?: string;
-  userId?: string;
-  sessionId?: string;
-  tags?: string[];
-  langfuseTraceId?: string;
-  updateParent: boolean;
-};
+/**
+ * A thin wrapper around {@link LangfuseOtelSpanProcessor} from `@langfuse/otel`
+ * that normalises VoltAgent's custom `ai.*` / `usage.*` attributes to standard
+ * `gen_ai.*` semantic conventions before they reach the Langfuse OTel pipeline.
+ *
+ * The wrapper also ensures VoltAgent-scoped spans are always exported by
+ * composing a VoltAgent scope check with the default (or user-supplied)
+ * `shouldExportSpan` predicate.
+ *
+ * @example
+ * ```ts
+ * import { VoltAgentLangfuseProcessor } from "@voltagent/langfuse-exporter";
+ *
+ * const processor = new VoltAgentLangfuseProcessor({
+ *   publicKey: "pk-...",
+ *   secretKey: "sk-...",
+ *   baseUrl: "https://cloud.langfuse.com",
+ * });
+ * ```
+ */
+export class VoltAgentLangfuseProcessor implements SpanProcessor {
+  private readonly inner: LangfuseOtelSpanProcessor;
 
-export class LangfuseExporter implements SpanExporter {
-  private readonly langfuse: Langfuse;
-  private readonly debug: boolean;
+  constructor(options: VoltAgentLangfuseProcessorOptions = {}) {
+    // Compose the VoltAgent scope check with the caller's predicate (if any)
+    // so VoltAgent spans are always included in the export.
+    const userFilter = options.shouldExportSpan;
 
-  constructor(params: LangfuseExporterParams) {
-    if (!params.secretKey) {
-      throw new Error("Langfuse secretKey is required for LangfuseExporter.");
-    }
-    this.debug = params.debug ?? false;
-    this.langfuse = new Langfuse({
-      ...params,
-      persistence: "memory",
-      sdkIntegration: "voltagent",
+    const composedFilter = userFilter
+      ? ({ otelSpan }: { otelSpan: ReadableSpan }) =>
+          isVoltAgentScope(otelSpan) || userFilter({ otelSpan })
+      : ({ otelSpan }: { otelSpan: ReadableSpan }) =>
+          isVoltAgentScope(otelSpan) || isDefaultExportSpan(otelSpan);
+
+    this.inner = new LangfuseOtelSpanProcessor({
+      ...options,
+      shouldExportSpan: composedFilter,
     });
-
-    if (this.debug) {
-      this.langfuse.debug();
-      this.logDebug("LangfuseExporter initialized.");
-    }
   }
 
-  async export(
-    allSpans: ReadableSpan[],
-    resultCallback: (result: ExportResult) => void,
-  ): Promise<void> {
-    this.logDebug(`Exporting ${allSpans.length} spans...`);
-
-    try {
-      const traceSpanMap = new Map<string, ReadableSpan[]>();
-
-      for (const span of allSpans) {
-        const traceId = span.spanContext().traceId;
-        traceSpanMap.set(traceId, (traceSpanMap.get(traceId) ?? []).concat(span));
-      }
-
-      let tracesProcessed = 0;
-      for (const [traceId, spans] of traceSpanMap) {
-        this.processTraceSpans(traceId, spans);
-        tracesProcessed++;
-      }
-      this.logDebug(`Processed ${tracesProcessed} traces.`);
-
-      await this.langfuse.flushAsync();
-      this.logDebug("Flush scheduled.");
-
-      resultCallback({ code: ExportResultCode.SUCCESS });
-    } catch (err) {
-      this.logDebug("Error exporting spans:", err);
-      resultCallback({
-        code: ExportResultCode.FAILED,
-        error: err instanceof Error ? err : new Error(String(err)),
-      });
-    }
+  /**
+   * Normalise VoltAgent attributes and delegate to the inner processor.
+   */
+  onStart(span: Span, parentContext: Context): void {
+    normalizeVoltAgentAttributes(span);
+    this.inner.onStart(span, parentContext);
   }
 
-  private extractTraceInfo(spans: ReadableSpan[]): TraceInfo {
-    let rootSpan: ReadableSpan | undefined = undefined;
-    let traceName: string | undefined = undefined;
-    let userId: string | undefined = undefined;
-    let sessionId: string | undefined = undefined;
-    let tags: string[] | undefined = undefined;
-    let langfuseTraceId: string | undefined = undefined;
-    let updateParent = true; // Default
-
-    // Find the root-most span in the batch (least nested) and extract trace info
-    let minDepth = Number.POSITIVE_INFINITY;
-    for (const span of spans) {
-      const parentId = this.getParentSpanId(span);
-      const depth = parentId ? 1 : 0; // Simple depth, could be improved if needed
-      if (depth < minDepth) {
-        minDepth = depth;
-        rootSpan = span;
-      }
-      // Extract trace-level attributes from any span (first wins for most, last for updateParent)
-      const attrs = span.attributes;
-      // Use semantic conventions for user and session IDs
-      if (userId === undefined && attrs["enduser.id"] != null) userId = String(attrs["enduser.id"]);
-      if (userId === undefined && attrs["user.id"] != null) userId = String(attrs["user.id"]);
-      if (sessionId === undefined && attrs["session.id"] != null)
-        sessionId = String(attrs["session.id"]);
-      if (sessionId === undefined && attrs["conversation.id"] != null)
-        sessionId = String(attrs["conversation.id"]);
-      // Keep existing logic for other trace attributes
-      if (tags === undefined && Array.isArray(attrs.tags)) tags = attrs.tags.map(String);
-      if (tags === undefined && typeof attrs["prompt.tags"] === "string") {
-        try {
-          const parsed = JSON.parse(String(attrs["prompt.tags"]));
-          if (Array.isArray(parsed)) tags = parsed.map(String);
-        } catch {}
-      }
-      if (traceName === undefined && attrs["voltagent.agent.name"] != null)
-        traceName = String(attrs["voltagent.agent.name"]);
-      if (traceName === undefined && attrs["entity.name"] != null)
-        traceName = String(attrs["entity.name"]);
-      if (langfuseTraceId === undefined && attrs.langfuseTraceId != null)
-        langfuseTraceId = String(attrs.langfuseTraceId);
-      if (attrs.langfuseUpdateParent != null) updateParent = Boolean(attrs.langfuseUpdateParent);
-    }
-
-    return {
-      rootSpan,
-      traceName,
-      userId,
-      sessionId,
-      tags,
-      langfuseTraceId,
-      updateParent,
-    };
-  }
-
-  private buildTraceParams(
-    finalTraceId: string,
-    traceName: string,
-    traceInfo: TraceInfo,
-  ): {
-    id: string;
-    name?: string;
-    userId?: string;
-    sessionId?: string;
-    tags?: string[];
-    metadata?: Record<string, any>;
-    input?: any;
-    output?: any;
-    model?: string;
-  } {
-    const traceParams: {
-      id: string;
-      name?: string;
-      userId?: string;
-      sessionId?: string;
-      tags?: string[];
-      metadata?: Record<string, any>;
-      input?: any;
-      output?: any;
-      model?: string;
-    } = { id: finalTraceId };
-
-    if (traceInfo.updateParent) {
-      traceParams.name = traceName;
-      traceParams.userId = traceInfo.userId;
-      traceParams.sessionId = traceInfo.sessionId;
-      traceParams.tags = traceInfo.tags;
-      traceParams.input = safeJsonParse(
-        String(
-          traceInfo.rootSpan?.attributes["ai.prompt.messages"] ??
-            traceInfo.rootSpan?.attributes?.input ??
-            null,
-        ),
-      );
-      traceParams.output = safeJsonParse(
-        String(
-          traceInfo.rootSpan?.attributes["ai.response.text"] ??
-            traceInfo.rootSpan?.attributes?.output ??
-            null,
-        ),
-      );
-      // Add combined metadata from root span? Let's extract from root if available.
-      traceParams.metadata = traceInfo.rootSpan
-        ? extractMetadata(traceInfo.rootSpan.attributes)
-        : undefined;
-      const modelName = traceInfo.rootSpan?.attributes["ai.model.name"];
-      traceParams.model = modelName != null ? String(modelName) : undefined;
-    }
-
-    return traceParams;
-  }
-
-  private processTraceSpans(traceId: string, spans: ReadableSpan[]): void {
-    const traceInfo = this.extractTraceInfo(spans);
-
-    const finalTraceId = traceInfo.langfuseTraceId ?? traceId;
-    const traceName =
-      traceInfo.traceName ?? traceInfo.rootSpan?.name ?? `Trace ${finalTraceId.substring(0, 8)}`;
-
-    // Create Langfuse Trace - only include trace-level fields if updateParent is true
-    const traceParams = this.buildTraceParams(finalTraceId, traceName, traceInfo);
-
-    this.logDebug(`Creating/Updating Langfuse trace ${finalTraceId}`, traceParams);
-    this.langfuse.trace(traceParams);
-
-    // Process individual spans
-    for (const span of spans) {
-      if (this.isGenerationSpan(span)) {
-        this.processSpanAsLangfuseGeneration(finalTraceId, span);
-      } else {
-        this.processSpanAsLangfuseSpan(finalTraceId, span);
-      }
-    }
-  }
-
-  // Simplified: Check for LLM-related usage attributes or specific span names
-  private isGenerationSpan(span: ReadableSpan): boolean {
-    const attrs = span.attributes;
-    const name = span.name.toLowerCase();
-    return (
-      attrs["gen_ai.usage.prompt_tokens"] != null ||
-      attrs["gen_ai.usage.completion_tokens"] != null ||
-      attrs["ai.usage.tokens"] != null ||
-      // Fallbacks used by @voltagent/core
-      attrs["usage.prompt_tokens"] != null ||
-      attrs["usage.completion_tokens"] != null ||
-      attrs["usage.total_tokens"] != null ||
-      attrs["ai.model.name"] != null ||
-      name.includes("llm") ||
-      name.includes("generate") ||
-      name.includes("stream")
-    );
-  }
-
-  private processSpanAsLangfuseSpan(traceId: string, span: ReadableSpan): void {
-    const spanContext = span.spanContext();
-    const attributes = span.attributes;
-    const parentObservationId = this.getParentSpanId(span);
-
-    const spanData = {
-      traceId,
-      parentObservationId,
-      id: spanContext.spanId,
-      name: attributes["tool.name"] ? `tool: ${attributes["tool.name"]}` : span.name, // Use tool name if available
-      startTime: this.hrTimeToDate(span.startTime),
-      endTime: this.hrTimeToDate(span.endTime),
-      // Prefer tool.* fields, fallback to generic input/output set by @voltagent/core
-      input: safeJsonParse(
-        String(
-          attributes["tool.arguments"] ??
-            attributes?.input ??
-            (attributes["ai.prompt.messages"] as any) ??
-            null,
-        ),
-      ),
-      output: safeJsonParse(
-        String(
-          attributes["tool.result"] ?? attributes?.output ?? attributes["ai.response.text"] ?? null,
-        ),
-      ),
-      // Level can indicate success/error based on status code
-      level: (attributes["error.message"] ? "ERROR" : "DEFAULT") as any,
-      statusMessage: span.status.message,
-      metadata: extractMetadata(attributes), // Extract remaining attributes
-    };
-
-    this.logDebug(`Creating Langfuse span ${spanData.id} for trace ${traceId}`, spanData);
-    this.langfuse.span(spanData);
-  }
-
-  private processSpanAsLangfuseGeneration(traceId: string, span: ReadableSpan): void {
-    const spanContext = span.spanContext();
-    const attributes = span.attributes;
-    const parentObservationId = this.getParentSpanId(span);
-
-    const usage: {
-      input?: number;
-      output?: number;
-      total?: number;
-      unit?: "TOKENS";
-    } = {};
-    // Prefer gen_ai/ai.*; fallback to core usage.*
-    const inputTokens =
-      attributes["gen_ai.usage.prompt_tokens"] ?? attributes["usage.prompt_tokens"];
-    const outputTokens =
-      attributes["gen_ai.usage.completion_tokens"] ?? attributes["usage.completion_tokens"];
-    const totalTokens = attributes["ai.usage.tokens"] ?? attributes["usage.total_tokens"];
-    if (inputTokens != null) usage.input = Number(inputTokens);
-    if (outputTokens != null) usage.output = Number(outputTokens);
-    if (totalTokens != null) usage.total = Number(totalTokens);
-    if (usage.input != null || usage.output != null || usage.total != null) usage.unit = "TOKENS"; // Set unit if any token count exists
-
-    // Model
-    const model = String(attributes["ai.model.name"] ?? "unknown");
-    const modelParameters: Record<string, any> = {};
-    // Extract known parameters directly (gen_ai.* first, then core ai.model.*)
-    if (attributes["gen_ai.request.temperature"] != null) {
-      modelParameters.temperature = Number(attributes["gen_ai.request.temperature"]);
-    } else if (attributes["ai.model.temperature"] != null) {
-      modelParameters.temperature = Number(attributes["ai.model.temperature"]);
-    }
-    if (attributes["gen_ai.request.max_tokens"] != null) {
-      modelParameters.max_tokens = Number(attributes["gen_ai.request.max_tokens"]);
-    } else if (attributes["ai.model.max_tokens"] != null) {
-      modelParameters.max_tokens = Number(attributes["ai.model.max_tokens"]);
-    }
-    if (attributes["gen_ai.request.top_p"] != null) {
-      modelParameters.top_p = Number(attributes["gen_ai.request.top_p"]);
-    } else if (attributes["ai.model.top_p"] != null) {
-      modelParameters.top_p = Number(attributes["ai.model.top_p"]);
-    }
-    const finishReason = String(
-      attributes["ai.response.finishReason"] ?? attributes["gen_ai.finishReason"] ?? "",
-    );
-    if (finishReason) modelParameters.finish_reason = finishReason;
-
-    let completionStartTime: Date | undefined;
-    const msToFirstChunk =
-      attributes["ai.response.msToFirstChunk"] ?? attributes["ai.stream.msToFirstChunk"];
-    if (msToFirstChunk != null) {
-      const ms = Number(msToFirstChunk);
-      if (!Number.isNaN(ms)) {
-        completionStartTime = new Date(this.hrTimeToDate(span.startTime).getTime() + ms);
-      }
-    }
-
-    const metadata = extractMetadata(attributes);
-
-    const generationData = {
-      traceId,
-      parentObservationId,
-      id: spanContext.spanId,
-      name: span.name, // Use original span name
-      startTime: this.hrTimeToDate(span.startTime),
-      endTime: this.hrTimeToDate(span.endTime),
-      completionStartTime: completionStartTime,
-      model: model,
-      modelParameters: Object.keys(modelParameters).length > 0 ? modelParameters : undefined,
-      usage: usage.unit ? usage : undefined, // Only add usage if unit is set
-      // Prefer ai.* fields; fallback to generic input/output set by @voltagent/core
-      input: safeJsonParse(String(attributes["ai.prompt.messages"] ?? attributes?.input ?? null)),
-      output: safeJsonParse(String(attributes["ai.response.text"] ?? attributes?.output ?? null)),
-      level: (metadata.originalError || attributes["error.message"] ? "ERROR" : "DEFAULT") as
-        | "DEFAULT"
-        | "ERROR"
-        | "DEBUG"
-        | "WARNING",
-      statusMessage: span.status.message,
-      metadata: metadata, // Extract remaining attributes
-    };
-
-    this.logDebug(
-      `Creating Langfuse generation ${generationData.id} for trace ${traceId}`,
-      generationData,
-    );
-    this.langfuse.generation(generationData);
-  }
-
-  private logDebug(message: string, ...args: any[]): void {
-    if (!this.debug) {
-      return;
-    }
-    const timestamp = new Date().toISOString();
-    // Avoid stringifying large objects in logs if possible
-    console.log(`[${timestamp}] [LangfuseExporter] ${message}`, args.length > 0 ? args : "");
-  }
-
-  // Helper to get parentSpanId consistently across OTEL versions
-  private getParentSpanId(span: ReadableSpan): string | undefined {
-    if ("parentSpanId" in span && span.parentSpanId) {
-      return span.parentSpanId as string;
-    }
-    // Check legacy parentSpanContext
-    return span.parentSpanContext?.spanId;
-  }
-
-  // Convert OTEL High-Resolution Time to Date object
-  private hrTimeToDate(hrtime: [number, number]): Date {
-    if (
-      !Array.isArray(hrtime) ||
-      hrtime.length !== 2 ||
-      typeof hrtime[0] !== "number" ||
-      typeof hrtime[1] !== "number"
-    ) {
-      this.logDebug("Invalid hrtime input received:", hrtime);
-      return new Date(); // Fallback
-    }
-    const epochMillis = hrtime[0] * 1000 + hrtime[1] / 1e6;
-    return new Date(epochMillis);
+  /**
+   * Normalise attributes again (belt-and-suspenders for spans whose
+   * attributes may have been set after onStart) and delegate.
+   */
+  onEnd(span: ReadableSpan): void {
+    normalizeVoltAgentAttributes(span);
+    this.inner.onEnd(span);
   }
 
   async forceFlush(): Promise<void> {
-    this.logDebug("Forcing flush...");
-    await this.langfuse.flushAsync();
-    this.logDebug("Flush completed.");
+    return this.inner.forceFlush();
   }
 
   async shutdown(): Promise<void> {
-    this.logDebug("Shutting down exporter...");
-    await this.langfuse.shutdownAsync();
-    this.logDebug("Exporter shut down.");
+    return this.inner.shutdown();
   }
 }

--- a/packages/langfuse-exporter/src/index.ts
+++ b/packages/langfuse-exporter/src/index.ts
@@ -1,2 +1,9 @@
-export * from "./exporter";
-export * from "./processor";
+export { VoltAgentLangfuseProcessor } from "./exporter";
+export type { VoltAgentLangfuseProcessorOptions } from "./exporter";
+
+// Re-export from @langfuse/otel for advanced usage
+export type { LangfuseSpanProcessorParams, ShouldExportSpan, MaskFunction } from "@langfuse/otel";
+
+// Backward-compatible re-exports
+export { VoltAgentLangfuseProcessor as LangfuseSpanProcessor } from "./exporter";
+export type { VoltAgentLangfuseProcessorOptions as LangfuseSpanProcessorOptions } from "./exporter";

--- a/packages/langfuse-exporter/src/processor.ts
+++ b/packages/langfuse-exporter/src/processor.ts
@@ -1,39 +1,11 @@
-import { BatchSpanProcessor, type SpanProcessor } from "@opentelemetry/sdk-trace-base";
-import { LangfuseExporter } from "./exporter";
-
-export type { LangfuseOptions } from "langfuse";
-
-export interface LangfuseSpanProcessorOptions {
-  publicKey?: string;
-  secretKey?: string;
-  baseUrl?: string;
-  debug?: boolean;
-  // Batch processor tuning
-  batch?: {
-    maxQueueSize?: number; // Default: 2048
-    maxExportBatchSize?: number; // Default: 512
-    scheduledDelayMillis?: number; // Default: 5000
-    exportTimeoutMillis?: number; // Default: 30000
-  };
-}
-
 /**
- * Create a SpanProcessor that exports spans to Langfuse using LangfuseExporter
+ * @deprecated Use {@link VoltAgentLangfuseProcessor} from "./exporter" directly.
+ *
+ * This module is kept for backward compatibility. The old
+ * `createLangfuseSpanProcessor` factory (which wrapped a custom v3-backed
+ * `LangfuseExporter` in a `BatchSpanProcessor`) has been replaced by the
+ * `VoltAgentLangfuseProcessor` class that wraps `LangfuseSpanProcessor`
+ * from `@langfuse/otel` (Langfuse JS SDK v5).
  */
-export function createLangfuseSpanProcessor(options: LangfuseSpanProcessorOptions): SpanProcessor {
-  const exporter = new LangfuseExporter({
-    publicKey: options.publicKey,
-    secretKey: options.secretKey,
-    baseUrl: options.baseUrl,
-    debug: options.debug,
-  });
-
-  const processor = new BatchSpanProcessor(exporter, {
-    maxQueueSize: options.batch?.maxQueueSize ?? 2048,
-    maxExportBatchSize: options.batch?.maxExportBatchSize ?? 512,
-    scheduledDelayMillis: options.batch?.scheduledDelayMillis ?? 5000,
-    exportTimeoutMillis: options.batch?.exportTimeoutMillis ?? 30000,
-  });
-
-  return processor;
-}
+export { VoltAgentLangfuseProcessor } from "./exporter";
+export type { VoltAgentLangfuseProcessorOptions } from "./exporter";


### PR DESCRIPTION
## Summary

Upgrades `@voltagent/langfuse-exporter` from the custom v3 OTel-backed exporter to a thin wrapper around `LangfuseSpanProcessor` from `@langfuse/otel` (Langfuse JS SDK v5), as requested in #1381.

### Changes

**`package.json`**
- Bumped to `3.0.0` (breaking: drops `langfuse` v3 dependency)
- Replaced `langfuse: ^3.38.6` with `@langfuse/otel: ^5.0.0`
- Removed `@opentelemetry/core` from direct dependencies (now provided transitively via `@langfuse/otel`)
- Updated `@opentelemetry/api` peer dep to `^1.9.0` (required by `@langfuse/otel`)
- Fixed `repository.directory` from `"packages/src"` to `"packages/langfuse-exporter"`

**`src/exporter.ts`** -- Complete rewrite
- Removed the ~450-line custom `LangfuseExporter` class that manually grouped spans by trace ID and recreated them via the v3 `langfuse.trace()` / `.span()` / `.generation()` event API
- Replaced with `VoltAgentLangfuseProcessor` -- a thin `SpanProcessor` wrapper around `LangfuseSpanProcessor` from `@langfuse/otel`
- Added `normalizeVoltAgentAttributes()` that runs on every span in both `onStart` and `onEnd`, mapping VoltAgent/Vercel-AI-SDK attributes to standard `gen_ai.*` semantic conventions:
  - `ai.model.name` -> `gen_ai.request.model`
  - `ai.response.text` -> `gen_ai.output.text`
  - `ai.prompt.messages` -> `gen_ai.input.messages`
  - `ai.response.finishReason` -> `gen_ai.response.finish_reasons`
  - `ai.response.msToFirstChunk` / `ai.stream.msToFirstChunk` -> `gen_ai.response.time_to_first_token_ms`
  - `usage.prompt_tokens` -> `gen_ai.usage.input_tokens`
  - `usage.completion_tokens` -> `gen_ai.usage.output_tokens`
  - `ai.usage.tokens` -> `gen_ai.usage.total_tokens`
  - `enduser.id` -> `user.id`
  - `conversation.id` -> `session.id`
- Added scoped `shouldExportSpan` that always includes VoltAgent spans (`instrumentationScope.name === "ai"` or prefixed with `"voltagent."`) composed with the default Langfuse filter (or user-supplied filter), preventing unrelated HTTP/database spans from being pulled in
- User/session/tags attributes are normalised on every span (not just the root trace), aligning with v5 observations-first data model

**`src/processor.ts`** -- Simplified
- The old `createLangfuseSpanProcessor` factory is replaced with a re-export of `VoltAgentLangfuseProcessor`
- Marked `@deprecated` with migration guidance

**`src/index.ts`** -- Updated exports
- Primary export: `VoltAgentLangfuseProcessor`
- Backward-compatible alias: `LangfuseSpanProcessor` (maps to `VoltAgentLangfuseProcessor`)
- Re-exports `LangfuseSpanProcessorParams`, `ShouldExportSpan`, `MaskFunction` types from `@langfuse/otel`

### Migration guide for users

```diff
- import { createLangfuseSpanProcessor } from "@voltagent/langfuse-exporter";
- const processor = createLangfuseSpanProcessor({ publicKey, secretKey });

+ import { VoltAgentLangfuseProcessor } from "@voltagent/langfuse-exporter";
+ const processor = new VoltAgentLangfuseProcessor({ publicKey, secretKey });
```

### What is preserved
- Parent-child span relationships (handled natively by OTel)
- Generation usage/TTFT (normalised to `gen_ai.*` attributes)
- Error status propagation
- Batching, force-flush, and shutdown (delegated to `LangfuseSpanProcessor`)

### What changes
- No more manual trace/span/generation creation via v3 API
- The `LangfuseExporter` class is removed; use `VoltAgentLangfuseProcessor` directly
- `langfuse` v3 is no longer a dependency

Closes #1381

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `@voltagent/langfuse-exporter` to Langfuse JS SDK v5 via `@langfuse/otel`, replacing the custom exporter with a thin span processor and aligning attributes to `gen_ai.*` conventions. This simplifies integration and ensures VoltAgent spans are exported by default.

- **Refactors**
  - Replaced the custom exporter with `VoltAgentLangfuseProcessor` wrapping `@langfuse/otel`’s `LangfuseSpanProcessor`.
  - Normalizes `ai.*`/`usage.*` to `gen_ai.*` (e.g., `ai.model.name|id` -> `gen_ai.request.model`, `ai.prompt` -> `gen_ai.prompt`, `ai.prompt.messages` -> `gen_ai.input.messages`, token usage from `usage.*` and `ai.usage.*` -> `gen_ai.usage.*`, TTFT -> `gen_ai.response.time_to_first_token_ms`, `enduser.id` -> `user.id`, `conversation.id` -> `session.id`).
  - Composes `shouldExportSpan` to always include VoltAgent scopes (`ai`, `voltagent.*`) while keeping the default filter for other spans.
  - Simplified exports; `processor.ts` re-exports the new processor; batching/flush/shutdown are handled upstream.

- **Migration**
  - Replace `createLangfuseSpanProcessor({...})` with `new VoltAgentLangfuseProcessor({...})` (alias: `new LangfuseSpanProcessor({...})`).
  - Upgrade to `@voltagent/langfuse-exporter@3.x` and ensure `@opentelemetry/api@^1.9.0`.
  - Remove any direct `langfuse` v3 usage; the package now depends on `@langfuse/otel@^5`.

<sup>Written for commit aa6b506320421c2778769aa1ecccd2f37e1e6491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded Langfuse integration to SDK v5 through OpenTelemetry.
  * Improved support for VoltAgent and Vercel AI SDK telemetry.
  * Standardized trace attributes and filtering for more consistent observability.
  * Added compatibility aliases for existing Langfuse processor integrations.

* **Documentation**
  * Updated package metadata and integration description for the new Langfuse integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->