### PR TITLE
docs(examples): remove dead link to removed sdk-trace-example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -93,7 +93,6 @@ Create a multi-agent research workflow where different AI agents collaborate to 
 - [Airtable](./with-airtable) — React to new Airtable records and write updates back using VoltOps Airtable actions.
 - [GitHub Repo Analyzer](./github-repo-analyzer) — Agents read repository code and summarize insights/issues from GitHub projects.
 - [GitHub Star Stories](./github-star-stories) — Celebrate new GitHub stars with enriched profiles, AI-written stories, and VoltOps Discord actions.
-- [SDK Trace Example](./sdk-trace-example) — OpenTelemetry tracing wired to VoltOps so you can inspect spans and events.
 - [Agent‑to‑Agent Server](./with-a2a-server) — Expose agents over HTTP so other agents/services can call them.
 - [Amazon Bedrock](./with-amazon-bedrock) — Run AWS Bedrock models by configuring credentials and model IDs in VoltAgent.
 - [Anthropic](./with-anthropic) — Use Claude models as your agent’s LLM via the AI SDK.


### PR DESCRIPTION
## What is the current behavior?

The examples index (`examples/README.md`) lists an **SDK Trace Example** entry:

```
- [SDK Trace Example](./sdk-trace-example) — OpenTelemetry tracing wired to VoltOps so you can inspect spans and events.
```

But `examples/sdk-trace-example/` no longer exists. It was deleted in commit `5aa84b5b` (`feat: add evals`, #674), which removed all of its files (`src/index.ts`, `README.md`, `.env.example`, `tsconfig.json`, `.gitignore`). The relative link therefore 404s on GitHub, and there is no replacement example directory that covers OpenTelemetry tracing (searched all 87 example dirs — none match trace/observability/otel).

## What is the new behavior?

Remove the stale entry so the examples index only points at examples that actually exist. One-line deletion, no other entries touched.

## Verification

- `curl` of `contents/examples/sdk-trace-example` on `main` returns **404**.
- The removed line is the only broken relative link in `examples/README.md` (every other `./…` entry resolves to an existing directory).

## Notes for reviewers

There is one more stale reference to the same removed example in a dated blog post (`website/blog/2025-10-21-ai-agent-examples/index.md`, links to `.../tree/main/examples/sdk-trace-example`). I left the blog untouched since it is point-in-time content — happy to update it too if you'd prefer.

Docs-only change (examples index), so no changeset or tests.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dead SDK Trace Example entry from the examples index, since `examples/sdk-trace-example/` was deleted and the link now 404s on GitHub.

<sup>Written for commit 5e1b6c05f4875ffe405a0d503dd4a7424b75da2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the SDK Trace Example from the list of available examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->