### PR TITLE
fix(core): remove once() listener when off() is called with the original function

### DIFF
--- a/.changeset/fix-simple-event-emitter-once-off.md
+++ b/.changeset/fix-simple-event-emitter-once-off.md
@@ -1,0 +1,5 @@
+---
+"@voltagent/core": patch
+---
+
+Fix `SimpleEventEmitter.off()` not removing a listener registered via `once()`. `once()` registers an internal wrapper, so `off(event, listener)` deleted the original function (never in the set) and left the wrapper registered — a removed one-time listener still fired on the next `emit`. `off()` now resolves the original listener back to its wrapper (mirroring Node's `EventEmitter`).

--- a/.changeset/fix-simple-event-emitter-once-off.md
+++ b/.changeset/fix-simple-event-emitter-once-off.md
@@ -2,4 +2,4 @@
 "@voltagent/core": patch
 ---
 
-Fix `SimpleEventEmitter.off()` not removing a listener registered via `once()`. `once()` registers an internal wrapper, so `off(event, listener)` deleted the original function (never in the set) and left the wrapper registered — a removed one-time listener still fired on the next `emit`. `off()` now resolves the original listener back to its wrapper (mirroring Node's `EventEmitter`).
+Fix `SimpleEventEmitter.off()` not removing a listener registered via `once()`. `once()` registers an internal wrapper, so `off(event, listener)` deleted the original function (never in the set) and left the wrapper registered — a removed one-time listener still fired on the next `emit`. `off()` now resolves the original listener back to its wrapper (mirroring Node's `EventEmitter`). When the same function is registered with both `on()` and `once()`, `off()` removes only the newest matching registration, matching Node's removal order.

--- a/packages/core/src/utils/simple-event-emitter.spec.ts
+++ b/packages/core/src/utils/simple-event-emitter.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { SimpleEventEmitter } from "./simple-event-emitter";
+
+describe("SimpleEventEmitter", () => {
+  it("off() removes a once() listener before it fires", () => {
+    const emitter = new SimpleEventEmitter();
+    const listener = vi.fn();
+
+    emitter.once("evt", listener);
+    emitter.off("evt", listener);
+
+    // once() registers an internal wrapper, so off() must resolve the original
+    // listener back to that wrapper — otherwise the removed listener still fires.
+    expect(emitter.listenerCount("evt")).toBe(0);
+    emitter.emit("evt");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("once() still fires exactly once and then removes itself", () => {
+    const emitter = new SimpleEventEmitter();
+    const listener = vi.fn();
+
+    emitter.once("evt", listener);
+    emitter.emit("evt");
+    emitter.emit("evt");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(emitter.listenerCount("evt")).toBe(0);
+  });
+});

--- a/packages/core/src/utils/simple-event-emitter.spec.ts
+++ b/packages/core/src/utils/simple-event-emitter.spec.ts
@@ -27,4 +27,23 @@ describe("SimpleEventEmitter", () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(emitter.listenerCount("evt")).toBe(0);
   });
+
+  it("off() removes only the newest registration when on() and once() share a listener", () => {
+    const emitter = new SimpleEventEmitter();
+    const listener = vi.fn();
+
+    emitter.on("evt", listener);
+    emitter.once("evt", listener);
+    expect(emitter.listenerCount("evt")).toBe(2);
+
+    // Like Node's EventEmitter, off() drops the newest matching entry (the once()
+    // wrapper here), leaving the persistent on() registration intact.
+    emitter.off("evt", listener);
+    expect(emitter.listenerCount("evt")).toBe(1);
+
+    emitter.emit("evt");
+    emitter.emit("evt");
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(emitter.listenerCount("evt")).toBe(1);
+  });
 });

--- a/packages/core/src/utils/simple-event-emitter.ts
+++ b/packages/core/src/utils/simple-event-emitter.ts
@@ -14,7 +14,17 @@ export class SimpleEventEmitter {
   off(event: string, listener: (...args: any[]) => void): this {
     const set = this.listeners.get(event);
     if (set) {
-      set.delete(listener);
+      // A listener added via once() is stored as an internal wrapper, so a direct
+      // delete of the original function misses. Fall back to removing the wrapper
+      // whose `.listener` is the original (mirrors Node's EventEmitter).
+      if (!set.delete(listener)) {
+        for (const registered of set) {
+          if ((registered as { listener?: (...args: any[]) => void }).listener === listener) {
+            set.delete(registered);
+            break;
+          }
+        }
+      }
       if (set.size === 0) {
         this.listeners.delete(event);
       }
@@ -27,6 +37,8 @@ export class SimpleEventEmitter {
       this.off(event, wrapper);
       listener(...args);
     };
+    // Tag the wrapper so off(event, listener) can find and remove it.
+    (wrapper as { listener?: (...args: any[]) => void }).listener = listener;
     return this.on(event, wrapper);
   }
 

--- a/packages/core/src/utils/simple-event-emitter.ts
+++ b/packages/core/src/utils/simple-event-emitter.ts
@@ -15,15 +15,22 @@ export class SimpleEventEmitter {
     const set = this.listeners.get(event);
     if (set) {
       // A listener added via once() is stored as an internal wrapper, so a direct
-      // delete of the original function misses. Fall back to removing the wrapper
-      // whose `.listener` is the original (mirrors Node's EventEmitter).
-      if (!set.delete(listener)) {
-        for (const registered of set) {
-          if ((registered as { listener?: (...args: any[]) => void }).listener === listener) {
-            set.delete(registered);
-            break;
-          }
+      // delete of the original function misses. Scan every registration and match
+      // either the function itself or a wrapper whose `.listener` is the original.
+      // The same function can be registered with both on() and once(); like Node's
+      // EventEmitter we remove only the newest matching entry, so the Set's
+      // insertion order lets the last match win.
+      let match: ((...args: any[]) => void) | undefined;
+      for (const registered of set) {
+        if (
+          registered === listener ||
+          (registered as { listener?: (...args: any[]) => void }).listener === listener
+        ) {
+          match = registered;
         }
+      }
+      if (match) {
+        set.delete(match);
       }
       if (set.size === 0) {
         this.listeners.delete(event);


### PR DESCRIPTION
## What

`SimpleEventEmitter.once()` registers an internal `wrapper` (not the original `listener`), but `off(event, listener)` did `set.delete(listener)` against the original function — which is never in the set. So calling `off()` with a listener added via `once()` was a no-op: the listener stayed registered and still fired on the next `emit()`, and `listenerCount` stayed non-zero.

## Fix

Mirror Node's `EventEmitter`: tag the `once()` wrapper with `.listener = listener`, and in `off()`, if the direct delete misses, remove the wrapper whose `.listener` is the original. Normal `on()`/`off()` and the fire-once-then-remove path are unchanged.

## Test

Adds `simple-event-emitter.spec.ts`: after `off()` a `once()` listener no longer fires and `listenerCount` is 0; `once()` still fires exactly once and self-removes. Full `@voltagent/core` suite green (1269 tests), biome and build clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `SimpleEventEmitter.off()` so it removes listeners registered via `once()`. Previously `once()` stored an internal wrapper, so `off(event, listener)` deleted the original function (never in the set) and left the wrapper registered — a removed listener still fired on the next `emit()`. `off()` now resolves the original listener back to its wrapper and removes only the newest matching registration when the same function is registered with both `on()` and `once()`, mirroring Node's `EventEmitter`.

**Bug Fixes**
- Tags the `once()` wrapper with a `.listener` reference so `off()` can find and delete it.
- Adds tests covering `off()` removing a `once()` listener, single-fire behavior, and mixed `on()`/`once()` registrations.

<sup>Written for commit 86c1d660111f5515bb75dd078f966727dd633bb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed event listener removal so one-time listeners no longer fire after being removed.
  - Ensured one-time listeners fire only once before being automatically removed.
  - When the same callback is registered as both persistent and one-time, removal now targets the newest registration while preserving the persistent listener.

- **Tests**
  - Added coverage for listener removal order, pre-emission removal, single-fire behavior, and mixed persistent/one-time registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->