### PR TITLE
feat(core): support Valibot schemas for tools

### DIFF
--- a/.changeset/valibot-tool-schemas.md
+++ b/.changeset/valibot-tool-schemas.md
@@ -1,0 +1,7 @@
+---
+"@voltagent/core": minor
+---
+
+Let tools use Valibot (and other Standard Schema libraries) for their parameter and output schemas, not just Zod.
+
+Tool schemas now accept any Standard Schema, so `createTool`/`new Tool` take a Valibot schema and infer the `execute` args from it. Zod keeps working exactly as before. Since Valibot doesn't ship a JSON Schema extension yet, VoltAgent converts Valibot schemas with `@valibot/to-json-schema` (install it alongside `valibot` to use Valibot schemas); Zod-only users don't need it and nothing extra loads for them.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@standard-schema/spec": "^1.0.0",
     "@voltagent/internal": "^1.0.3",
     "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",
@@ -52,9 +53,11 @@
     "@ai-sdk/provider-utils": "^4.0.0",
     "@types/micromatch": "^4.0.10",
     "@types/uuid": "^10.0.0",
+    "@valibot/to-json-schema": "^1.0.0",
     "@vitest/coverage-v8": "^3.2.4",
     "ai": "^6.0.0",
     "msw": "^2.11.5",
+    "valibot": "^1.0.0",
     "zod": "^3.25.76"
   },
   "exports": {
@@ -78,11 +81,15 @@
   "module": "dist/index.mjs",
   "peerDependencies": {
     "@ai-sdk/provider-utils": "4.x",
+    "@valibot/to-json-schema": "^1.0.0",
     "@voltagent/logger": "2.0.2",
     "ai": "^6.0.0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
+    "@valibot/to-json-schema": {
+      "optional": true
+    },
     "@voltagent/logger": {
       "optional": true
     }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -78,6 +78,7 @@ import type {
   ToolSearchSelection,
   ToolSearchStrategy,
 } from "../tool/routing/types";
+import { normalizeToolSchemasForModel } from "../tool/standard-schema";
 import { randomUUID } from "../utils/id";
 import { convertModelMessagesToUIMessages } from "../utils/message-converter";
 import { NodeType, createNodeId } from "../utils/node-utils";
@@ -6363,6 +6364,10 @@ export class Agent {
     const preparedDynamicTools = tempManager.prepareToolsForExecution(createToolExecuteFunction);
     const preparedStaticTools =
       this.toolManager.prepareToolsForExecution(createToolExecuteFunction);
+
+    // Convert non-Zod schemas (e.g. Valibot) so the model still gets JSON Schema params.
+    await normalizeToolSchemasForModel(preparedDynamicTools);
+    await normalizeToolSchemasForModel(preparedStaticTools);
 
     const toolRouting = this.resolveToolRouting(options);
     oc.systemContext.set(TOOL_ROUTING_CONTEXT_KEY, toolRouting);

--- a/packages/core/src/agent/providers/base/types.ts
+++ b/packages/core/src/agent/providers/base/types.ts
@@ -5,6 +5,7 @@ import type {
   ToolContent,
   UserContent,
 } from "@ai-sdk/provider-utils";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { AsyncIterableStream } from "@voltagent/internal/utils";
 import type { TextStreamPart } from "ai";
 import type { z } from "zod";
@@ -242,7 +243,26 @@ export type MessageRole = "user" | "assistant" | "system" | "tool";
 export type BaseMessage = ModelMessage;
 
 // Schema types
-export type ToolSchema = z.ZodType;
+/**
+ * Schema accepted for tool parameters and output.
+ *
+ * Any Standard Schema library works here (Valibot, ArkType, Effect Schema, ...),
+ * and Zod stays fully supported since Zod implements the Standard Schema interface.
+ * The AI SDK converts whatever it's given to JSON Schema for the model.
+ */
+export type ToolSchema = z.ZodType | StandardSchemaV1;
+
+/**
+ * Infer the parsed output type of a tool schema.
+ *
+ * Zod schemas keep going through `z.infer` for exact backward compatibility;
+ * other Standard Schema libraries resolve via their inferred output type.
+ */
+export type InferSchema<T> = T extends z.ZodType
+  ? z.infer<T>
+  : T extends StandardSchemaV1
+    ? StandardSchemaV1.InferOutput<T>
+    : unknown;
 
 /**
  * Tool execution context containing all tool-specific metadata.

--- a/packages/core/src/tool/index.ts
+++ b/packages/core/src/tool/index.ts
@@ -1,7 +1,11 @@
 import type { ProviderOptions, ToolNeedsApprovalFunction } from "@ai-sdk/provider-utils";
 import type { Tool as VercelTool } from "ai";
-import type { z } from "zod";
-import type { BaseTool, ToolExecuteOptions, ToolSchema } from "../agent/providers/base/types";
+import type {
+  BaseTool,
+  InferSchema,
+  ToolExecuteOptions,
+  ToolSchema,
+} from "../agent/providers/base/types";
 import { LoggerProxy } from "../logger";
 
 /**
@@ -161,7 +165,7 @@ export type ToolOptions<
    * Whether the tool requires approval before execution.
    * When set to a function, it can decide dynamically per call.
    */
-  needsApproval?: boolean | ToolNeedsApprovalFunction<z.infer<T>>;
+  needsApproval?: boolean | ToolNeedsApprovalFunction<InferSchema<T>>;
 
   /**
    * Provider-specific options for the tool.
@@ -204,7 +208,7 @@ export type ToolOptions<
    * ```
    */
   toModelOutput?: (args: {
-    output: O extends ToolSchema ? z.infer<O> : unknown;
+    output: O extends ToolSchema ? InferSchema<O> : unknown;
   }) => ToolResultOutput;
 
   /**
@@ -214,9 +218,9 @@ export type ToolOptions<
    * @returns A result or an AsyncIterable of results (last value is final).
    */
   execute?: (
-    args: z.infer<T>,
+    args: InferSchema<T>,
     options?: ToolExecuteOptions,
-  ) => ToolExecutionResult<O extends ToolSchema ? z.infer<O> : unknown>;
+  ) => ToolExecutionResult<O extends ToolSchema ? InferSchema<O> : unknown>;
 
   /**
    * Optional tool-specific hooks for lifecycle events.
@@ -228,7 +232,7 @@ export type ToolOptions<
  * Tool class for defining tools that agents can use
  */
 export class Tool<T extends ToolSchema = ToolSchema, O extends ToolSchema | undefined = undefined> {
-  /* implements BaseTool<z.infer<T>> */
+  /* implements BaseTool<InferSchema<T>> */
   /**
    * Unique identifier for the tool
    */
@@ -262,7 +266,7 @@ export class Tool<T extends ToolSchema = ToolSchema, O extends ToolSchema | unde
   /**
    * Whether the tool requires approval before execution.
    */
-  readonly needsApproval?: boolean | ToolNeedsApprovalFunction<z.infer<T>>;
+  readonly needsApproval?: boolean | ToolNeedsApprovalFunction<InferSchema<T>>;
 
   /**
    * Provider-specific options for the tool.
@@ -278,7 +282,7 @@ export class Tool<T extends ToolSchema = ToolSchema, O extends ToolSchema | unde
    * Enables returning images, media, or structured content to the LLM.
    */
   readonly toModelOutput?: (args: {
-    output: O extends ToolSchema ? z.infer<O> : unknown;
+    output: O extends ToolSchema ? InferSchema<O> : unknown;
   }) => ToolResultOutput;
 
   /**
@@ -299,9 +303,9 @@ export class Tool<T extends ToolSchema = ToolSchema, O extends ToolSchema | unde
    * @returns A result or an AsyncIterable of results (last value is final).
    */
   readonly execute?: (
-    args: z.infer<T>,
+    args: InferSchema<T>,
     options?: ToolExecuteOptions,
-  ) => ToolExecutionResult<O extends ToolSchema ? z.infer<O> : unknown>;
+  ) => ToolExecutionResult<O extends ToolSchema ? InferSchema<O> : unknown>;
 
   /**
    * Whether this tool should be executed on the client side.

--- a/packages/core/src/tool/standard-schema.spec.ts
+++ b/packages/core/src/tool/standard-schema.spec.ts
@@ -1,0 +1,98 @@
+import { asSchema } from "ai";
+import * as v from "valibot";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { z } from "zod";
+import { createTool } from "./index";
+import { normalizeToolSchemasForModel, toModelToolSchema } from "./standard-schema";
+
+describe("Valibot tool schemas", () => {
+  it("accepts a Valibot schema and infers execute args from it", async () => {
+    const executed: Array<{ city: string; days?: number }> = [];
+
+    const tool = createTool({
+      name: "getWeather",
+      description: "Get the weather for a city",
+      parameters: v.object({
+        city: v.string(),
+        days: v.optional(v.number()),
+      }),
+      execute: async (args) => {
+        // Types come from the Valibot schema, not `any`.
+        expectTypeOf(args.city).toEqualTypeOf<string>();
+        expectTypeOf(args.days).toEqualTypeOf<number | undefined>();
+        executed.push(args);
+        return { forecast: "sunny" };
+      },
+    });
+
+    expect(tool.name).toBe("getWeather");
+    expect(tool.parameters).toBeDefined();
+
+    await tool.execute?.({ city: "Paris", days: 3 });
+    expect(executed).toEqual([{ city: "Paris", days: 3 }]);
+  });
+
+  it("converts a Valibot schema to the same JSON Schema as the Zod equivalent", async () => {
+    const valibotSchema = v.object({
+      city: v.string(),
+      days: v.optional(v.number()),
+    });
+    const zodSchema = z.object({
+      city: z.string(),
+      days: z.number().optional(),
+    });
+
+    const converted = await toModelToolSchema(valibotSchema);
+    const valibotJson = asSchema(converted).jsonSchema;
+    const zodJson = asSchema(zodSchema).jsonSchema;
+
+    expect(valibotJson.type).toBe("object");
+    expect(valibotJson.properties).toEqual({
+      city: { type: "string" },
+      days: { type: "number" },
+    });
+    expect(valibotJson.required).toEqual(["city"]);
+    // Same shape the model would see for the Zod version.
+    expect(valibotJson.properties).toEqual(zodJson.properties);
+    expect(valibotJson.required).toEqual(zodJson.required);
+  });
+
+  it("keeps Valibot validation on the converted schema", async () => {
+    const converted = await toModelToolSchema(
+      v.object({ city: v.string(), days: v.optional(v.number()) }),
+    );
+    const schema = asSchema(converted);
+
+    const ok = await schema.validate?.({ city: "Paris", days: 3 });
+    expect(ok).toEqual({ success: true, value: { city: "Paris", days: 3 } });
+
+    const bad = await schema.validate?.({ city: 123 });
+    expect(bad?.success).toBe(false);
+  });
+
+  it("leaves Zod schemas untouched", async () => {
+    const zodSchema = z.object({ query: z.string() });
+    const result = await toModelToolSchema(zodSchema);
+    expect(result).toBe(zodSchema);
+  });
+
+  it("normalizes only Valibot entries in a prepared tool map", async () => {
+    const zodSchema = z.object({ query: z.string() });
+    const valibotSchema = v.object({ query: v.string() });
+
+    const tools: Record<string, { inputSchema?: unknown }> = {
+      zodTool: { inputSchema: zodSchema },
+      valibotTool: { inputSchema: valibotSchema },
+      providerTool: {},
+    };
+
+    await normalizeToolSchemasForModel(tools);
+
+    expect(tools.zodTool.inputSchema).toBe(zodSchema);
+    expect(tools.valibotTool.inputSchema).not.toBe(valibotSchema);
+    expect(asSchema(tools.valibotTool.inputSchema).jsonSchema.properties).toEqual({
+      query: { type: "string" },
+    });
+    expect(tools.providerTool.inputSchema).toBeUndefined();
+  });
+});

--- a/packages/core/src/tool/standard-schema.ts
+++ b/packages/core/src/tool/standard-schema.ts
@@ -1,0 +1,92 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { safeStringify } from "@voltagent/internal/utils";
+import { jsonSchema } from "ai";
+
+/**
+ * Tool schemas can come from any Standard Schema library, not just Zod. The AI SDK
+ * turns Zod schemas and any Standard Schema that ships a JSON Schema extension into
+ * JSON Schema on its own, so those pass straight through.
+ *
+ * Valibot is the exception: as of v1 its `~standard` entry only exposes `validate`,
+ * with no JSON Schema, so the model would never see the parameter shape. For those we
+ * convert to JSON Schema with `@valibot/to-json-schema` (an optional peer dependency)
+ * and keep Valibot's own validator for argument checking.
+ */
+
+type ToJsonSchema = (schema: unknown, config?: Record<string, unknown>) => Record<string, unknown>;
+
+let converterPromise: Promise<ToJsonSchema> | undefined;
+
+function isStandardSchema(schema: unknown): schema is StandardSchemaV1 {
+  return typeof schema === "object" && schema !== null && "~standard" in schema;
+}
+
+/**
+ * True when a schema needs VoltAgent to convert it before the AI SDK sees it.
+ * Zod and JSON-Schema-capable Standard Schemas are left untouched.
+ */
+function needsValibotConversion(schema: unknown): schema is StandardSchemaV1 {
+  if (!isStandardSchema(schema)) return false;
+  const standard = schema["~standard"] as StandardSchemaV1.Props & { jsonSchema?: unknown };
+  if (standard.vendor === "zod") return false;
+  if ("jsonSchema" in standard) return false;
+  return standard.vendor === "valibot";
+}
+
+async function loadValibotConverter(): Promise<ToJsonSchema> {
+  if (!converterPromise) {
+    converterPromise = import("@valibot/to-json-schema")
+      .then((mod) => mod.toJsonSchema as unknown as ToJsonSchema)
+      .catch(() => {
+        throw new Error(
+          "A Valibot schema was passed to a tool, but '@valibot/to-json-schema' is not installed. " +
+            "Install it to use Valibot schemas: `npm install @valibot/to-json-schema`.",
+        );
+      });
+  }
+  return converterPromise;
+}
+
+/**
+ * Normalize a tool schema into a form the AI SDK can hand to the model. Zod and other
+ * schemas pass through unchanged; Valibot schemas are converted to a JSON Schema that
+ * keeps Valibot's runtime validation.
+ */
+export async function toModelToolSchema(schema: unknown): Promise<unknown> {
+  if (!needsValibotConversion(schema)) {
+    return schema;
+  }
+
+  const toJsonSchema = await loadValibotConverter();
+  const standard = schema["~standard"];
+
+  return jsonSchema(toJsonSchema(schema, { errorMode: "ignore" }), {
+    validate: async (value) => {
+      const result = await standard.validate(value);
+      if (result.issues) {
+        return {
+          success: false,
+          error: new Error(`Tool argument validation failed: ${safeStringify(result.issues)}`),
+        };
+      }
+      return { success: true, value: result.value };
+    },
+  });
+}
+
+/**
+ * Rewrite the `inputSchema` of every entry in a prepared tool map so Valibot-defined
+ * tools produce a JSON Schema for the model. Mutates in place; provider tools and
+ * tools without a schema are left alone.
+ */
+export async function normalizeToolSchemasForModel(
+  tools: Record<string, { inputSchema?: unknown }>,
+): Promise<void> {
+  await Promise.all(
+    Object.values(tools).map(async (tool) => {
+      if (tool && "inputSchema" in tool && needsValibotConversion(tool.inputSchema)) {
+        tool.inputSchema = await toModelToolSchema(tool.inputSchema);
+      }
+    }),
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3938,6 +3938,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.28.0
         version: 1.36.0
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.1.0
       '@voltagent/internal':
         specifier: ^1.0.3
         version: link:../internal
@@ -3984,6 +3987,9 @@ importers:
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
+      '@valibot/to-json-schema':
+        specifier: ^1.0.0
+        version: 1.7.1(valibot@1.4.2)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -3993,6 +3999,9 @@ importers:
       msw:
         specifier: ^2.11.5
         version: 2.11.6(@types/node@24.2.1)(typescript@5.9.2)
+      valibot:
+        specifier: ^1.0.0
+        version: 1.4.2(typescript@5.9.2)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -15446,8 +15455,8 @@ packages:
     dev: false
     optional: true
 
-  /@oxc-project/types@0.142.0:
-    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+  /@oxc-project/types@0.144.0:
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
     dev: true
 
   /@oxc-project/types@0.94.0:
@@ -17659,8 +17668,8 @@ packages:
   /@repeaterjs/repeater@3.0.6:
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
-  /@rolldown/binding-android-arm64@1.2.2:
-    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+  /@rolldown/binding-android-arm64@1.2.4:
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -17668,8 +17677,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-darwin-arm64@1.2.2:
-    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
+  /@rolldown/binding-darwin-arm64@1.2.4:
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -17677,8 +17686,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-darwin-x64@1.2.2:
-    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
+  /@rolldown/binding-darwin-x64@1.2.4:
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -17686,8 +17695,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-freebsd-x64@1.2.2:
-    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
+  /@rolldown/binding-freebsd-x64@1.2.4:
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -17695,8 +17704,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-arm-gnueabihf@1.2.2:
-    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
+  /@rolldown/binding-linux-arm-gnueabihf@1.2.4:
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -17704,8 +17713,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-arm64-gnu@1.2.2:
-    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
+  /@rolldown/binding-linux-arm64-gnu@1.2.4:
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -17713,8 +17722,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-arm64-musl@1.2.2:
-    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
+  /@rolldown/binding-linux-arm64-musl@1.2.4:
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -17722,8 +17731,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-ppc64-gnu@1.2.2:
-    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
+  /@rolldown/binding-linux-ppc64-gnu@1.2.4:
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -17731,8 +17740,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-s390x-gnu@1.2.2:
-    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
+  /@rolldown/binding-linux-s390x-gnu@1.2.4:
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -17740,8 +17749,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-x64-gnu@1.2.2:
-    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
+  /@rolldown/binding-linux-x64-gnu@1.2.4:
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -17749,8 +17758,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-linux-x64-musl@1.2.2:
-    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
+  /@rolldown/binding-linux-x64-musl@1.2.4:
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -17758,8 +17767,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-openharmony-arm64@1.2.2:
-    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
+  /@rolldown/binding-openharmony-arm64@1.2.4:
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -17767,8 +17776,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-win32-arm64-msvc@1.2.2:
-    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
+  /@rolldown/binding-win32-arm64-msvc@1.2.4:
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -17776,8 +17785,8 @@ packages:
     dev: true
     optional: true
 
-  /@rolldown/binding-win32-x64-msvc@1.2.2:
-    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
+  /@rolldown/binding-win32-x64-msvc@1.2.4:
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -19001,6 +19010,7 @@ packages:
 
   /@standard-schema/spec@1.0.0:
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+    dev: false
 
   /@standard-schema/spec@1.1.0:
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -21405,6 +21415,14 @@ packages:
     transitivePeerDependencies:
       - graphql
     dev: false
+
+  /@valibot/to-json-schema@1.7.1(valibot@1.4.2):
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
+    dependencies:
+      valibot: 1.4.2(typescript@5.9.2)
+    dev: true
 
   /@vercel/nft@0.29.4(supports-color@10.2.2):
     resolution: {integrity: sha512-6lLqMNX3TuycBPABycx7A9F1bHQR7kiQln6abjFbPrf5C/05qHM9M5E4PeTE59c7z8g6vHnx1Ioihb2AQl7BTA==}
@@ -26398,7 +26416,7 @@ packages:
   /effect@3.17.7:
     resolution: {integrity: sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA==}
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
     dev: true
 
@@ -37702,7 +37720,7 @@ packages:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
     dev: false
 
-  /rolldown-plugin-dts@0.16.11(rolldown@1.2.2)(typescript@5.9.2):
+  /rolldown-plugin-dts@0.16.11(rolldown@1.2.4)(typescript@5.9.2):
     resolution: {integrity: sha512-9IQDaPvPqTx3RjG2eQCK5GYZITo203BxKunGI80AGYicu1ySFTUyugicAaTZWRzFWh9DSnzkgNeMNbDWBbSs0w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
@@ -37730,35 +37748,35 @@ packages:
       dts-resolver: 2.1.2
       get-tsconfig: 4.10.1
       magic-string: 0.30.19
-      rolldown: 1.2.2
+      rolldown: 1.2.4
       typescript: 5.9.2
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
     dev: true
 
-  /rolldown@1.2.2:
-    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
+  /rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.144.0
       '@rolldown/pluginutils': 1.0.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.2
-      '@rolldown/binding-darwin-arm64': 1.2.2
-      '@rolldown/binding-darwin-x64': 1.2.2
-      '@rolldown/binding-freebsd-x64': 1.2.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
-      '@rolldown/binding-linux-arm64-gnu': 1.2.2
-      '@rolldown/binding-linux-arm64-musl': 1.2.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
-      '@rolldown/binding-linux-s390x-gnu': 1.2.2
-      '@rolldown/binding-linux-x64-gnu': 1.2.2
-      '@rolldown/binding-linux-x64-musl': 1.2.2
-      '@rolldown/binding-openharmony-arm64': 1.2.2
-      '@rolldown/binding-win32-arm64-msvc': 1.2.2
-      '@rolldown/binding-win32-x64-msvc': 1.2.2
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
     dev: true
 
   /rollup-plugin-inject@3.0.2:
@@ -39962,8 +39980,8 @@ packages:
       empathic: 2.0.0
       hookable: 5.5.3
       publint: 0.3.12
-      rolldown: 1.2.2
-      rolldown-plugin-dts: 0.16.11(rolldown@1.2.2)(typescript@5.9.2)
+      rolldown: 1.2.4
+      rolldown-plugin-dts: 0.16.11(rolldown@1.2.4)(typescript@5.9.2)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
@@ -41242,6 +41260,17 @@ packages:
       '@jridgewell/trace-mapping': 0.3.30
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+    dev: true
+
+  /valibot@1.4.2(typescript@5.9.2):
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.9.2
     dev: true
 
   /validate-npm-package-license@3.0.4:


### PR DESCRIPTION
Tools can now take a Valibot schema (or any Standard Schema library) for their parameters and output instead of only Zod, so people don't have to rewrite existing schemas to use VoltAgent.

Since VoltAgent runs on AI SDK v6, most of this comes for free: `createTool`/`new Tool` already hand `parameters` straight to the SDK, and the SDK turns Zod and any JSON-Schema-capable Standard Schema into JSON Schema itself. The blocker was really the type (`ToolSchema = z.ZodType`) plus one gap: Valibot v1's `~standard` only exposes `validate`, no JSON Schema, so the model would never see the parameter shape.

What's here:

- `ToolSchema` now accepts `z.ZodType | StandardSchemaV1`, and a small `InferSchema<T>` helper infers `execute` args from either. Zod still resolves through `z.infer`, so existing tools are untouched.
- For Valibot specifically, `prepareToolsForExecution`'s output gets a normalization pass that converts the schema with `@valibot/to-json-schema` and wraps it with the SDK's `jsonSchema()` helper, keeping Valibot's own validator for argument checking. `@valibot/to-json-schema` is an optional peer dependency loaded lazily, so Zod-only users pull nothing extra and nothing loads for them.

Zod stays the default and behaves exactly as before. The `getToolsForApi` UI helper still only introspects Zod; a Valibot schema renders as `unknown` there, which felt out of scope for this PR.

Tests (`packages/core/src/tool/standard-schema.spec.ts`, vitest with `--typecheck`): a Valibot tool builds and infers `execute` args from the schema; the converted schema produces the same JSON Schema the Zod equivalent does and keeps validating (valid passes, bad input fails); Zod schemas pass through by reference untouched; and the prepared-tool-map pass only rewrites Valibot entries. `pnpm --filter @voltagent/core test` (tool suite, 51 tests) is green, `tsc --noEmit` is clean, and the package builds.

fixes #143


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow tools to use Valibot and other Standard Schema libraries for parameters and outputs, not just Zod. The model still receives JSON Schema, Zod behavior is unchanged.

- `ToolSchema` now accepts `z.ZodType | StandardSchemaV1`, and `InferSchema<T>` infers types from either. For Valibot, we convert schemas to JSON Schema at execution prep with `@valibot/to-json-schema` and keep Valibot validation.
- The agent normalizes prepared tools via `normalizeToolSchemasForModel`; Zod schemas pass through untouched. `getToolsForApi` still introspects only Zod, so non-Zod parameters appear as `unknown`.
- Added tests to verify Valibot conversion, validation, type inference, and no regressions for Zod.

**Migration**
- To use Valibot schemas, install `valibot` and `@valibot/to-json-schema` (optional peer). Without the converter, passing a Valibot schema will throw at runtime.
- No changes required for Zod-only tools.

<sup>Written for commit 86775415cd0982079182e982fb3e3066c06fbb5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Valibot and other Standard Schema libraries in tool input and output schemas.
  - Tool execution arguments and outputs now receive accurate type inference beyond Zod.
  - Valibot schemas are converted for model use while retaining runtime validation.
  - Clear guidance and errors are provided when the required Valibot conversion package is missing.
- **Bug Fixes**
  - Preserved existing Zod behavior and provider-specific tool handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->