### PR TITLE
fix(evals): keep sampled-out items out of the experiment pass rate

### DIFF
--- a/.changeset/pass-rate-excludes-sampled-out-items.md
+++ b/.changeset/pass-rate-excludes-sampled-out-items.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/evals": patch
+---
+
+Fixed experiment `summary.passRate` counting items whose scorers were all sampled out as passes. Those items have no evaluation evidence, but `evaluateItemStatus()` returns `passed` for them, so lowering scorer sampling pushed the pass rate toward 1 and a `{ type: "passRate" }` criterion could pass on results that were never scored. Sampled-out items are now excluded from the pass rate, matching how skipped scorer results are already excluded from a scorer's own pass rate; a run with nothing evaluated reports `passRate: null`. `successCount`, `failureCount`, `errorCount`, and `skippedCount` are unchanged.

--- a/packages/evals/src/experiment/aggregator.ts
+++ b/packages/evals/src/experiment/aggregator.ts
@@ -32,6 +32,8 @@ export interface ExperimentAggregatorState {
   failureCount: number;
   errorCount: number;
   skippedCount: number;
+  evaluatedCount: number;
+  evaluatedSuccessCount: number;
   globalScoreSum: number;
   globalScoreCount: number;
   scorers: Map<string, ScorerAggregateState>;
@@ -47,6 +49,8 @@ export function createAggregatorState(totalHint?: number): ExperimentAggregatorS
     failureCount: 0,
     errorCount: 0,
     skippedCount: 0,
+    evaluatedCount: 0,
+    evaluatedSuccessCount: 0,
     globalScoreSum: 0,
     globalScoreCount: 0,
     scorers: new Map(),
@@ -76,8 +80,16 @@ export function recordAggregatorResult(
 
   const scores = Object.values(item.scores);
   const allSkipped = scores.length > 0 && scores.every((score) => score.status === "skipped");
+  // An item whose every scorer was skipped carries no evaluation evidence, so
+  // it stays out of the pass rate, the same way skipped scorer results stay
+  // out of a scorer's own pass rate.
   if (allSkipped) {
     state.skippedCount += 1;
+  } else {
+    state.evaluatedCount += 1;
+    if (item.status === "passed") {
+      state.evaluatedSuccessCount += 1;
+    }
   }
 
   for (const score of scores) {
@@ -141,7 +153,7 @@ export function buildAggregatorSummary(
     errorCount: state.errorCount,
     skippedCount: state.skippedCount,
     meanScore: state.globalScoreCount > 0 ? state.globalScoreSum / state.globalScoreCount : null,
-    passRate: completedCount > 0 ? state.successCount / completedCount : null,
+    passRate: state.evaluatedCount > 0 ? state.evaluatedSuccessCount / state.evaluatedCount : null,
     startedAt: state.startedAt,
     scorers: buildScorerAggregates(state),
     criteria: [],

--- a/packages/evals/src/experiment/run-experiment.spec.ts
+++ b/packages/evals/src/experiment/run-experiment.spec.ts
@@ -9,6 +9,7 @@ const DATASET_ID = "dataset-integration";
 const DATASET_VERSION_ID = "dataset-version-integration";
 const DATASET_ITEM_1_ID = "11111111-1111-4111-8111-111111111111";
 const DATASET_ITEM_2_ID = "22222222-2222-4222-8222-222222222222";
+const DATASET_ITEM_3_ID = "33333333-3333-4333-8333-333333333333";
 
 function createDatasetItems(): ExperimentDatasetItem[] {
   return [
@@ -141,5 +142,82 @@ describe("runExperiment integration", () => {
     );
     expect(result.summary.scorers.hede?.passRate).toBe(1);
     expect(result.summary.scorers).not.toHaveProperty("original-id");
+  });
+
+  it("keeps sampled-out items out of the pass rate", async () => {
+    const experiment = createExperiment({
+      id: "run-sampled-out",
+      dataset: {
+        items: [
+          { id: DATASET_ITEM_1_ID, input: "scored", expected: "scored" },
+          { id: DATASET_ITEM_2_ID, input: "sampled-out", expected: "sampled-out" },
+          { id: DATASET_ITEM_3_ID, input: "boom", expected: "boom" },
+        ],
+      },
+      runner: async ({ item }) => ({ output: item.input }),
+      scorers: [
+        {
+          id: "sampled",
+          threshold: 0.5,
+          scorer: {
+            id: "sampled",
+            name: "sampled",
+            // One item is skipped, exactly as scorer sampling skips it, one
+            // scores below the threshold and one errors.
+            scorer: ({ payload }) => {
+              if (payload.input === "sampled-out") {
+                return { status: "skipped" };
+              }
+              if (payload.input === "boom") {
+                return { status: "error", error: new Error("scorer failed") };
+              }
+              return { status: "success", score: 0 };
+            },
+          },
+        },
+      ],
+    });
+
+    const result = await runExperiment(experiment);
+
+    // Nothing passed: one item scored below its threshold and one errored, so
+    // the pass rate is 0 of the 2 evaluated items. Before this fix the
+    // sampled-out item counted as a success and reported passRate 0.33.
+    expect(result.summary.passRate).toBe(0);
+    expect(result.summary.skippedCount).toBe(1);
+    expect(result.summary.errorCount).toBe(1);
+  });
+
+  it("reports a null pass rate when every item is sampled out", async () => {
+    const experiment = createExperiment({
+      id: "run-fully-sampled-out",
+      dataset: {
+        items: [{ id: DATASET_ITEM_1_ID, input: "hello", expected: "hello" }],
+      },
+      runner: async ({ item }) => ({ output: item.input }),
+      scorers: [
+        {
+          id: "sampled",
+          threshold: 0.5,
+          scorer: {
+            id: "sampled",
+            name: "sampled",
+            sampling: { type: "never" },
+            scorer: () => ({ status: "success", score: 1 }),
+          },
+        },
+      ],
+      passCriteria: [
+        { type: "passRate", min: 1 },
+        { type: "passRate", min: 1, scorerId: "sampled" },
+      ],
+    });
+
+    const result = await runExperiment(experiment);
+
+    // Both spellings of the same criterion must agree: with no evaluated
+    // evidence there is no pass rate to meet, so neither can pass.
+    expect(result.summary.passRate).toBeNull();
+    expect(result.summary.criteria.map((entry) => entry.passed)).toEqual([false, false]);
   });
 });

--- a/website/evaluation-docs/offline-evaluations.md
+++ b/website/evaluation-docs/offline-evaluations.md
@@ -164,7 +164,7 @@ While individual scorers determine if each item passes or fails, **pass criteria
 There are two types of criteria:
 
 - **`meanScore`**: Average score across all items must meet a minimum
-- **`passRate`**: Percentage of passed items must meet a minimum
+- **`passRate`**: Percentage of passed items must meet a minimum. Items whose scorers were all sampled out are not counted, since they carry no evaluation evidence
 
 ```ts
 import { createExperiment } from "@voltagent/evals";
@@ -785,7 +785,7 @@ interface ExperimentSummary {
   errorCount: number; // items with status "error"
   skippedCount: number; // items with status "skipped"
   meanScore?: number | null;
-  passRate?: number | null;
+  passRate?: number | null; // passed / evaluated items; null if nothing was evaluated
   startedAt: number; // Unix timestamp
   completedAt?: number; // Unix timestamp
   durationMs?: number;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [x] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

An experiment item whose scorers were all sampled out counts as a **pass** in
`summary.passRate`.

`evaluateItemStatus()` sees a score list with no `thresholdPassed === false`
and returns `passed`, so the item lands in `successCount`
(`packages/evals/src/experiment/run-experiment.ts:456`). `passRate` is then
`successCount / completedCount` (`aggregator.ts:144`), and the item is in both
the numerator and the denominator — even though nothing about it was evaluated.

The same criterion resolves two different ways today:

```ts
function resolvePassRate(summary, scorerId) {
  if (!scorerId) return summary.passRate; // sampled-out items count as passes
  return summary.scorers[scorerId]?.passRate ?? null; // skipped results excluded
}
```

A scorer's own `passRate` is `passCount / (passCount + failureCount)`
(`aggregator.ts:179`) — skipped results are already left out of the
denominator. The item-level pass rate does not do the same, so
`{ type: "passRate", min: 1 }` and
`{ type: "passRate", min: 1, scorerId: "x" }` can disagree on one run.

### Repro

```ts
const result = await runExperiment(
  createExperiment({
    id: "sampled-out",
    dataset: { items: [{ id: "item-1", input: "hello", expected: "hello" }] },
    runner: async ({ item }) => ({ output: item.input }),
    scorers: [
      {
        id: "sampled",
        threshold: 0.5,
        scorer: {
          id: "sampled",
          name: "sampled",
          sampling: { type: "never" },
          scorer: () => ({ status: "success", score: 1 }),
        },
      },
    ],
    passCriteria: { type: "passRate", min: 1 },
  }),
);

result.summary.passRate; // 1 — nothing was scored
result.summary.criteria[0].passed; // true
```

Because sampling is a cost control, the realistic shape is partial: with 100
items at 10 % sampling, ~90 unevaluated items are counted as passes, so the
pass rate sits near 1 regardless of how the evaluated 10 did. The practical
effect is that a `passRate` criterion gets easier to satisfy the less you
evaluate — including in the setup the evaluation docs suggest for a regression
test (`passCriteria: { type: "passRate", min: 1.0 }`).

## What is the new behavior?

Items whose every scorer was skipped are excluded from the pass rate, on both
sides of the fraction. A run with nothing evaluated reports `passRate: null`,
the same "no data" value already used for `meanScore` and for a scorer-scoped
pass rate with no attempts. With that, the two spellings of the criterion agree.

| Run | `passRate` before | after |
|---|---|---|
| 1 item, its only scorer sampled out | `1` | `null` |
| 1 below threshold + 1 sampled out | `0.5` | `0` |
| 1 passed + 1 failed + 1 sampled out | `0.67` | `0.5` |
| 100 items, 10 % sampling | ≈ `1` | passes among the ~10 scored |
| no sampling anywhere | unchanged | unchanged |

`successCount`, `failureCount`, `errorCount`, and `skippedCount` keep their
current meanings, and item status is untouched.

Added two regression tests beside the existing experiment specs: a mixed run
(one item below threshold, one errored, one skipped) that reported `0.33`
before and reports `0` now, and a fully sampled-out run that pins
`passRate: null` plus agreement between the scoped and unscoped criteria.

## Notes for reviewers

The change is confined to `aggregator.ts`, which the package does not export,
so no public type changes and no changeset beyond a `@voltagent/evals` patch.

One consequence worth flagging: with sampled-out items present,
`summary.passRate` is no longer `successCount / completedCount`. Anything
downstream that recomputes a pass rate from those counts — including consumers
of the summary `voltops/run.ts` uploads — would differ from the reported
`passRate` by exactly the sampled-out items. `mapSummary` currently sends
`successCount`, `failureCount`, `meanScore` and `passRate`; happy to add
`skippedCount` there too if that is useful on your side.

One neighbouring question this PR deliberately does **not** decide: a
sampled-out item still has item status `passed`, while the offline-evaluation
docs list `skipped` as an item status and define `skippedCount` as "items with
status `skipped`". Reconciling those would mean adding `"skipped"` to
`EvalResultStatus` / `VoltOpsEvalResultStatus`, which is forwarded to VoltOps
(`packages/evals/src/voltops/run.ts:407`) — whether the API accepts that value
is something only you can tell from here. Glad to follow up either way; this
fix holds under both outcomes.

Developed with AI assistance. I ran the repro above and the `@voltagent/evals`
suite myself against `main`, and I'm answerable for everything in the diff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated experiment pass rates by excluding items whose scorers were all sampled out. Pass criteria now reflect only evaluated items and match scorer-scoped pass rates.

- **Bug Fixes**
  - Exclude fully sampled-out items from `summary.passRate` (both numerator and denominator).
  - Report `passRate: null` when nothing was evaluated.
  - Keep `successCount`, `failureCount`, `errorCount`, and `skippedCount` unchanged.
  - Added regression tests and updated docs in `website/evaluation-docs`.

- **Migration**
  - `summary.passRate` may no longer equal `successCount / completedCount` when sampling is used. Update any downstream recomputations accordingly.

<sup>Written for commit 35a5fdd82ef6038f45723f3c48c635eb5187975c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pass rates now exclude items whose scorers were entirely sampled out.
  * Runs with no evaluated items now report a `null` pass rate instead of an inflated result.
  * Other evaluation counts remain unchanged.

* **Documentation**
  * Clarified pass-rate behavior for offline evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->