### PR TITLE
fix(core): preserve template replacement tokens

### DIFF
--- a/.changeset/bright-prompts-smile.md
+++ b/.changeset/bright-prompts-smile.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Preserve JavaScript replacement tokens in simple template variable values.

--- a/packages/core/src/voltops/template-engine.spec.ts
+++ b/packages/core/src/voltops/template-engine.spec.ts
@@ -101,5 +101,13 @@ describe("Template Engine", () => {
 
       expect(result).toBe("Pattern: $1.50 (special)");
     });
+
+    it("should preserve replacement tokens in variable values", () => {
+      const content = "Amount: {{value}}";
+      const variables = { value: "$&" };
+      const result = engine.process(content, variables);
+
+      expect(result).toBe("Amount: $&");
+    });
   });
 });

--- a/packages/core/src/voltops/template-engine.spec.ts
+++ b/packages/core/src/voltops/template-engine.spec.ts
@@ -109,5 +109,19 @@ describe("Template Engine", () => {
 
       expect(result).toBe("Amount: $&");
     });
+
+    it("should convert each variable to a string only once", () => {
+      let conversions = 0;
+      const content = "{{value}}/{{value}}";
+      const variables = {
+        value: {
+          [Symbol.toPrimitive]: () => `value-${++conversions}`,
+        },
+      };
+      const result = engine.process(content, variables);
+
+      expect(result).toBe("value-1/value-1");
+      expect(conversions).toBe(1);
+    });
   });
 });

--- a/packages/core/src/voltops/template-engine.ts
+++ b/packages/core/src/voltops/template-engine.ts
@@ -22,7 +22,7 @@ export const createSimpleTemplateEngine = (): TemplateEngine => ({
     let processed = content;
     for (const [key, value] of Object.entries(variables)) {
       const regex = new RegExp(`{{\\s*${key}\\s*}}`, "g");
-      processed = processed.replace(regex, String(value));
+      processed = processed.replace(regex, () => String(value));
     }
     return processed;
   },

--- a/packages/core/src/voltops/template-engine.ts
+++ b/packages/core/src/voltops/template-engine.ts
@@ -22,7 +22,8 @@ export const createSimpleTemplateEngine = (): TemplateEngine => ({
     let processed = content;
     for (const [key, value] of Object.entries(variables)) {
       const regex = new RegExp(`{{\\s*${key}\\s*}}`, "g");
-      processed = processed.replace(regex, () => String(value));
+      const replacement = String(value);
+      processed = processed.replace(regex, () => replacement);
     }
     return processed;
   },


### PR DESCRIPTION
## Summary

- Preserves literal JavaScript replacement tokens such as `$&` in VoltOps prompt variable values.
- Uses a replacement callback so `String.replace` cannot reinterpret prompt data as replacement patterns.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://voltagent.dev/docs/community/contributing/#commit-convention

## Bugs / Features

- [ ] Related issue(s) linked
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
- [x] Changesets have been added https://voltagent.dev/docs/community/contributing/#creating-a-changeset

## What is the current behavior?

When a prompt variable contains `$&`, rendering `{{value}}` returns the placeholder text instead of the literal variable value because JavaScript treats the value as a replacement string.

## What is the new behavior?

Prompt variable values are inserted literally, including `$&` and other replacement-token sequences.

fixes (issue)

N/A — the defect is demonstrated by a deterministic boundary-case regression test.

## Regression evidence

- Before: `npx --yes --package=node@20 --package=pnpm@8.10.5 -- pnpm --dir packages/core exec vitest run src/voltops/template-engine.spec.ts --reporter=verbose` exited `1` with the placeholder still present.
- After: the same command exited `0` with all 13 template-engine tests passing.

## Verification

- `CI=1 npx --yes --package=node@20 --package=pnpm@8.10.5 -- pnpm --filter @voltagent/core test`
- `npx --yes --package=node@20 --package=pnpm@8.10.5 -- sh -c 'node --version && pnpm --version && CI=1 pnpm install --frozen-lockfile'`
- `npx --yes --package=node@20 --package=pnpm@8.10.5 -- pnpm exec lerna run build --scope @voltagent/core --include-dependencies`
- `npx --yes --package=node@20 --package=pnpm@8.10.5 -- pnpm --filter @voltagent/core typecheck`
- `npx --yes --package=node@20 --package=pnpm@8.10.5 -- pnpm lint:ci`
- `npx --yes --package=node@20 --package=pnpm@8.10.5 -- pnpm sp lint`
- `npx --yes --package=node@20 --package=pnpm@8.10.5 -- pnpm changeset status`
- `npx --yes --package=node@20 --package=pnpm@8.10.5 -- pnpm --filter @voltagent/core publint`

## Scope

- 3 files changed, +14 / -1 lines.

## Notes for reviewers

The implementation change is intentionally limited to replacement-string handling; template-key parsing is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves literal replacement tokens and stringifies each variable once in `@voltagent/core` templates. Previously, `String.replace` interpreted tokens like `$&`, and our initial callback-based fix re-stringified per match; now we precompute the string and insert it via a callback so tokens are literal and conversion happens once.

- Implementation: compute `const replacement = String(value)` per variable and use `replace(regex, () => replacement)`; template-key parsing is unchanged.
- Tests: cover `$&` preservation and single stringification.
- No public API changes; no migration.

<sup>Written for commit 264cc1d045b26b0ae76f94caad4ec41d30f5c47c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved JavaScript replacement tokens such as `$&` when processing template variable values.

* **Tests**
  * Added coverage to verify replacement-token values remain unchanged during template processing.

* **Release**
  * Included a patch release for the template processing fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->