### PR TITLE
fix: update Groq example model

### DIFF
--- a/examples/with-groq-ai/src/index.ts
+++ b/examples/with-groq-ai/src/index.ts
@@ -12,7 +12,7 @@ const logger = createPinoLogger({
 const agent = new Agent({
   name: "Assistant",
   instructions: "A helpful assistant that answers questions",
-  model: "groq/meta-llama/llama-4-scout-17b-16e-instruct",
+  model: "groq/openai/gpt-oss-20b",
   memory: new Memory({
     storage: new LibSQLMemoryAdapter({
       url: "file:./.voltagent/memory.db",


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Related issue(s) linked
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
- [ ] Changesets have been added

## What is the current behavior?

The `with-groq-ai` example starts successfully, but requests fail because the configured Groq model is unavailable:

`meta-llama/llama-4-scout-17b-16e-instruct`

## What is the new behavior?

The example now uses:

`groq/openai/gpt-oss-20b`

The agent responds successfully to requests through `/agents/Assistant/text`.

## Notes for reviewers

Verified locally:

- `pnpm build` passes
- The server starts with `pnpm dev`
- A real POST request returned `"success": true`

No API keys or secrets are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `with-groq-ai` example by switching from the unavailable `meta-llama/llama-4-scout-17b-16e-instruct` model to `groq/openai/gpt-oss-20b`, so requests to `/agents/Assistant/text` now succeed instead of failing.

<sup>Written for commit 6647c4becb00b341a53582e34cb47f5cbc81d001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VoltAgent/voltagent/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Examples**
  * Updated the example agent to use the Groq OpenAI GPT-OSS 20B model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->