### PR TITLE
feat(internal): add config helpers for configurable defaults and adopt in supabase

### DIFF
--- a/.changeset/configurable-supabase-defaults.md
+++ b/.changeset/configurable-supabase-defaults.md
@@ -4,3 +4,5 @@
 ---
 
 Add `@voltagent/internal/config` with helpers to resolve configurable defaults (explicit option > environment variable > default value) and adopt them in `@voltagent/supabase`: the memory adapter defaults (`tableName`, `debug`, logger name) now live in a package-level `defaults.ts` and `tableName`/`debug` can be overridden via the `VOLTAGENT_SUPABASE_TABLE_NAME` and `VOLTAGENT_SUPABASE_DEBUG` environment variables.
+
+Note: `@voltagent/supabase` now imports `@voltagent/internal/config`, which first ships in `@voltagent/internal@1.1.0`. The monorepo declares internal dependencies with semver ranges (not `workspace:*`), and `changeset version` (`updateInternalDependencies: "patch"`) automatically raises dependents' ranges to `^1.1.0` when this minor release is versioned — verified locally — so the published `@voltagent/supabase` will require the internal version that contains the new subpath export.

--- a/.changeset/configurable-supabase-defaults.md
+++ b/.changeset/configurable-supabase-defaults.md
@@ -1,0 +1,6 @@
+---
+"@voltagent/internal": minor
+"@voltagent/supabase": patch
+---
+
+Add `@voltagent/internal/config` with helpers to resolve configurable defaults (explicit option > environment variable > default value) and adopt them in `@voltagent/supabase`: the memory adapter defaults (`tableName`, `debug`, logger name) now live in a package-level `defaults.ts` and `tableName`/`debug` can be overridden via the `VOLTAGENT_SUPABASE_TABLE_NAME` and `VOLTAGENT_SUPABASE_DEBUG` environment variables.

--- a/.changeset/configurable-supabase-defaults.md
+++ b/.changeset/configurable-supabase-defaults.md
@@ -4,5 +4,3 @@
 ---
 
 Add `@voltagent/internal/config` with helpers to resolve configurable defaults (explicit option > environment variable > default value) and adopt them in `@voltagent/supabase`: the memory adapter defaults (`tableName`, `debug`, logger name) now live in a package-level `defaults.ts` and `tableName`/`debug` can be overridden via the `VOLTAGENT_SUPABASE_TABLE_NAME` and `VOLTAGENT_SUPABASE_DEBUG` environment variables.
-
-Note: `@voltagent/supabase` now imports `@voltagent/internal/config`, which first ships in `@voltagent/internal@1.1.0`. The monorepo declares internal dependencies with semver ranges (not `workspace:*`), and `changeset version` (`updateInternalDependencies: "patch"`) automatically raises dependents' ranges to `^1.1.0` when this minor release is versioned — verified locally — so the published `@voltagent/supabase` will require the internal version that contains the new subpath export.

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -93,7 +93,7 @@
     "lint": "biome check .",
     "lint:fix": "biome check . --write",
     "publint": "publint --strict",
-    "test": "vitest",
+    "test": "vitest --reporter=hanging-process --reporter=default --typecheck",
     "test:coverage": "vitest run --coverage"
   },
   "types": "dist/main/index.d.ts",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -39,6 +39,16 @@
         "default": "./dist/utils/index.js"
       }
     },
+    "./config": {
+      "import": {
+        "types": "./dist/config/index.d.mts",
+        "default": "./dist/config/index.mjs"
+      },
+      "require": {
+        "types": "./dist/config/index.d.ts",
+        "default": "./dist/config/index.js"
+      }
+    },
     "./a2a": {
       "import": {
         "types": "./dist/main/index.d.mts",
@@ -97,6 +107,9 @@
       ],
       "utils": [
         "dist/utils/index.d.ts"
+      ],
+      "config": [
+        "dist/config/index.d.ts"
       ],
       "a2a": [
         "dist/main/index.d.ts"

--- a/packages/internal/src/config/config.spec-d.ts
+++ b/packages/internal/src/config/config.spec-d.ts
@@ -1,0 +1,27 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { parseEnvBoolean, parseEnvNumber, resolveConfig } from "./config";
+
+describe("resolveConfig types", () => {
+  it("should not require a parse function for string values", () => {
+    expectTypeOf(resolveConfig({ defaultValue: "voltagent_memory" })).toBeString();
+    expectTypeOf(
+      resolveConfig({ value: "custom", env: "VOLTAGENT_TEST", defaultValue: "default" }),
+    ).toBeString();
+  });
+
+  it("should require a parse function for boolean values", () => {
+    // @ts-expect-error - a parse function is required for non-string values
+    resolveConfig({ defaultValue: false });
+
+    expectTypeOf(resolveConfig({ defaultValue: false, parse: parseEnvBoolean })).toBeBoolean();
+  });
+
+  it("should require a parse function for number values", () => {
+    // @ts-expect-error - a parse function is required for non-string values
+    resolveConfig({ defaultValue: 3141 });
+
+    expectTypeOf(
+      resolveConfig({ defaultValue: 3141, parse: (raw) => parseEnvNumber(raw, 3141) }),
+    ).toBeNumber();
+  });
+});

--- a/packages/internal/src/config/config.spec.ts
+++ b/packages/internal/src/config/config.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { parseEnvBoolean, parseEnvNumber, resolveConfig } from "./config";
+
+const TEST_ENV_VAR = "VOLTAGENT_INTERNAL_CONFIG_TEST";
+
+afterEach(() => {
+  delete process.env[TEST_ENV_VAR];
+});
+
+describe("resolveConfig", () => {
+  it("should return the explicit value when provided", () => {
+    process.env[TEST_ENV_VAR] = "from-env";
+
+    expect(resolveConfig({ value: "explicit", env: TEST_ENV_VAR, defaultValue: "default" })).toBe(
+      "explicit",
+    );
+  });
+
+  it("should return the environment variable when no explicit value is provided", () => {
+    process.env[TEST_ENV_VAR] = "from-env";
+
+    expect(resolveConfig({ env: TEST_ENV_VAR, defaultValue: "default" })).toBe("from-env");
+  });
+
+  it("should return the default value when neither value nor env is set", () => {
+    expect(resolveConfig({ env: TEST_ENV_VAR, defaultValue: "default" })).toBe("default");
+  });
+
+  it("should return the default value when no env var name is provided", () => {
+    expect(resolveConfig({ defaultValue: "default" })).toBe("default");
+  });
+
+  it("should ignore an empty environment variable", () => {
+    process.env[TEST_ENV_VAR] = "";
+
+    expect(resolveConfig({ env: TEST_ENV_VAR, defaultValue: "default" })).toBe("default");
+  });
+
+  it("should treat an explicit undefined value as not provided", () => {
+    expect(resolveConfig({ value: undefined, defaultValue: "default" })).toBe("default");
+  });
+
+  it("should use the parse function for the environment variable", () => {
+    process.env[TEST_ENV_VAR] = "true";
+
+    expect(
+      resolveConfig({
+        env: TEST_ENV_VAR,
+        defaultValue: false,
+        parse: parseEnvBoolean,
+      }),
+    ).toBe(true);
+  });
+
+  it("should not use the parse function for the explicit value", () => {
+    process.env[TEST_ENV_VAR] = "not-a-boolean";
+
+    expect(
+      resolveConfig({
+        value: true,
+        env: TEST_ENV_VAR,
+        defaultValue: false,
+        parse: parseEnvBoolean,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("parseEnvBoolean", () => {
+  it.each(["1", "true", "TRUE", "True", "yes", "on", " true "])(
+    "should return true for %j",
+    (raw) => {
+      expect(parseEnvBoolean(raw)).toBe(true);
+    },
+  );
+
+  it.each(["0", "false", "no", "off", "anything", " "])("should return false for %j", (raw) => {
+    expect(parseEnvBoolean(raw)).toBe(false);
+  });
+});
+
+describe("parseEnvNumber", () => {
+  it("should parse a numeric string", () => {
+    expect(parseEnvNumber("42", 0)).toBe(42);
+    expect(parseEnvNumber("3.14", 0)).toBe(3.14);
+  });
+
+  it("should return the fallback for non-numeric strings", () => {
+    expect(parseEnvNumber("abc", 10)).toBe(10);
+    expect(parseEnvNumber("12x", 10)).toBe(10);
+  });
+});

--- a/packages/internal/src/config/config.spec.ts
+++ b/packages/internal/src/config/config.spec.ts
@@ -83,10 +83,17 @@ describe("parseEnvNumber", () => {
   it("should parse a numeric string", () => {
     expect(parseEnvNumber("42", 0)).toBe(42);
     expect(parseEnvNumber("3.14", 0)).toBe(3.14);
+    expect(parseEnvNumber(" 42 ", 0)).toBe(42);
   });
 
   it("should return the fallback for non-numeric strings", () => {
     expect(parseEnvNumber("abc", 10)).toBe(10);
     expect(parseEnvNumber("12x", 10)).toBe(10);
+  });
+
+  it("should return the fallback for empty and whitespace-only strings", () => {
+    expect(parseEnvNumber("", 10)).toBe(10);
+    expect(parseEnvNumber(" ", 10)).toBe(10);
+    expect(parseEnvNumber("   ", 10)).toBe(10);
   });
 });

--- a/packages/internal/src/config/config.ts
+++ b/packages/internal/src/config/config.ts
@@ -1,0 +1,80 @@
+/**
+ * Options for resolving a configuration value.
+ */
+export type ResolveConfigOptions<T> = {
+  /**
+   * The explicit value provided by the caller. Takes precedence over the
+   * environment variable and the default value.
+   */
+  value?: T;
+  /**
+   * The name of the environment variable that overrides the default value.
+   * An unset or empty environment variable is ignored.
+   */
+  env?: string;
+  /**
+   * The fallback value used when neither `value` nor the environment variable is set.
+   */
+  defaultValue: T;
+  /**
+   * Parses the raw environment variable string into the target type.
+   * When omitted, the raw string is returned as-is.
+   */
+  parse?: (raw: string) => T;
+};
+
+/**
+ * Resolves a configuration value with the following priority:
+ * explicit value > environment variable > default value.
+ *
+ * @example
+ * ```ts
+ * const tableName = resolveConfig({
+ *   value: options.tableName,
+ *   env: "VOLTAGENT_SUPABASE_TABLE_NAME",
+ *   defaultValue: "voltagent_memory",
+ * });
+ * ```
+ *
+ * @param options - The resolution options, see {@link ResolveConfigOptions}.
+ * @returns The resolved configuration value.
+ */
+export function resolveConfig<T>({ value, env, defaultValue, parse }: ResolveConfigOptions<T>): T {
+  if (value !== undefined) {
+    return value;
+  }
+
+  if (env) {
+    const raw = process.env[env];
+    if (raw !== undefined && raw !== "") {
+      return parse ? parse(raw) : (raw as unknown as T);
+    }
+  }
+
+  return defaultValue;
+}
+
+/**
+ * Parses an environment variable string into a boolean.
+ * `"1"`, `"true"`, `"yes"` and `"on"` (case-insensitive) resolve to `true`,
+ * everything else resolves to `false`.
+ *
+ * @param raw - The raw environment variable string.
+ * @returns The parsed boolean.
+ */
+export function parseEnvBoolean(raw: string): boolean {
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}
+
+/**
+ * Parses an environment variable string into a number.
+ * Falls back to the provided default when the value is not a finite number.
+ *
+ * @param raw - The raw environment variable string.
+ * @param fallback - The value returned when `raw` is not a valid number.
+ * @returns The parsed number or the fallback.
+ */
+export function parseEnvNumber(raw: string, fallback: number): number {
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}

--- a/packages/internal/src/config/config.ts
+++ b/packages/internal/src/config/config.ts
@@ -1,5 +1,9 @@
 /**
  * Options for resolving a configuration value.
+ *
+ * `parse` is optional for `string` values (the raw environment variable
+ * string is used as-is) and required for every other type, so non-string
+ * values can never be resolved without an explicit parser.
  */
 export type ResolveConfigOptions<T> = {
   /**
@@ -16,12 +20,21 @@ export type ResolveConfigOptions<T> = {
    * The fallback value used when neither `value` nor the environment variable is set.
    */
   defaultValue: T;
-  /**
-   * Parses the raw environment variable string into the target type.
-   * When omitted, the raw string is returned as-is.
-   */
-  parse?: (raw: string) => T;
-};
+} & ([T] extends [string]
+  ? {
+      /**
+       * Parses the raw environment variable string into the target type.
+       * When omitted, the raw string is returned as-is.
+       */
+      parse?: (raw: string) => T;
+    }
+  : {
+      /**
+       * Parses the raw environment variable string into the target type.
+       * Required for non-string values.
+       */
+      parse: (raw: string) => T;
+    });
 
 /**
  * Resolves a configuration value with the following priority:
@@ -68,13 +81,19 @@ export function parseEnvBoolean(raw: string): boolean {
 
 /**
  * Parses an environment variable string into a number.
- * Falls back to the provided default when the value is not a finite number.
+ * Falls back to the provided default when the value is empty, whitespace-only
+ * or not a finite number.
  *
  * @param raw - The raw environment variable string.
  * @param fallback - The value returned when `raw` is not a valid number.
  * @returns The parsed number or the fallback.
  */
 export function parseEnvNumber(raw: string, fallback: number): number {
-  const parsed = Number(raw);
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return fallback;
+  }
+
+  const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : fallback;
 }

--- a/packages/internal/src/config/index.ts
+++ b/packages/internal/src/config/index.ts
@@ -1,0 +1,2 @@
+export { resolveConfig, parseEnvBoolean, parseEnvNumber } from "./config";
+export type { ResolveConfigOptions } from "./config";

--- a/packages/internal/src/index.ts
+++ b/packages/internal/src/index.ts
@@ -2,4 +2,5 @@ export * from "./test";
 export * from "./utils";
 export * from "./a2a";
 export * from "./mcp";
+export * from "./config";
 export type * from "./logger/types";

--- a/packages/internal/tsconfig.typecheck.json
+++ b/packages/internal/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.spec-d.ts"]
+}

--- a/packages/internal/tsup.config.ts
+++ b/packages/internal/tsup.config.ts
@@ -34,6 +34,11 @@ export default defineConfig([
   },
   {
     ...baseConfig,
+    outDir: "dist/config",
+    entry: ["src/config/index.ts"],
+  },
+  {
+    ...baseConfig,
     outDir: "dist/types",
     dts: {
       only: true,

--- a/packages/internal/vitest.config.mts
+++ b/packages/internal/vitest.config.mts
@@ -18,5 +18,13 @@ export default defineConfig({
         },
       },
     },
+    typecheck: {
+      include: ["**/**/*.spec-d.ts"],
+      exclude: ["**/**/*.spec.ts"],
+      // Only type-check the spec-d type tests (and their imports), so the
+      // pre-existing type error in src/utils/objects.spec.ts does not fail
+      // this package's typecheck run.
+      tsconfig: "./tsconfig.typecheck.json",
+    },
   },
 });

--- a/packages/supabase/src/defaults.ts
+++ b/packages/supabase/src/defaults.ts
@@ -1,0 +1,36 @@
+/**
+ * Default values for the Supabase memory adapter.
+ *
+ * Every default can be overridden per-instance via `SupabaseMemoryOptions`
+ * and some can additionally be overridden via environment variables,
+ * see {@link supabaseEnvVars}.
+ */
+export const supabaseDefaults = {
+  /**
+   * The base table name, used as the prefix for all tables created by the adapter.
+   */
+  tableName: "voltagent_memory",
+  /**
+   * Whether debug logging is enabled.
+   */
+  debug: false,
+  /**
+   * The name of the default logger.
+   */
+  loggerName: "supabase-memory-v2",
+} as const;
+
+/**
+ * Environment variables that override the Supabase memory adapter defaults
+ * when no explicit option is provided.
+ */
+export const supabaseEnvVars = {
+  /**
+   * Overrides {@link supabaseDefaults.tableName}.
+   */
+  tableName: "VOLTAGENT_SUPABASE_TABLE_NAME",
+  /**
+   * Overrides {@link supabaseDefaults.debug}. Accepts "1", "true", "yes" and "on".
+   */
+  debug: "VOLTAGENT_SUPABASE_DEBUG",
+} as const;

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -8,3 +8,4 @@
 // Export Memory Adapter
 export { SupabaseMemoryAdapter } from "./memory-adapter";
 export type { SupabaseMemoryOptions } from "./memory-adapter";
+export { supabaseDefaults, supabaseEnvVars } from "./defaults";

--- a/packages/supabase/src/memory-adapter.spec.ts
+++ b/packages/supabase/src/memory-adapter.spec.ts
@@ -108,6 +108,20 @@ describe.sequential("SupabaseMemoryAdapter - Core Functionality", () => {
   // ============================================================================
 
   describe("Configurable Defaults", () => {
+    /**
+     * Test-only view of the resolved adapter configuration, used to assert
+     * which defaults were applied without resorting to `any`.
+     */
+    type ResolvedAdapterConfig = {
+      baseTableName: string;
+      debug: boolean;
+    };
+
+    const resolvedConfigOf = (adapter: SupabaseMemoryAdapter): ResolvedAdapterConfig => {
+      const { baseTableName, debug } = adapter as unknown as ResolvedAdapterConfig;
+      return { baseTableName, debug };
+    };
+
     const createAdapter = (options: Partial<{ tableName: string; debug: boolean }> = {}) =>
       new SupabaseMemoryAdapter({
         supabaseUrl: "https://test.supabase.co",
@@ -115,23 +129,43 @@ describe.sequential("SupabaseMemoryAdapter - Core Functionality", () => {
         ...options,
       });
 
+    const envBackup: Record<string, string | undefined> = {};
+
+    const restoreEnv = (name: string) => {
+      if (envBackup[name] === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = envBackup[name];
+      }
+    };
+
+    beforeEach(() => {
+      for (const name of ["VOLTAGENT_SUPABASE_TABLE_NAME", "VOLTAGENT_SUPABASE_DEBUG"]) {
+        envBackup[name] = process.env[name];
+        delete process.env[name];
+      }
+    });
+
     afterEach(() => {
-      // biome-ignore lint/performance/noDelete: Required for proper test isolation
-      delete process.env.VOLTAGENT_SUPABASE_TABLE_NAME;
-      // biome-ignore lint/performance/noDelete: Required for proper test isolation
-      delete process.env.VOLTAGENT_SUPABASE_DEBUG;
+      for (const name of ["VOLTAGENT_SUPABASE_TABLE_NAME", "VOLTAGENT_SUPABASE_DEBUG"]) {
+        restoreEnv(name);
+      }
     });
 
     it("should use the default table name and debug flag", () => {
       const localAdapter = createAdapter();
-      expect((localAdapter as any).baseTableName).toBe("voltagent_memory");
-      expect((localAdapter as any).debug).toBe(false);
+      expect(resolvedConfigOf(localAdapter)).toEqual({
+        baseTableName: "voltagent_memory",
+        debug: false,
+      });
     });
 
     it("should use the explicit options when provided", () => {
       const localAdapter = createAdapter({ tableName: "custom_memory", debug: true });
-      expect((localAdapter as any).baseTableName).toBe("custom_memory");
-      expect((localAdapter as any).debug).toBe(true);
+      expect(resolvedConfigOf(localAdapter)).toEqual({
+        baseTableName: "custom_memory",
+        debug: true,
+      });
     });
 
     it("should override defaults with environment variables", () => {
@@ -139,8 +173,10 @@ describe.sequential("SupabaseMemoryAdapter - Core Functionality", () => {
       process.env.VOLTAGENT_SUPABASE_DEBUG = "true";
 
       const localAdapter = createAdapter();
-      expect((localAdapter as any).baseTableName).toBe("env_memory");
-      expect((localAdapter as any).debug).toBe(true);
+      expect(resolvedConfigOf(localAdapter)).toEqual({
+        baseTableName: "env_memory",
+        debug: true,
+      });
     });
 
     it("should prefer explicit options over environment variables", () => {
@@ -148,8 +184,10 @@ describe.sequential("SupabaseMemoryAdapter - Core Functionality", () => {
       process.env.VOLTAGENT_SUPABASE_DEBUG = "true";
 
       const localAdapter = createAdapter({ tableName: "custom_memory", debug: false });
-      expect((localAdapter as any).baseTableName).toBe("custom_memory");
-      expect((localAdapter as any).debug).toBe(false);
+      expect(resolvedConfigOf(localAdapter)).toEqual({
+        baseTableName: "custom_memory",
+        debug: false,
+      });
     });
   });
 

--- a/packages/supabase/src/memory-adapter.spec.ts
+++ b/packages/supabase/src/memory-adapter.spec.ts
@@ -104,6 +104,56 @@ describe.sequential("SupabaseMemoryAdapter - Core Functionality", () => {
   });
 
   // ============================================================================
+  // Configurable Defaults Tests
+  // ============================================================================
+
+  describe("Configurable Defaults", () => {
+    const createAdapter = (options: Partial<{ tableName: string; debug: boolean }> = {}) =>
+      new SupabaseMemoryAdapter({
+        supabaseUrl: "https://test.supabase.co",
+        supabaseKey: "test-key",
+        ...options,
+      });
+
+    afterEach(() => {
+      // biome-ignore lint/performance/noDelete: Required for proper test isolation
+      delete process.env.VOLTAGENT_SUPABASE_TABLE_NAME;
+      // biome-ignore lint/performance/noDelete: Required for proper test isolation
+      delete process.env.VOLTAGENT_SUPABASE_DEBUG;
+    });
+
+    it("should use the default table name and debug flag", () => {
+      const localAdapter = createAdapter();
+      expect((localAdapter as any).baseTableName).toBe("voltagent_memory");
+      expect((localAdapter as any).debug).toBe(false);
+    });
+
+    it("should use the explicit options when provided", () => {
+      const localAdapter = createAdapter({ tableName: "custom_memory", debug: true });
+      expect((localAdapter as any).baseTableName).toBe("custom_memory");
+      expect((localAdapter as any).debug).toBe(true);
+    });
+
+    it("should override defaults with environment variables", () => {
+      process.env.VOLTAGENT_SUPABASE_TABLE_NAME = "env_memory";
+      process.env.VOLTAGENT_SUPABASE_DEBUG = "true";
+
+      const localAdapter = createAdapter();
+      expect((localAdapter as any).baseTableName).toBe("env_memory");
+      expect((localAdapter as any).debug).toBe(true);
+    });
+
+    it("should prefer explicit options over environment variables", () => {
+      process.env.VOLTAGENT_SUPABASE_TABLE_NAME = "env_memory";
+      process.env.VOLTAGENT_SUPABASE_DEBUG = "true";
+
+      const localAdapter = createAdapter({ tableName: "custom_memory", debug: false });
+      expect((localAdapter as any).baseTableName).toBe("custom_memory");
+      expect((localAdapter as any).debug).toBe(false);
+    });
+  });
+
+  // ============================================================================
   // Conversation Tests
   // ============================================================================
 

--- a/packages/supabase/src/memory-adapter.ts
+++ b/packages/supabase/src/memory-adapter.ts
@@ -18,9 +18,11 @@ import type {
   WorkflowStateEntry,
   WorkingMemoryScope,
 } from "@voltagent/core";
+import { parseEnvBoolean, resolveConfig } from "@voltagent/internal/config";
 import { type Logger, createPinoLogger } from "@voltagent/logger";
 import type { UIMessage } from "ai";
 import { P, match } from "ts-pattern";
+import { supabaseDefaults, supabaseEnvVars } from "./defaults";
 
 /**
  * Supabase configuration options for Memory
@@ -33,6 +35,8 @@ interface BaseSupabaseMemoryOptions {
   /**
    * The base table name for the memory, use to customize the prefix appended to all the tables
    *
+   * Can also be set via the `VOLTAGENT_SUPABASE_TABLE_NAME` environment variable.
+   *
    * @example
    *  'my_app_memory' => 'my_app_memory_conversations', 'my_app_memory_messages', 'my_app_memory_steps', 'my_app_memory_events'
    *
@@ -42,6 +46,9 @@ interface BaseSupabaseMemoryOptions {
 
   /**
    * Whether to enable debug logging
+   *
+   * Can also be set via the `VOLTAGENT_SUPABASE_DEBUG` environment variable.
+   *
    * @default false
    */
   debug?: boolean;
@@ -115,12 +122,21 @@ export class SupabaseMemoryAdapter implements StorageAdapter {
         throw new Error("Invalid configuration");
       });
 
-    this.baseTableName = options.tableName ?? "voltagent_memory";
-    this.debug = options.debug ?? false;
+    this.baseTableName = resolveConfig({
+      value: options.tableName,
+      env: supabaseEnvVars.tableName,
+      defaultValue: supabaseDefaults.tableName,
+    });
+    this.debug = resolveConfig({
+      value: options.debug,
+      env: supabaseEnvVars.debug,
+      defaultValue: supabaseDefaults.debug,
+      parse: parseEnvBoolean,
+    });
 
     // Initialize the logger
     this.logger = match(options.logger)
-      .with(P.nullish, () => createPinoLogger({ name: "supabase-memory-v2" }))
+      .with(P.nullish, () => createPinoLogger({ name: supabaseDefaults.loggerName }))
       .otherwise((logger) => logger);
 
     this.log("Supabase Memory V2 adapter initialized");


### PR DESCRIPTION
Part of #263.

This follows the approach @zrosenbauer laid out in https://github.com/VoltAgent/voltagent/pull/266#issuecomment-2986575124:

- Config resolution lives in `@voltagent/internal` (`internal/config` subpath export), with unit tests
- Defaults stay per-package rather than a single root `defaults.ts`
- Examples untouched
- One package at a time — this PR converts `@voltagent/supabase` first

What changed:

- Added `resolveConfig()` to `@voltagent/internal/config` (explicit option > env var > default), plus `parseEnvBoolean` / `parseEnvNumber` helpers. Non-string defaults must supply a `parse` function, enforced at compile time (type tests run via vitest `--typecheck`)
- `@voltagent/supabase` memory adapter defaults (`tableName`, `debug`, logger name) are now configurable via options or the `VOLTAGENT_SUPABASE_TABLE_NAME` / `VOLTAGENT_SUPABASE_DEBUG` env vars. Explicit options keep precedence, so existing behavior is unchanged
- Changeset included (internal: minor, supabase: patch)

Note: `@voltagent/supabase` now imports `@voltagent/internal/config`, which first ships in `@voltagent/internal@1.1.0`. The monorepo declares internal dependencies with semver ranges (not `workspace:*`), and `changeset version` (`updateInternalDependencies: "patch"`) automatically raises dependents' ranges to `^1.1.0` when this minor release is versioned — verified locally — so the published `@voltagent/supabase` will require the internal version that contains the new subpath export.

If this direction looks good, I'm happy to convert the remaining packages (postgres, libsql, etc.) in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable defaults for the Supabase memory adapter.
  * Table names and debug logging can be overridden through environment variables.
  * Explicit settings take priority over environment variables and built-in defaults.
  * Added reusable configuration helpers for resolving values and parsing boolean or numeric settings.
  * Exposed Supabase defaults and supported environment-variable mappings for reuse.

* **Bug Fixes**
  * Improved numeric configuration parsing by handling surrounding whitespace and empty values consistently.

* **Documentation**
  * Updated configuration guidance for Supabase table names and debug logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->