### PR TITLE
fix(subagent): attach subAgentId and subAgentName metadata to delegated task messages (#1407)

### DIFF
--- a/packages/core/src/agent/subagent/index.ts
+++ b/packages/core/src/agent/subagent/index.ts
@@ -574,6 +574,11 @@ ${task}\n\nContext: ${safeStringify(contextObj, { indentation: 2 })}`;
         id: crypto.randomUUID(),
         role: "user",
         parts: [{ type: "text", text: task }],
+        metadata: {
+          subAgentId: targetAgent.id,
+          subAgentName: targetAgent.name,
+          parentAgentId: sourceAgent?.id || parentAgentId,
+        },
       };
 
       return {


### PR DESCRIPTION
## Motivation
Fixes #1407.

When delegating tasks to sub-agents via `delegate_task`, the error task message fallback previously lacked `metadata` (`subAgentId`, `subAgentName`, `parentAgentId`), leading to asymmetric message structures during task failures.

## Proposed Changes
- Add `subAgentId`, `subAgentName`, and `parentAgentId` metadata to the fallback `errorTaskMessage` in `delegate_task` execution workflow within `packages/core/src/agent/subagent/index.ts`.
- Aligns error message structure with normal execution task messages, ensuring UI and persistence layers can reliably group and filter all sub-agent interaction steps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `subAgentId`, `subAgentName`, and `parentAgentId` metadata to fallback messages created when `delegate_task` fails. Previously, these error messages lacked metadata, preventing UI and persistence layers from consistently grouping or filtering delegated sub-agent steps.

<sup>Written for commit cdba2c99cf15543d6aef1525bbb4946e989790fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages from delegated tasks now include relevant sub-agent and parent-agent details, making failures easier to understand and troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->